### PR TITLE
use arctl list

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ curl -fsSL https://raw.githubusercontent.com/agentregistry-dev/agentregistry/mai
 
 ```bash
 # Start the registry server and look for available MCP servers
-arctl mcp list
+arctl list
 
 # The first time the CLI runs it will automatically start the registry server daemon and import the built-in seed data.
 ```


### PR DESCRIPTION
As I'm working through the agent registry I saw that `arctl mcp list` doesn't exist. `arctl list` does and the CLI help suggests that it could be the right command.