### PR TITLE
Fixes readme for local setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ curl -fsSL https://raw.githubusercontent.com/agentregistry-dev/agentregistry/mai
 
 ```bash
 # Start the registry server and look for available MCP servers
-arctl list -A
+arctl mcp list
 
 # The first time the CLI runs, it will automatically start the registry server daemon and import the built-in seed data.
 ```


### PR DESCRIPTION
### Summary
This PR fixes the readme. The command:
```
arctl list -A
```
No longer exists. Updating this to use the MCP list command. 

### Testing
Tested this locally and got it running locally