### PR TITLE
copy uv.lock file without failing

### DIFF
--- a/internal/cli/mcp/frameworks/python/templates/Dockerfile.tmpl
+++ b/internal/cli/mcp/frameworks/python/templates/Dockerfile.tmpl
@@ -8,17 +8,15 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 WORKDIR /app
 
 # Copy dependency files first for layer caching
-COPY pyproject.toml .python-version ./
+COPY pyproject.toml .python-version* uv.lock* ./
 COPY README.md ./
 
-# Copy lockfile if it exists, otherwise generate it
-COPY uv.loc[k] ./
 RUN if [ -f uv.lock ]; then \
         echo "Using existing lockfile"; \
-        uv sync --frozen --no-dev --no-cache; \
+        uv sync --frozen --no-dev --no-cache --no-install-project; \
     else \
         echo "Generating lockfile and installing dependencies"; \
-        uv sync --no-dev --no-cache; \
+        uv sync --no-dev --no-cache --no-install-project; \
     fi
 
 # Copy source code


### PR DESCRIPTION
some docker versions fail when using the `uv.loc[k]` format (if the file doesn't exist)