### PR TITLE
tiny: update example of jwt key to use hex-encoded seed

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,7 +22,7 @@ AGENT_REGISTRY_GITHUB_CLIENT_SECRET=
 # JWT Configuration
 # Private key for signing JWT tokens (required for authentication)
 # Generate with: openssl rand -hex 32
-AGENT_REGISTRY_JWT_PRIVATE_KEY="d5685223b2dbcaad6a622cebe2700e3180f3f2cb17a785af4a2731405b4afd23"
+AGENT_REGISTRY_JWT_PRIVATE_KEY="0000000000000000000000000000000000000000000000000000000000000000"
 
 # Authentication Settings
 # Enable anonymous authentication (useful for development)


### PR DESCRIPTION
the underlying jwt manager expects a 32-byte signature, not RSA

```
	seed, err := hex.DecodeString(cfg.JWTPrivateKey)
	if err != nil {
		panic(fmt.Sprintf("JWTPrivateKey must be a valid hex-encoded string: %v", err))
	}

	// Require a valid Ed25519 seed (32 bytes)
	if len(seed) != ed25519.SeedSize {
		panic(fmt.Sprintf("JWTPrivateKey seed must be exactly %d bytes for Ed25519, got %d bytes", ed25519.SeedSize, len(seed)))
	}

	// Generate the full Ed25519 key pair from the seed
	privateKey := ed25519.NewKeyFromSeed(seed)
	publicKey := privateKey.Public().(ed25519.PublicKey)
```