### PR TITLE
various fixes

### DIFF
--- a/internal/cli/agent/add-mcp.go
+++ b/internal/cli/agent/add-mcp.go
@@ -92,6 +92,7 @@ func addMcpCmd(name string) error {
 				RegistryServerName:         registryServerName,
 				RegistryServerVersion:      registryServerVersion,
 				RegistryServerPreferRemote: registryServerPreferRemote,
+				Env:                        env,
 			}
 		} else {
 			if image != "" && build != "" {

--- a/internal/cli/agent/frameworks/adk/python/templates/docker-compose.yaml.tmpl
+++ b/internal/cli/agent/frameworks/adk/python/templates/docker-compose.yaml.tmpl
@@ -52,12 +52,22 @@ services:
 {{- range .McpServers }}
 {{- if eq .Type "command" }}
   {{.Name}}:
+{{- if .Build }}
     image: localhost:5001/{{$.Name}}-{{.Name}}:latest
     build:
-      context: ./{{if .Build}}{{.Build}}{{else}}{{.Name}}{{end}}
+      context: ./{{.Build}}
       dockerfile: Dockerfile
+{{- else }}
+    image: {{.Image}}
+{{- end }}
     expose:
       - "3000"
+{{- if .Env }}
+    environment:
+{{- range .Env }}
+      - {{.}}
+{{- end }}
+{{- end }}
 {{- if $.TelemetryEndpoint}}
     networks:
       - agentregistry-network

--- a/internal/cli/agent/utils/registry_resolver.go
+++ b/internal/cli/agent/utils/registry_resolver.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"fmt"
+	"maps"
 	"os"
 	"strings"
 
@@ -110,9 +111,7 @@ func resolveRegistryServer(mcpServer common.McpServerType, verbose bool) (*commo
 
 	// Also add user-provided env vars from the manifest (set via TUI or agent.yaml)
 	manifestEnvVars := parseManifestEnvVars(mcpServer.Env)
-	for k, v := range manifestEnvVars {
-		envOverrides[k] = v
-	}
+	maps.Copy(envOverrides, manifestEnvVars)
 
 	if verbose {
 		if len(envOverrides) > 0 {

--- a/internal/cli/agent/utils/registry_resolver.go
+++ b/internal/cli/agent/utils/registry_resolver.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/agentregistry-dev/agentregistry/internal/cli/agent/frameworks/common"
 	"github.com/agentregistry-dev/agentregistry/internal/registry"
@@ -13,18 +14,40 @@ import (
 func ParseAgentManifestServers(manifest *common.AgentManifest, verbose bool) ([]common.McpServerType, error) {
 	servers := []common.McpServerType{}
 
-	for _, mcpServer := range manifest.McpServers {
+	if verbose {
+		fmt.Printf("[registry-resolver] Processing %d MCP servers from manifest\n", len(manifest.McpServers))
+	}
+
+	for i, mcpServer := range manifest.McpServers {
 		switch mcpServer.Type {
 		case "registry":
+			if verbose {
+				fmt.Printf("[registry-resolver] [%d] Resolving registry server: name=%q registryServerName=%q version=%q registryURL=%q preferRemote=%v\n",
+					i, mcpServer.Name, mcpServer.RegistryServerName, mcpServer.RegistryServerVersion, mcpServer.RegistryURL, mcpServer.RegistryServerPreferRemote)
+			}
 			// Fetch server spec from registry and translate to command/remote type
 			translatedServer, err := resolveRegistryServer(mcpServer, verbose)
 			if err != nil {
+				if verbose {
+					fmt.Printf("[registry-resolver] [%d] FAILED to resolve registry server %q: %v\n", i, mcpServer.Name, err)
+				}
 				return nil, fmt.Errorf("failed to resolve registry server %q: %w", mcpServer.Name, err)
+			}
+			if verbose {
+				fmt.Printf("[registry-resolver] [%d] Successfully resolved %q -> type=%q build=%q image=%q command=%q args=%v\n",
+					i, mcpServer.Name, translatedServer.Type, translatedServer.Build, translatedServer.Image, translatedServer.Command, translatedServer.Args)
 			}
 			servers = append(servers, *translatedServer)
 		default:
+			if verbose {
+				fmt.Printf("[registry-resolver] [%d] Keeping non-registry server as-is: name=%q type=%q\n", i, mcpServer.Name, mcpServer.Type)
+			}
 			servers = append(servers, mcpServer)
 		}
+	}
+
+	if verbose {
+		fmt.Printf("[registry-resolver] Finished processing. Resolved %d servers total\n", len(servers))
 	}
 
 	return servers, nil
@@ -35,27 +58,111 @@ func resolveRegistryServer(mcpServer common.McpServerType, verbose bool) (*commo
 	registryURL := mcpServer.RegistryURL
 	if registryURL == "" {
 		registryURL = "http://127.0.0.1:12121"
+		if verbose {
+			fmt.Printf("[registry-resolver]   Using default registry URL: %s\n", registryURL)
+		}
+	} else if verbose {
+		fmt.Printf("[registry-resolver]   Using specified registry URL: %s\n", registryURL)
+	}
+
+	if verbose {
+		fmt.Printf("[registry-resolver]   Fetching server %q (version=%q) from registry...\n",
+			mcpServer.RegistryServerName, mcpServer.RegistryServerVersion)
 	}
 
 	client := registry.NewClient()
 	serverEntry, err := client.FetchServer(registryURL, mcpServer.RegistryServerName, mcpServer.RegistryServerVersion)
 	if err != nil {
+		if verbose {
+			fmt.Printf("[registry-resolver]   ERROR: Failed to fetch server from registry: %v\n", err)
+		}
 		return nil, fmt.Errorf("failed to fetch server %q from registry: %w", mcpServer.RegistryServerName, err)
+	}
+
+	if verbose {
+		fmt.Printf("[registry-resolver]   Fetched server successfully:\n")
+		fmt.Printf("[registry-resolver]     - Name: %s\n", serverEntry.Server.Name)
+		fmt.Printf("[registry-resolver]     - Version: %s\n", serverEntry.Server.Version)
+		fmt.Printf("[registry-resolver]     - Description: %s\n", serverEntry.Server.Description)
+		fmt.Printf("[registry-resolver]     - Packages count: %d\n", len(serverEntry.Server.Packages))
+		for j, pkg := range serverEntry.Server.Packages {
+			fmt.Printf("[registry-resolver]     - Package[%d]: registryType=%q identifier=%q version=%q\n",
+				j, pkg.RegistryType, pkg.Identifier, pkg.Version)
+			if len(pkg.EnvironmentVariables) > 0 {
+				fmt.Printf("[registry-resolver]       Environment variables: %d\n", len(pkg.EnvironmentVariables))
+				for _, envVar := range pkg.EnvironmentVariables {
+					fmt.Printf("[registry-resolver]         - %s\n", envVar.Name)
+				}
+			}
+		}
+		if len(serverEntry.Server.Remotes) > 0 {
+			fmt.Printf("[registry-resolver]     - Remotes count: %d\n", len(serverEntry.Server.Remotes))
+			for j, remote := range serverEntry.Server.Remotes {
+				fmt.Printf("[registry-resolver]     - Remote[%d]: type=%q url=%q\n",
+					j, remote.Type, remote.URL)
+			}
+		}
 	}
 
 	// Collect environment variable overrides from the current environment
 	// This allows users to set required env vars before running
 	envOverrides := collectEnvOverrides(serverEntry.Server.Packages)
 
+	// Also add user-provided env vars from the manifest (set via TUI or agent.yaml)
+	manifestEnvVars := parseManifestEnvVars(mcpServer.Env)
+	for k, v := range manifestEnvVars {
+		envOverrides[k] = v
+	}
+
+	if verbose {
+		if len(envOverrides) > 0 {
+			fmt.Printf("[registry-resolver]   Collected %d environment variable overrides (from environment and manifest):\n", len(envOverrides))
+			for k, v := range envOverrides {
+				// Mask the value for security (unless it's a variable reference)
+				maskedValue := v
+				if !strings.HasPrefix(v, "${") {
+					if len(v) > 4 {
+						maskedValue = v[:2] + "***" + v[len(v)-2:]
+					} else {
+						maskedValue = "***"
+					}
+				}
+				fmt.Printf("[registry-resolver]     - %s=%s\n", k, maskedValue)
+			}
+		} else {
+			fmt.Printf("[registry-resolver]   No environment variable overrides found\n")
+		}
+	}
+
+	if verbose {
+		fmt.Printf("[registry-resolver]   Translating registry server to runnable config (preferRemote=%v)...\n",
+			mcpServer.RegistryServerPreferRemote)
+	}
+
 	// Translate the registry server spec to a runnable McpServerType
 	translated, err := TranslateRegistryServer(mcpServer.Name, &serverEntry.Server, envOverrides, mcpServer.RegistryServerPreferRemote)
 	if err != nil {
+		if verbose {
+			fmt.Printf("[registry-resolver]   ERROR: Failed to translate server: %v\n", err)
+		}
 		return nil, err
 	}
 
 	if verbose {
-		fmt.Printf("Resolved registry server %q (%s) -> %s (image: %s, command: %s)\n",
-			mcpServer.RegistryServerName, serverEntry.Server.Version, translated.Type, translated.Image, translated.Command)
+		fmt.Printf("[registry-resolver]   Translation successful:\n")
+		fmt.Printf("[registry-resolver]     - Result type: %s\n", translated.Type)
+		if translated.Build == "" {
+			fmt.Printf("[registry-resolver]     - Build path: (none - OCI image ready to use)\n")
+		} else {
+			fmt.Printf("[registry-resolver]     - Build path: %s\n", translated.Build)
+		}
+		fmt.Printf("[registry-resolver]     - Image: %s\n", translated.Image)
+		fmt.Printf("[registry-resolver]     - Command: %s\n", translated.Command)
+		fmt.Printf("[registry-resolver]     - Args: %v\n", translated.Args)
+		fmt.Printf("[registry-resolver]     - URL: %s\n", translated.URL)
+		if len(translated.Env) > 0 {
+			fmt.Printf("[registry-resolver]     - Env vars: %d\n", len(translated.Env))
+		}
 	}
 
 	return translated, nil
@@ -75,4 +182,18 @@ func collectEnvOverrides(packages []model.Package) map[string]string {
 	}
 
 	return overrides
+}
+
+// parseManifestEnvVars parses environment variables from the manifest's Env field.
+// The Env field is a []string in "KEY=VALUE" format.
+func parseManifestEnvVars(envSlice []string) map[string]string {
+	result := make(map[string]string)
+	for _, env := range envSlice {
+		if idx := strings.Index(env, "="); idx > 0 {
+			key := env[:idx]
+			value := env[idx+1:]
+			result[key] = value
+		}
+	}
+	return result
 }

--- a/internal/cli/agent/utils/registry_translator.go
+++ b/internal/cli/agent/utils/registry_translator.go
@@ -62,11 +62,18 @@ func TranslateRegistryServer(
 		}
 		envVars := utils.EnvMapToStringSlice(envVarsMap)
 
+		// For OCI registry type, we already have a complete image - no build needed.
+		// For other types (npm, pypi), we need to create a build context with Dockerfile.
+		buildPath := ""
+		if !config.IsOCI {
+			buildPath = "registry/" + name // Registry-resolved servers go under registry/ to easily manage on sequential runs
+		}
+
 		return &common.McpServerType{
 			Type:    "command",
 			Name:    name,
 			Image:   config.Image,
-			Build:   "registry/" + name, // Registry-resolved servers go under registry/ to easily manage on sequential runs
+			Build:   buildPath,
 			Command: config.Command,
 			Args:    args,
 			Env:     envVars,

--- a/internal/cli/mcp/manifest/manager.go
+++ b/internal/cli/mcp/manifest/manager.go
@@ -84,6 +84,9 @@ func GetDefault(name, framework, description, author, email string) *ProjectMani
 	if description == "" {
 		description = fmt.Sprintf("MCP server built with %s", framework)
 	}
+
+	runtimeHint, runtimeArgs := getFrameworkRuntimeConfig(framework)
+
 	return &ProjectManifest{
 		Name:        name,
 		Framework:   framework,
@@ -99,8 +102,24 @@ func GetDefault(name, framework, description, author, email string) *ProjectMani
 				File:     ".env.local",
 			},
 		},
-		CreatedAt: time.Now(),
-		UpdatedAt: time.Now(),
+		RuntimeHint: runtimeHint,
+		RuntimeArgs: runtimeArgs,
+		CreatedAt:   time.Now(),
+		UpdatedAt:   time.Now(),
+	}
+}
+
+// getFrameworkRuntimeConfig returns the runtime command and arguments based on framework
+func getFrameworkRuntimeConfig(framework string) (string, []string) {
+	switch framework {
+	case FrameworkFastMCPPython:
+		return "python", []string{"src/main.py"}
+	case FrameworkMCPGo:
+		return "/app/server", nil
+	case FrameworkTypeScript:
+		return "node", []string{"dist/index.js"}
+	default:
+		return "", nil
 	}
 }
 

--- a/internal/cli/mcp/manifest/types.go
+++ b/internal/cli/mcp/manifest/types.go
@@ -19,6 +19,12 @@ type ProjectManifest struct {
 	Secrets   SecretsConfig         `yaml:"secrets,omitempty" json:"secrets,omitempty"`
 	Transport *TransportConfig      `yaml:"transport,omitempty" json:"transport,omitempty"`
 
+	// Runtime configuration for OCI deployment
+	// RuntimeHint is the command to run inside the container (e.g., "python", "node")
+	RuntimeHint string `yaml:"runtimeHint,omitempty" json:"runtimeHint,omitempty"`
+	// RuntimeArgs are the arguments to pass to the command (e.g., ["src/main.py"])
+	RuntimeArgs []string `yaml:"runtimeArgs,omitempty" json:"runtimeArgs,omitempty"`
+
 	// Metadata
 	CreatedAt time.Time `yaml:"created_at,omitempty" json:"created_at,omitempty"`
 	UpdatedAt time.Time `yaml:"updated_at,omitempty" json:"updated_at,omitempty"`

--- a/internal/cli/mcp/publish.go
+++ b/internal/cli/mcp/publish.go
@@ -251,6 +251,18 @@ func translateServerJSON(
 		transportURL = "http://localhost:3000/mcp"
 	}
 
+	var runtimeArguments []model.Argument
+	for _, arg := range projectManifest.RuntimeArgs {
+		runtimeArguments = append(runtimeArguments, model.Argument{
+			InputWithVariables: model.InputWithVariables{
+				Input: model.Input{
+					Value: arg,
+				},
+			},
+			Type: model.ArgumentTypePositional,
+		})
+	}
+
 	return &apiv0.ServerJSON{
 		Schema:      model.CurrentSchemaURL,
 		Name:        name,
@@ -266,12 +278,12 @@ func translateServerJSON(
 			Identifier:      imageRef,
 			Version:         version,
 			FileSHA256:      "",
-			RunTimeHint:     "",
+			RunTimeHint:     projectManifest.RuntimeHint,
 			Transport: model.Transport{
 				Type: transportType,
 				URL:  transportURL,
 			},
-			RuntimeArguments:     nil,
+			RuntimeArguments:     runtimeArguments,
 			PackageArguments:     nil,
 			EnvironmentVariables: nil,
 		}},

--- a/internal/runtime/translation/api/internal_runtime_api.go
+++ b/internal/runtime/translation/api/internal_runtime_api.go
@@ -40,6 +40,8 @@ type MCPServer struct {
 	Remote *RemoteMCPServer `json:"remote,omitempty"`
 	// Local defines how to deploy the MCP server locally
 	Local *LocalMCPServer `json:"local,omitempty"`
+	// Namespace is the target namespace for Kubernetes deployments (optional, defaults to "kagent")
+	Namespace string `json:"namespace,omitempty"`
 }
 
 type MCPServerType string

--- a/internal/runtime/translation/registry/utils/registry_utils.go
+++ b/internal/runtime/translation/registry/utils/registry_utils.go
@@ -12,6 +12,7 @@ import (
 type RegistryConfig struct {
 	Image   string
 	Command string
+	IsOCI   bool // True for OCI registry type where image is ready to use (no build needed)
 }
 
 // ProcessArguments processes model.Argument slices into []string args, allowing for overrides.
@@ -208,6 +209,8 @@ func GetRegistryConfig(
 
 	case strings.ToLower(string(model.RegistryTypeOCI)):
 		config.Image = packageInfo.Identifier
+		config.Command = packageInfo.RunTimeHint
+		config.IsOCI = true
 
 	default:
 		return RegistryConfig{}, nil, fmt.Errorf("unsupported package registry type: %s", string(packageInfo.RegistryType))

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -3,9 +3,11 @@ package daemon
 import (
 	_ "embed"
 	"fmt"
+	"net/http"
 	"os"
 	"os/exec"
 	"strings"
+	"time"
 
 	"github.com/agentregistry-dev/agentregistry/internal/daemon"
 	"github.com/agentregistry-dev/agentregistry/internal/version"
@@ -70,6 +72,11 @@ func (d *DefaultDaemonManager) Start() error {
 }
 
 func (d *DefaultDaemonManager) IsRunning() bool {
+	// First check if a server is responding on the API port (local or Docker)
+	if isServerResponding() {
+		return true
+	}
+
 	cmd := exec.Command("docker", "compose", "-p", d.config.ProjectName, "-f", "-", "ps")
 	cmd.Stdin = strings.NewReader(d.config.ComposeYAML)
 	cmd.Env = append(os.Environ(), fmt.Sprintf("VERSION=%s", d.config.Version), fmt.Sprintf("DOCKER_REGISTRY=%s", d.config.DockerRegistry))
@@ -79,4 +86,15 @@ func (d *DefaultDaemonManager) IsRunning() bool {
 		return false
 	}
 	return strings.Contains(string(output), d.config.ContainerName)
+}
+
+// isServerResponding checks if the server is responding on port 12121
+func isServerResponding() bool {
+	client := &http.Client{Timeout: 2 * time.Second}
+	resp, err := client.Get("http://localhost:12121/v0/version")
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode == http.StatusOK
 }

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -93,7 +93,7 @@ func isServerResponding() bool {
 	client := &http.Client{Timeout: 2 * time.Second}
 
 	const maxRetries = 3
-	for i := 0; i < maxRetries; i++ {
+	for i := range maxRetries {
 		resp, err := client.Get("http://localhost:12121/v0/version")
 		if err == nil {
 			defer resp.Body.Close()


### PR DESCRIPTION
- adding more logging
- if the MCP server has an OCI image, we don't need to rebuild the image (i.e. we don't need a Dockerfile etc.)
- support setting the environment variables for MCP servers
- set the cmd and args for MCP server -- this is used when deploying to k8s, so we know which cmd to call
- add a check for localhost:12121 before starting the daemon, so we can run the server outside of docker (faster dev)