### PR TITLE
feat: publish mcp package ref from cli

### DIFF
--- a/internal/cli/mcp/publish.go
+++ b/internal/cli/mcp/publish.go
@@ -49,6 +49,9 @@ This command supports three modes:
 Examples:
   # Build and publish from local folder
   arctl mcp publish ./my-server --docker-url docker.io/myorg --push
+  
+  # Build and publish from local folder and include a repository reference
+  arctl mcp publish ./my-server --docker-url docker.io/myorg --push --github https://github.com/repo/user
 
   # Re-publish an existing server from the registry
   arctl mcp publish io.github.example/my-server --version 1.0.0


### PR DESCRIPTION
- The CLI does not support publishing package references (npm / pypi / oci images) for mcp, this adds a third mode to `arctl mcp publish` that does not depend on a `mcp.yaml` file (similar to how the UI works), usage:

```bash
arctl mcp publish myorg/server-everything \
    --registry-type npm \
    --package-id @modelcontextprotocol/server-everything\
    --package-version latest \
    --version 1.0.0 \
    --description "Everything MCP server"
```

- Improve error msg
- Fix #116 (now it checks `--version` flag not just `mcp.yaml`)