### PR TITLE
fix(cli): normalize semver version handling

### DIFF
--- a/internal/cli/version.go
+++ b/internal/cli/version.go
@@ -32,12 +32,12 @@ var VersionCmd = &cobra.Command{
 		fmt.Printf("Server version: %s\n", serverVersion.Version)
 		fmt.Printf("Server git commit: %s\n", serverVersion.GitCommit)
 		fmt.Printf("Server build date: %s\n", serverVersion.BuildTime)
-		if !semver.IsValid(serverVersion.Version) || !semver.IsValid(version.Version) {
+		if !semver.IsValid(version.EnsureVPrefix(serverVersion.Version)) || !semver.IsValid(version.EnsureVPrefix(version.Version)) {
 			fmt.Printf("Server or local version is not a valid semantic version, not sure if update require: %s or %s\n", serverVersion.Version, version.Version)
 			return
 		}
 
-		compare := semver.Compare("v"+version.Version, "v"+serverVersion.Version)
+		compare := semver.Compare(version.EnsureVPrefix(version.Version), version.EnsureVPrefix(serverVersion.Version))
 		switch compare {
 		case 1:
 			fmt.Println("\n-------------------------------")

--- a/internal/registry/service/versioning.go
+++ b/internal/registry/service/versioning.go
@@ -5,6 +5,8 @@ import (
 	"time"
 
 	"golang.org/x/mod/semver"
+
+	versionpkg "github.com/agentregistry-dev/agentregistry/internal/version"
 )
 
 // IsSemanticVersion checks if a version string follows semantic versioning format
@@ -12,7 +14,7 @@ import (
 // Requires exactly three parts: major.minor.patch (optionally with prerelease/build)
 func IsSemanticVersion(version string) bool {
 	// The semver package requires a "v" prefix, so add it for validation
-	versionWithV := ensureVPrefix(version)
+	versionWithV := versionpkg.EnsureVPrefix(version)
 	if !semver.IsValid(versionWithV) {
 		return false
 	}
@@ -33,14 +35,6 @@ func IsSemanticVersion(version string) bool {
 	return len(parts) == 3
 }
 
-// ensureVPrefix adds a "v" prefix if not present
-func ensureVPrefix(version string) string {
-	if !strings.HasPrefix(version, "v") {
-		return "v" + version
-	}
-	return version
-}
-
 // compareSemanticVersions compares two semantic version strings
 // Uses the official golang.org/x/mod/semver package for comparison
 // Returns:
@@ -50,8 +44,8 @@ func ensureVPrefix(version string) string {
 //	+1 if version1 > version2
 func compareSemanticVersions(version1 string, version2 string) int {
 	// The semver package requires a "v" prefix, so add it for comparison
-	v1 := ensureVPrefix(version1)
-	v2 := ensureVPrefix(version2)
+	v1 := versionpkg.EnsureVPrefix(version1)
+	v2 := versionpkg.EnsureVPrefix(version2)
 	return semver.Compare(v1, v2)
 }
 

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,8 +1,18 @@
 package version
 
+import "strings"
+
 var (
 	Version        = "dev"
 	GitCommit      = "unknown"
 	BuildDate      = "unknown"
 	DockerRegistry = "localhost:5001"
 )
+
+// EnsureVPrefix adds a "v" prefix if missing; golang.org/x/mod/semver requires it.
+func EnsureVPrefix(s string) string {
+	if strings.HasPrefix(s, "v") {
+		return s
+	}
+	return "v" + s
+}


### PR DESCRIPTION
Fixes #120 

- normalize semver version handling
- share EnsureVPrefix in internal/version and use it in CLI and versioning.