### PR TITLE
Change license from MIT to Apache V2

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,6 @@ We welcome contributions! Please see [`CONTRIBUTING.md`](CONTRIBUTING.md) for gu
 
 ## 📄 License
 
-MIT License - see [`LICENSE`](LICENSE) for details.
+Apache V2 License - see [`LICENSE`](LICENSE) for details.
 
 ---


### PR DESCRIPTION
The link on the bottom of the page was poinitng to Apache V2 license instead of MIT