### PR TITLE
fix: hide registry flags from mcp init help output

### DIFF
--- a/internal/cli/mcp/init.go
+++ b/internal/cli/mcp/init.go
@@ -23,6 +23,11 @@ var InitCmd = &cobra.Command{
 This command provides subcommands to initialize a new MCP server project
 using one of the supported frameworks.`,
 	RunE: runInit,
+	// Override root's PersistentPreRunE — mcp init is a local scaffolding
+	// command that does not need a registry connection.
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		return nil
+	},
 }
 
 var (
@@ -41,6 +46,14 @@ func init() {
 	InitCmd.PersistentFlags().StringVar(&initEmail, "email", "", "Author email for the project")
 	InitCmd.PersistentFlags().StringVar(&initDescription, "description", "", "Description for the project")
 	InitCmd.PersistentFlags().BoolVar(&initNonInteractive, "non-interactive", false, "Run in non-interactive mode")
+
+	// Shadow the root-level registry flags with hidden local ones so they
+	// don't appear in "mcp init --help". The init command is purely local
+	// scaffolding and never talks to a registry.
+	InitCmd.PersistentFlags().String("registry-url", "", "")
+	InitCmd.PersistentFlags().String("registry-token", "", "")
+	_ = InitCmd.PersistentFlags().MarkHidden("registry-url")
+	_ = InitCmd.PersistentFlags().MarkHidden("registry-token")
 }
 
 func runInit(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
## Summary

Fixes #115 — `arctl mcp init` no longer shows `--registry-token` and `--registry-url` in its help output.

**Problem:** The root command defines `--registry-url` and `--registry-token` as `PersistentFlags`, which Cobra inherits to all subcommands including `mcp init`. Since `mcp init` is a local scaffolding command that never connects to a registry, these flags are confusing.

**Fix:**
1. Override `PersistentPreRunE` on `InitCmd` with a no-op to prevent the root's registry-connection logic from running
2. Shadow the root's registry flags with hidden local persistent flags on `InitCmd` so they don't appear in help output

**Before:**
```
Global Flags:
      --registry-token string   Registry bearer token (overrides ARCTL_API_TOKEN)
      --registry-url string     Registry base URL (overrides ARCTL_API_BASE_URL; default http://localhost:12121)
  -v, --verbose                 Enable verbose output
```

**After:**
```
Global Flags:
  -v, --verbose   Enable verbose output
```

This applies to `mcp init`, `mcp init go`, and `mcp init python`.

## Test plan
- [x] `arctl mcp init --help` no longer shows registry flags
- [x] `arctl mcp init go --help` no longer shows registry flags
- [x] `arctl mcp init python --help` no longer shows registry flags
- [x] `arctl mcp list --help` still shows registry flags correctly
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)