### PR TITLE
Randomize RuntimeDir to prevent concurrent run collisions

### DIFF
--- a/internal/registry/config/config.go
+++ b/internal/registry/config/config.go
@@ -1,7 +1,10 @@
 package config
 
 import (
+	"crypto/rand"
+	"encoding/hex"
 	"log"
+	"os"
 
 	env "github.com/caarlos0/env/v11"
 	"github.com/joho/godotenv"
@@ -71,5 +74,26 @@ func NewConfig() *Config {
 	if err != nil {
 		log.Fatalf("failed to parse config: %v", err)
 	}
+
+	// Append a random suffix to RuntimeDir when the user has not set an
+	// explicit override via the AGENT_REGISTRY_RUNTIME_DIR env var. This
+	// prevents concurrent runs from sharing the same directory.
+	if os.Getenv("AGENT_REGISTRY_RUNTIME_DIR") == "" {
+		suffix, err := randomHex(8)
+		if err != nil {
+			log.Fatalf("failed to generate random runtime dir suffix: %v", err)
+		}
+		cfg.RuntimeDir = cfg.RuntimeDir + "-" + suffix
+	}
+
 	return &cfg
+}
+
+// randomHex returns a hex-encoded string of n random bytes.
+func randomHex(n int) (string, error) {
+	b := make([]byte, n)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
 }

--- a/internal/registry/config/config_test.go
+++ b/internal/registry/config/config_test.go
@@ -1,0 +1,46 @@
+package config
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestNewConfig_RuntimeDirHasRandomSuffix(t *testing.T) {
+	// Ensure the env var is unset so the default path is used.
+	os.Unsetenv("AGENT_REGISTRY_RUNTIME_DIR")
+
+	cfg := NewConfig()
+
+	base := "/tmp/arctl-runtime-"
+	if !strings.HasPrefix(cfg.RuntimeDir, base) {
+		t.Fatalf("RuntimeDir should start with %q, got %q", base, cfg.RuntimeDir)
+	}
+
+	suffix := strings.TrimPrefix(cfg.RuntimeDir, base)
+	if len(suffix) != 16 { // 8 bytes = 16 hex chars
+		t.Fatalf("RuntimeDir suffix should be 16 hex chars, got %q (len %d)", suffix, len(suffix))
+	}
+}
+
+func TestNewConfig_RuntimeDirUniqueBetweenCalls(t *testing.T) {
+	os.Unsetenv("AGENT_REGISTRY_RUNTIME_DIR")
+
+	cfg1 := NewConfig()
+	cfg2 := NewConfig()
+
+	if cfg1.RuntimeDir == cfg2.RuntimeDir {
+		t.Fatalf("two NewConfig() calls should produce different RuntimeDir values, both got %q", cfg1.RuntimeDir)
+	}
+}
+
+func TestNewConfig_RuntimeDirRespectsEnvOverride(t *testing.T) {
+	custom := "/custom/runtime/path"
+	t.Setenv("AGENT_REGISTRY_RUNTIME_DIR", custom)
+
+	cfg := NewConfig()
+
+	if cfg.RuntimeDir != custom {
+		t.Fatalf("RuntimeDir should be %q when env var is set, got %q", custom, cfg.RuntimeDir)
+	}
+}


### PR DESCRIPTION
# Description

Fixes #126. Appends a random hex suffix to the default `RuntimeDir` (`/tmp/arctl-runtime`) so that concurrent `arctl` sessions each get their own docker compose and config directory.

- When `AGENT_REGISTRY_RUNTIME_DIR` is **not set**: default becomes `/tmp/arctl-runtime-<16 hex chars>` (unique per invocation)
- When `AGENT_REGISTRY_RUNTIME_DIR` **is set**: the user's explicit value is used as-is (no suffix)
- Added 3 tests in `config_test.go`: suffix format, uniqueness between calls, and env var override

# Change Type

/kind cleanup

```release-note
NONE
```

## Test plan

- [x] `go test ./internal/registry/config/ -v` — 3 new tests pass
- [x] `go build ./...` — full project builds cleanly
- [x] `go vet ./internal/registry/config/` — clean