### PR TITLE
Add arctl status command

### DIFF
--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -1,0 +1,108 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/agentregistry-dev/agentregistry/internal/client"
+	"github.com/agentregistry-dev/agentregistry/internal/version"
+	"github.com/spf13/cobra"
+)
+
+var statusOutputFormat string
+
+var StatusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Show the status of the daemon and registry",
+	Long:  `Displays whether the agent registry daemon is running, the server version, and resource counts.`,
+	// Override PersistentPreRunE so we don't auto-start the daemon.
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		return nil
+	},
+	RunE: runStatus,
+}
+
+func init() {
+	StatusCmd.Flags().StringVarP(&statusOutputFormat, "output", "o", "table", "Output format (table, json)")
+}
+
+type statusInfo struct {
+	Daemon    string `json:"daemon"`
+	API       string `json:"api"`
+	Version   string `json:"version,omitempty"`
+	GitCommit string `json:"git_commit,omitempty"`
+	BuildTime string `json:"build_time,omitempty"`
+	Servers   int    `json:"servers"`
+	Agents    int    `json:"agents"`
+	Skills    int    `json:"skills"`
+}
+
+func runStatus(cmd *cobra.Command, args []string) error {
+	baseURL := os.Getenv("ARCTL_API_BASE_URL")
+	if baseURL == "" {
+		baseURL = client.DefaultBaseURL
+	}
+	token := os.Getenv("ARCTL_API_TOKEN")
+
+	info := statusInfo{
+		Daemon:  "unknown",
+		API:     "unreachable",
+		Servers: -1,
+		Agents:  -1,
+		Skills:  -1,
+	}
+
+	// Try to connect to the API without retries or auto-start.
+	c := client.NewClient(baseURL, token)
+	if err := c.Ping(); err != nil {
+		info.Daemon = "stopped"
+		info.API = "unreachable"
+	} else {
+		info.Daemon = "running"
+		info.API = "ok"
+
+		if ver, err := c.GetVersion(); err == nil {
+			info.Version = ver.Version
+			info.GitCommit = ver.GitCommit
+			info.BuildTime = ver.BuildTime
+		}
+
+		if servers, err := c.GetPublishedServers(); err == nil {
+			info.Servers = len(servers)
+		}
+		if agents, err := c.GetAgents(); err == nil {
+			info.Agents = len(agents)
+		}
+		if skills, err := c.GetSkills(); err == nil {
+			info.Skills = len(skills)
+		}
+	}
+
+	if statusOutputFormat == "json" {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(info)
+	}
+
+	// Table output
+	fmt.Printf("arctl version:   %s\n", version.Version)
+	fmt.Printf("Daemon:          %s\n", info.Daemon)
+	fmt.Printf("API:             %s\n", info.API)
+	if info.Version != "" {
+		fmt.Printf("Server version:  %s\n", info.Version)
+		fmt.Printf("Git commit:      %s\n", info.GitCommit)
+		fmt.Printf("Build time:      %s\n", info.BuildTime)
+	}
+	if info.Servers >= 0 {
+		fmt.Printf("MCP servers:     %d\n", info.Servers)
+	}
+	if info.Agents >= 0 {
+		fmt.Printf("Agents:          %d\n", info.Agents)
+	}
+	if info.Skills >= 0 {
+		fmt.Printf("Skills:          %d\n", info.Skills)
+	}
+
+	return nil
+}

--- a/internal/cli/status_test.go
+++ b/internal/cli/status_test.go
@@ -1,0 +1,146 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestStatusCmd_DaemonStopped(t *testing.T) {
+	// Point to a non-existent server so Ping fails.
+	t.Setenv("ARCTL_API_BASE_URL", "http://127.0.0.1:19999/v0")
+
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	err := StatusCmd.RunE(StatusCmd, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	w.Close()
+	os.Stdout = old
+	var buf bytes.Buffer
+	io.Copy(&buf, r)
+	out := buf.String()
+
+	if !strings.Contains(out, "stopped") {
+		t.Errorf("expected 'stopped' in output, got: %s", out)
+	}
+	if !strings.Contains(out, "unreachable") {
+		t.Errorf("expected 'unreachable' in output, got: %s", out)
+	}
+}
+
+func TestStatusCmd_DaemonRunning(t *testing.T) {
+	// Start a mock server that responds to /v0/ping, /v0/version, /v0/servers, /v0/agents, /v0/skills
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v0/ping", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"pong":true}`))
+	})
+	mux.HandleFunc("/v0/version", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]string{
+			"version":    "v0.5.0",
+			"git_commit": "abc1234",
+			"build_time": "2026-02-08T00:00:00Z",
+		})
+	})
+	mux.HandleFunc("/v0/servers", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"servers":  []any{map[string]any{"name": "test-server"}},
+			"metadata": map[string]string{"next_cursor": ""},
+		})
+	})
+	mux.HandleFunc("/v0/agents", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"agents":   []any{map[string]any{"name": "test-agent"}, map[string]any{"name": "test-agent-2"}},
+			"metadata": map[string]string{"next_cursor": ""},
+		})
+	})
+	mux.HandleFunc("/v0/skills", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"skills":   []any{},
+			"metadata": map[string]string{"next_cursor": ""},
+		})
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	t.Setenv("ARCTL_API_BASE_URL", srv.URL+"/v0")
+
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	err := StatusCmd.RunE(StatusCmd, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	w.Close()
+	os.Stdout = old
+	var buf bytes.Buffer
+	io.Copy(&buf, r)
+	out := buf.String()
+
+	if !strings.Contains(out, "running") {
+		t.Errorf("expected 'running' in output, got: %s", out)
+	}
+	if !strings.Contains(out, "v0.5.0") {
+		t.Errorf("expected server version in output, got: %s", out)
+	}
+	if !strings.Contains(out, "MCP servers:     1") {
+		t.Errorf("expected 1 server in output, got: %s", out)
+	}
+	if !strings.Contains(out, "Agents:          2") {
+		t.Errorf("expected 2 agents in output, got: %s", out)
+	}
+	if !strings.Contains(out, "Skills:          0") {
+		t.Errorf("expected 0 skills in output, got: %s", out)
+	}
+}
+
+func TestStatusCmd_JSONOutput(t *testing.T) {
+	// Point to a non-existent server.
+	t.Setenv("ARCTL_API_BASE_URL", "http://127.0.0.1:19999/v0")
+
+	// Set JSON output
+	statusOutputFormat = "json"
+	defer func() { statusOutputFormat = "table" }()
+
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	err := StatusCmd.RunE(StatusCmd, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	w.Close()
+	os.Stdout = old
+	var buf bytes.Buffer
+	io.Copy(&buf, r)
+
+	var info statusInfo
+	if err := json.Unmarshal(buf.Bytes(), &info); err != nil {
+		t.Fatalf("expected valid JSON, got parse error: %v\noutput: %s", err, buf.String())
+	}
+	if info.Daemon != "stopped" {
+		t.Errorf("expected daemon=stopped, got %s", info.Daemon)
+	}
+	if info.API != "unreachable" {
+		t.Errorf("expected api=unreachable, got %s", info.API)
+	}
+}

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -115,6 +115,7 @@ func init() {
 	rootCmd.AddCommand(skill.SkillCmd)
 	rootCmd.AddCommand(configure.ConfigureCmd)
 	rootCmd.AddCommand(cli.VersionCmd)
+	rootCmd.AddCommand(cli.StatusCmd)
 	rootCmd.AddCommand(cli.ImportCmd)
 	rootCmd.AddCommand(cli.ExportCmd)
 	rootCmd.AddCommand(cli.EmbeddingsCmd)


### PR DESCRIPTION
## Summary
- Adds `arctl status` command that shows daemon state, server version, and resource counts (fixes #17)
- Does NOT auto-start the daemon — reports current state without side effects
- Supports `--output json` for machine-readable output
- Includes 3 tests: daemon stopped, daemon running (mock server), and JSON output

## Example Output

When daemon is running:
```
arctl version:   v0.5.0
Daemon:          running
API:             ok
Server version:  v0.5.0
Git commit:      abc1234
Build time:      2026-02-08T00:00:00Z
MCP servers:     3
Agents:          2
Skills:          1
```

When daemon is stopped:
```
arctl version:   v0.5.0
Daemon:          stopped
API:             unreachable
```

## Test plan
- [x] `go test ./internal/cli/ -run TestStatus` — 3 tests pass
- [x] `go test ./...` — all existing tests still pass
- [x] `go build ./...` — compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)