### PR TITLE
Add arctl start and stop commands

### DIFF
--- a/internal/cli/start.go
+++ b/internal/cli/start.go
@@ -1,0 +1,37 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/agentregistry-dev/agentregistry/internal/utils"
+	"github.com/agentregistry-dev/agentregistry/pkg/daemon"
+	"github.com/spf13/cobra"
+)
+
+var StartCmd = &cobra.Command{
+	Use:   "start",
+	Short: "Start the daemon",
+	Long:  `Starts the agent registry daemon and its associated services using Docker Compose.`,
+	// Override PersistentPreRunE so we don't auto-start the daemon.
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		return nil
+	},
+	RunE: runStart,
+}
+
+func runStart(cmd *cobra.Command, args []string) error {
+	if !utils.IsDockerComposeAvailable() {
+		fmt.Println("Docker compose is not available. Please install docker compose and try again.")
+		fmt.Println("See https://docs.docker.com/compose/install/ for installation instructions.")
+		return fmt.Errorf("docker compose is not available")
+	}
+
+	dm := daemon.NewDaemonManager(nil)
+
+	if dm.IsRunning() {
+		fmt.Println("✓ Daemon is already running")
+		return nil
+	}
+
+	return dm.Start()
+}

--- a/internal/cli/start_test.go
+++ b/internal/cli/start_test.go
@@ -1,0 +1,24 @@
+package cli
+
+import (
+	"testing"
+)
+
+func TestStartCmd_Config(t *testing.T) {
+	if StartCmd.Use != "start" {
+		t.Errorf("expected Use to be 'start', got %q", StartCmd.Use)
+	}
+	if StartCmd.Short == "" {
+		t.Error("expected Short description to be non-empty")
+	}
+	if StartCmd.RunE == nil {
+		t.Error("expected RunE to be set")
+	}
+	if StartCmd.PersistentPreRunE == nil {
+		t.Error("expected PersistentPreRunE override to be set")
+	}
+	// The PersistentPreRunE override should return nil (bypass auto-start).
+	if err := StartCmd.PersistentPreRunE(nil, nil); err != nil {
+		t.Errorf("expected PersistentPreRunE to return nil, got %v", err)
+	}
+}

--- a/internal/cli/stop.go
+++ b/internal/cli/stop.go
@@ -1,0 +1,30 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/agentregistry-dev/agentregistry/pkg/daemon"
+	"github.com/spf13/cobra"
+)
+
+var StopCmd = &cobra.Command{
+	Use:   "stop",
+	Short: "Stop the daemon",
+	Long:  `Stops the agent registry daemon and its associated services.`,
+	// Override PersistentPreRunE so we don't auto-start the daemon.
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		return nil
+	},
+	RunE: runStop,
+}
+
+func runStop(cmd *cobra.Command, args []string) error {
+	dm := daemon.NewDaemonManager(nil)
+
+	if !dm.IsRunning() {
+		fmt.Println("✓ Daemon is not running")
+		return nil
+	}
+
+	return dm.Stop()
+}

--- a/internal/cli/stop_test.go
+++ b/internal/cli/stop_test.go
@@ -1,0 +1,24 @@
+package cli
+
+import (
+	"testing"
+)
+
+func TestStopCmd_Config(t *testing.T) {
+	if StopCmd.Use != "stop" {
+		t.Errorf("expected Use to be 'stop', got %q", StopCmd.Use)
+	}
+	if StopCmd.Short == "" {
+		t.Error("expected Short description to be non-empty")
+	}
+	if StopCmd.RunE == nil {
+		t.Error("expected RunE to be set")
+	}
+	if StopCmd.PersistentPreRunE == nil {
+		t.Error("expected PersistentPreRunE override to be set")
+	}
+	// The PersistentPreRunE override should return nil (bypass auto-start).
+	if err := StopCmd.PersistentPreRunE(nil, nil); err != nil {
+		t.Errorf("expected PersistentPreRunE to return nil, got %v", err)
+	}
+}

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -115,6 +115,8 @@ func init() {
 	rootCmd.AddCommand(skill.SkillCmd)
 	rootCmd.AddCommand(configure.ConfigureCmd)
 	rootCmd.AddCommand(cli.VersionCmd)
+	rootCmd.AddCommand(cli.StartCmd)
+	rootCmd.AddCommand(cli.StopCmd)
 	rootCmd.AddCommand(cli.ImportCmd)
 	rootCmd.AddCommand(cli.ExportCmd)
 	rootCmd.AddCommand(cli.EmbeddingsCmd)

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -151,6 +151,20 @@ func (d *DefaultDaemonManager) Start() error {
 	return nil
 }
 
+func (d *DefaultDaemonManager) Stop() error {
+	fmt.Printf("Stopping %s daemon...\n", d.config.ProjectName)
+	cmd := exec.Command("docker", "compose", "-p", d.config.ProjectName, "-f", "-", "down")
+	cmd.Stdin = strings.NewReader(d.getComposeYAML())
+	cmd.Env = append(os.Environ(), fmt.Sprintf("VERSION=%s", d.config.Version), fmt.Sprintf("DOCKER_REGISTRY=%s", d.config.DockerRegistry))
+	if byt, err := cmd.CombinedOutput(); err != nil {
+		fmt.Printf("failed to stop docker compose: %v, output: %s", err, string(byt))
+		return fmt.Errorf("failed to stop docker compose: %w", err)
+	}
+
+	fmt.Printf("✓ %s daemon stopped successfully\n", d.config.ProjectName)
+	return nil
+}
+
 func (d *DefaultDaemonManager) IsRunning() bool {
 	// First check if a server is responding on the API port (local or Docker)
 	if isServerResponding() {

--- a/pkg/daemon/daemon_test.go
+++ b/pkg/daemon/daemon_test.go
@@ -1,0 +1,36 @@
+package daemon
+
+import (
+	"testing"
+
+	"github.com/agentregistry-dev/agentregistry/pkg/types"
+)
+
+func TestDefaultDaemonManager_ImplementsInterface(t *testing.T) {
+	// Verify that DefaultDaemonManager implements the full DaemonManager interface,
+	// including the Stop() method.
+	var _ types.DaemonManager = (*DefaultDaemonManager)(nil)
+}
+
+func TestNewDaemonManager_DefaultConfig(t *testing.T) {
+	dm := NewDaemonManager(nil)
+	if dm.config.ProjectName != "agentregistry" {
+		t.Errorf("expected default project name 'agentregistry', got %q", dm.config.ProjectName)
+	}
+	if dm.config.ContainerName != "agentregistry-server" {
+		t.Errorf("expected default container name 'agentregistry-server', got %q", dm.config.ContainerName)
+	}
+}
+
+func TestNewDaemonManager_CustomConfig(t *testing.T) {
+	dm := NewDaemonManager(&types.DaemonConfig{
+		ProjectName:   "custom-project",
+		ContainerName: "custom-container",
+	})
+	if dm.config.ProjectName != "custom-project" {
+		t.Errorf("expected project name 'custom-project', got %q", dm.config.ProjectName)
+	}
+	if dm.config.ContainerName != "custom-container" {
+		t.Errorf("expected container name 'custom-container', got %q", dm.config.ContainerName)
+	}
+}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -84,6 +84,8 @@ type DaemonManager interface {
 	IsRunning() bool
 	// Start starts the daemon, blocking until it's ready
 	Start() error
+	// Stop stops the daemon
+	Stop() error
 }
 
 // CLIAuthnProvider provides authentication for CLI commands.


### PR DESCRIPTION
## Summary

Adds `arctl start` and `arctl stop` commands for explicit daemon lifecycle management.

- `arctl start`: Starts the daemon via Docker Compose (idempotent — prints success if already running)
- `arctl stop`: Stops the daemon via Docker Compose (idempotent — prints success if already stopped)
- Adds `Stop()` method to the `DaemonManager` interface
- Both commands override `PersistentPreRunE` to prevent recursive auto-start
- Docker Compose availability check before starting

Fixes #98

## Changes

| File | Change |
|------|--------|
| `pkg/types/types.go` | Add `Stop()` to `DaemonManager` interface |
| `pkg/daemon/daemon.go` | Implement `Stop()` on `DefaultDaemonManager` |
| `internal/cli/start.go` | New `arctl start` command |
| `internal/cli/stop.go` | New `arctl stop` command |
| `pkg/cli/root.go` | Register start/stop commands |
| `*_test.go` (3 files) | 5 tests: command config, interface compliance, daemon manager config |

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes (5 new tests, 0 regressions)
- [ ] Manual: `arctl start` starts daemon, `arctl stop` stops it
- [ ] Manual: `arctl start` when already running prints "already running"
- [ ] Manual: `arctl stop` when already stopped prints "not running"

🤖 Generated with [Claude Code](https://claude.com/claude-code)