### PR TITLE
fix: wait for daemon readiness after auto-start

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -65,11 +65,15 @@ func NewClientWithConfig(baseURL, token string) (*Client, error) {
 
 func pingWithRetry(c *Client) error {
 	var lastErr error
-	const attempts = 3
+	const attempts = 5
+	delay := time.Second
 	for i := range attempts {
 		if err := c.Ping(); err != nil {
 			lastErr = err
-			time.Sleep(time.Duration(i+1) * time.Second)
+			if i < attempts-1 {
+				time.Sleep(delay)
+				delay *= 2
+			}
 			continue
 		}
 		return nil

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -1,0 +1,55 @@
+package client
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+)
+
+func TestPingWithRetry_ImmediateSuccess(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "")
+	if err := pingWithRetry(c); err != nil {
+		t.Fatalf("pingWithRetry failed on immediate success: %v", err)
+	}
+}
+
+func TestPingWithRetry_SucceedsAfterFailures(t *testing.T) {
+	var calls atomic.Int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := calls.Add(1)
+		if n < 3 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "")
+	if err := pingWithRetry(c); err != nil {
+		t.Fatalf("pingWithRetry failed: %v (calls=%d)", err, calls.Load())
+	}
+	if calls.Load() < 3 {
+		t.Fatalf("expected at least 3 calls, got %d", calls.Load())
+	}
+}
+
+func TestPingWithRetry_AllFail(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "")
+	err := pingWithRetry(c)
+	if err == nil {
+		t.Fatal("expected error when all pings fail")
+	}
+}

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -64,6 +64,9 @@ var rootCmd = &cobra.Command{
 				if err := dm.Start(); err != nil {
 					return fmt.Errorf("failed to start daemon: %w", err)
 				}
+				if err := dm.WaitForReady(); err != nil {
+					return fmt.Errorf("daemon started but not ready: %w", err)
+				}
 			}
 		}
 

--- a/pkg/daemon/daemon_test.go
+++ b/pkg/daemon/daemon_test.go
@@ -1,0 +1,93 @@
+package daemon
+
+import (
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/agentregistry-dev/agentregistry/pkg/types"
+)
+
+func TestDefaultDaemonManagerImplementsInterface(t *testing.T) {
+	var _ types.DaemonManager = (*DefaultDaemonManager)(nil)
+}
+
+func TestWaitForReady_AlreadyReady(t *testing.T) {
+	// Start a test server on port 12121 that immediately responds
+	listener, err := net.Listen("tcp", "127.0.0.1:12121")
+	if err != nil {
+		t.Skip("port 12121 already in use, skipping")
+	}
+
+	srv := &http.Server{Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})}
+	go srv.Serve(listener)
+	defer srv.Close()
+
+	dm := NewDaemonManager(nil)
+	if err := dm.WaitForReady(); err != nil {
+		t.Fatalf("WaitForReady failed when server was already ready: %v", err)
+	}
+}
+
+func TestWaitForReady_BecomesReadyAfterDelay(t *testing.T) {
+	var ready atomic.Bool
+
+	// Start a test server that returns 503 until we set ready=true
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if ready.Load() {
+			w.WriteHeader(http.StatusOK)
+		} else {
+			w.WriteHeader(http.StatusServiceUnavailable)
+		}
+	})
+
+	listener, err := net.Listen("tcp", "127.0.0.1:12121")
+	if err != nil {
+		t.Skip("port 12121 already in use, skipping")
+	}
+
+	srv := &http.Server{Handler: handler}
+	go srv.Serve(listener)
+	defer srv.Close()
+
+	// Make server ready after 2 seconds
+	go func() {
+		time.Sleep(2 * time.Second)
+		ready.Store(true)
+	}()
+
+	dm := NewDaemonManager(nil)
+	start := time.Now()
+	if err := dm.WaitForReady(); err != nil {
+		t.Fatalf("WaitForReady failed: %v", err)
+	}
+	elapsed := time.Since(start)
+	if elapsed < 2*time.Second {
+		t.Fatalf("WaitForReady returned too quickly: %v", elapsed)
+	}
+}
+
+func TestIsServerResponding(t *testing.T) {
+	// When no server is running on 12121, isServerResponding should return false quickly
+	// (This test may be flaky if something is actually running on 12121)
+	listener, err := net.Listen("tcp", "127.0.0.1:12121")
+	if err != nil {
+		t.Skip("port 12121 already in use, skipping")
+	}
+
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	srv.Listener = listener
+	srv.Start()
+	defer srv.Close()
+
+	if !isServerResponding() {
+		t.Fatal("isServerResponding returned false when server is running")
+	}
+}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -84,6 +84,8 @@ type DaemonManager interface {
 	IsRunning() bool
 	// Start starts the daemon, blocking until it's ready
 	Start() error
+	// WaitForReady polls the daemon API until it responds or the timeout expires
+	WaitForReady() error
 }
 
 // CLIAuthnProvider provides authentication for CLI commands.


### PR DESCRIPTION
# Description

Fixes #48 — `arctl list -A` (and other commands) failed with "failed to reach API after 3 attempts" when the daemon was auto-started because the API server wasn't fully ready when the client tried to connect.

# Change Type

```
/kind fix
```

# Changelog

```release-note
wait for daemon readiness after auto-start
```

### Root cause

After `docker compose up -d --wait` returns, the container is "healthy" per Docker's health check, but the API server inside may still be initializing. The previous retry logic (3 attempts, 1s/2s/3s linear backoff = 6 seconds total) was insufficient for slow networks or cold starts.

### Changes

- **`pkg/types/types.go`**: Added `WaitForReady()` to `DaemonManager` interface
- **`pkg/daemon/daemon.go`**: Implemented `WaitForReady()` — polls `/v0/ping` with exponential backoff (500ms → 4s) for up to 30 seconds
- **`pkg/cli/root.go`**: Calls `dm.WaitForReady()` after `dm.Start()` so the API is confirmed responsive before creating the client
- **`internal/client/client.go`**: Increased `pingWithRetry` from 3 to 5 attempts with exponential backoff as a secondary safety net

### Tests

- 4 new daemon tests (`pkg/daemon/daemon_test.go`): interface compliance, already-ready, becomes-ready-after-delay, isServerResponding
- 3 new client tests (`internal/client/client_test.go`): immediate success, success after failures, all fail
- All existing tests pass: `go test ./...` clean

## Test plan

- [ ] Auto-start daemon from cold (no containers running) — verify `arctl list -A` succeeds without retry errors
- [ ] Verify behavior on slow network (hotel wifi scenario from #48)
- [ ] Verify `WaitForReady()` returns immediately if daemon is already running
- [ ] Run `go test ./...` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)