### PR TITLE
fix: skip daemon for offline commands (agent init, mcp init)

### DIFF
--- a/pkg/cli/root_test.go
+++ b/pkg/cli/root_test.go
@@ -1,0 +1,49 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// buildCmd constructs a command tree so CommandPath() returns the desired path.
+// e.g. buildCmd("arctl", "agent", "init") → cmd whose CommandPath() is "arctl agent init".
+func buildCmd(names ...string) *cobra.Command {
+	if len(names) == 0 {
+		return &cobra.Command{}
+	}
+	root := &cobra.Command{Use: names[0]}
+	cur := root
+	for _, n := range names[1:] {
+		child := &cobra.Command{Use: n}
+		cur.AddCommand(child)
+		cur = child
+	}
+	return cur
+}
+
+func TestIsOfflineCommand(t *testing.T) {
+	tests := []struct {
+		name  string
+		parts []string
+		want  bool
+	}{
+		{"agent init is offline", []string{"arctl", "agent", "init"}, true},
+		{"mcp init is offline", []string{"arctl", "mcp", "init"}, true},
+		{"mcp init go subcommand is offline", []string{"arctl", "mcp", "init", "go"}, true},
+		{"mcp init python subcommand is offline", []string{"arctl", "mcp", "init", "python"}, true},
+		{"agent list needs daemon", []string{"arctl", "agent", "list"}, false},
+		{"mcp list needs daemon", []string{"arctl", "mcp", "list"}, false},
+		{"agent publish needs daemon", []string{"arctl", "agent", "publish"}, false},
+		{"root command needs daemon", []string{"arctl"}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := buildCmd(tt.parts...)
+			if got := isOfflineCommand(cmd); got != tt.want {
+				t.Errorf("isOfflineCommand(%q) = %v, want %v", cmd.CommandPath(), got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #31.

- `agent init` and `mcp init` (including subcommands like `mcp init go`, `mcp init python`) only do local file I/O (scaffolding templates, creating directories) and never call the registry API
- The `PersistentPreRunE` hook forced daemon startup and API client creation for **all** commands, causing `agent init` to fail when the daemon was not running:
  ```
  Error: API client not initialized: failed to reach API at http://localhost:12121/v0
  ```
- Added `isOfflineCommand()` check that short-circuits `PersistentPreRunE` for commands that don't need network access
- New offline commands can be added by appending to the `offlineCommands` slice

## Changes

- `pkg/cli/root.go`: Added `offlineCommands` list and `isOfflineCommand()` function; early return in `PersistentPreRunE` for matching commands
- `pkg/cli/root_test.go`: 8 test cases covering offline and online commands, including subcommand matching

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes (all existing + 8 new tests)
- [x] `arctl agent init adk python dice` works without daemon running
- [x] Online commands (`agent list`, `mcp list`, etc.) still require daemon as before