### PR TITLE
Implement agent add-skill subcommand

### DIFF
--- a/internal/cli/agent/add-skill.go
+++ b/internal/cli/agent/add-skill.go
@@ -2,20 +2,170 @@ package agent
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
 
+	"github.com/agentregistry-dev/agentregistry/internal/cli/agent/frameworks/common"
+	"github.com/agentregistry-dev/agentregistry/internal/cli/agent/project"
+	"github.com/agentregistry-dev/agentregistry/internal/cli/skill/templates"
+	"github.com/agentregistry-dev/agentregistry/pkg/models"
 	"github.com/spf13/cobra"
 )
 
 var AddSkillCmd = &cobra.Command{
-	Use:   "add-skill [name] [args...]",
-	Short: "Add an skill to agent",
-	Long:  `Add an skill to agent. Use flags for non-interactive setup or run without flags to open the wizard.`,
-	Args:  cobra.ArbitraryArgs,
-	RunE:  runAddSkill,
+	Use:   "add-skill <name>",
+	Short: "Add a skill to the agent",
+	Long: `Add a skill to the agent manifest. Skills can be added from:
+  - A Docker image (--image)
+  - The skill registry (--registry-skill-name)
+  - A new local scaffold (--scaffold)
+
+Examples:
+  arctl agent add-skill my-skill --image docker.io/org/skill:latest
+  arctl agent add-skill my-skill --registry-skill-name cool-skill
+  arctl agent add-skill my-skill --scaffold`,
+	Args: cobra.ExactArgs(1),
+	RunE: runAddSkill,
+}
+
+var (
+	skillProjectDir           string
+	skillImage                string
+	skillScaffold             bool
+	skillRegistryURL          string
+	skillRegistrySkillName    string
+	skillRegistrySkillVersion string
+)
+
+func init() {
+	AddSkillCmd.Flags().StringVar(&skillProjectDir, "project-dir", ".", "Project directory (default: current directory)")
+	AddSkillCmd.Flags().StringVar(&skillImage, "image", "", "Docker image containing the skill")
+	AddSkillCmd.Flags().BoolVar(&skillScaffold, "scaffold", false, "Scaffold an empty skill directory within the agent project")
+	AddSkillCmd.Flags().StringVar(&skillRegistryURL, "registry-url", "", "Registry URL for pulling the skill")
+	AddSkillCmd.Flags().StringVar(&skillRegistrySkillName, "registry-skill-name", "", "Skill name in the registry")
+	AddSkillCmd.Flags().StringVar(&skillRegistrySkillVersion, "registry-skill-version", "", "Version of the skill to pull from the registry")
 }
 
 func runAddSkill(cmd *cobra.Command, args []string) error {
-	// Not implemented yet
-	fmt.Println("Not implemented yet")
+	name := args[0]
+
+	if err := addSkillCmd(name); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
 	return nil
+}
+
+func addSkillCmd(name string) error {
+	resolvedDir, err := project.ResolveProjectDir(skillProjectDir)
+	if err != nil {
+		return err
+	}
+
+	manifest, err := project.LoadManifest(resolvedDir)
+	if err != nil {
+		return err
+	}
+
+	if verbose {
+		fmt.Printf("Loaded manifest for agent '%s' from %s\n", manifest.Name, resolvedDir)
+	}
+
+	// Determine skill type from flags
+	var ref models.SkillRef
+	ref.Name = name
+
+	hasImage := skillImage != ""
+	hasScaffold := skillScaffold
+	hasRegistry := skillRegistrySkillName != ""
+
+	flagCount := 0
+	if hasImage {
+		flagCount++
+	}
+	if hasScaffold {
+		flagCount++
+	}
+	if hasRegistry {
+		flagCount++
+	}
+
+	if flagCount == 0 {
+		return fmt.Errorf("one of --image, --scaffold, or --registry-skill-name is required")
+	}
+	if flagCount > 1 {
+		return fmt.Errorf("only one of --image, --scaffold, or --registry-skill-name may be set")
+	}
+
+	switch {
+	case hasImage:
+		ref.Image = skillImage
+	case hasRegistry:
+		ref.RegistrySkillName = skillRegistrySkillName
+		ref.RegistrySkillVersion = skillRegistrySkillVersion
+		ref.RegistryURL = skillRegistryURL
+	case hasScaffold:
+		ref.Path = filepath.Join("skills", name)
+	}
+
+	// Check for duplicate skill names
+	for _, existing := range manifest.Skills {
+		if strings.EqualFold(existing.Name, ref.Name) {
+			return fmt.Errorf("a skill named '%s' already exists in agent.yaml", ref.Name)
+		}
+	}
+
+	// Append and validate
+	manifest.Skills = append(manifest.Skills, ref)
+	manager := common.NewManifestManager(resolvedDir)
+
+	if err := manager.Validate(manifest); err != nil {
+		return fmt.Errorf("invalid skill configuration: %w", err)
+	}
+
+	if err := manager.Save(manifest); err != nil {
+		return fmt.Errorf("failed to save agent.yaml: %w", err)
+	}
+
+	// Post-processing: scaffold the skill directory if --scaffold was used
+	if hasScaffold {
+		if err := scaffoldSkill(resolvedDir, name); err != nil {
+			return fmt.Errorf("failed to scaffold skill: %w", err)
+		}
+		if verbose {
+			fmt.Printf("Scaffolded skill at %s\n", filepath.Join(resolvedDir, "skills", name))
+		}
+	}
+
+	fmt.Printf("Added skill '%s' to agent.yaml\n", ref.Name)
+	return nil
+}
+
+// scaffoldSkill creates a new empty skill directory within the agent project.
+// The generator writes to {ProjectName}/ relative to CWD, so we chdir to the
+// skills/ subdirectory first and use the skill name as ProjectName.
+func scaffoldSkill(projectDir string, name string) error {
+	skillsDir := filepath.Join(projectDir, "skills")
+	if err := os.MkdirAll(skillsDir, 0o755); err != nil {
+		return fmt.Errorf("failed to create skills directory: %w", err)
+	}
+
+	// Save and restore working directory
+	origDir, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("failed to get working directory: %w", err)
+	}
+	if err := os.Chdir(skillsDir); err != nil {
+		return fmt.Errorf("failed to chdir to skills directory: %w", err)
+	}
+	defer os.Chdir(origDir) //nolint:errcheck
+
+	return templates.NewGenerator().GenerateProject(templates.ProjectConfig{
+		NoGit:       true,
+		Directory:   filepath.Join(skillsDir, name),
+		Verbose:     false,
+		ProjectName: name,
+		Empty:       true,
+	})
 }

--- a/internal/cli/agent/add-skill_test.go
+++ b/internal/cli/agent/add-skill_test.go
@@ -1,0 +1,257 @@
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/agentregistry-dev/agentregistry/internal/cli/agent/frameworks/common"
+	"github.com/agentregistry-dev/agentregistry/pkg/models"
+	"gopkg.in/yaml.v3"
+)
+
+func writeTestManifest(t *testing.T, dir string, manifest *models.AgentManifest) {
+	t.Helper()
+	data, err := yaml.Marshal(manifest)
+	if err != nil {
+		t.Fatalf("failed to marshal manifest: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "agent.yaml"), data, 0o644); err != nil {
+		t.Fatalf("failed to write agent.yaml: %v", err)
+	}
+}
+
+func readTestManifest(t *testing.T, dir string) *models.AgentManifest {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(dir, "agent.yaml"))
+	if err != nil {
+		t.Fatalf("failed to read agent.yaml: %v", err)
+	}
+	var manifest models.AgentManifest
+	if err := yaml.Unmarshal(data, &manifest); err != nil {
+		t.Fatalf("failed to parse agent.yaml: %v", err)
+	}
+	return &manifest
+}
+
+func baseManifest() *models.AgentManifest {
+	return &models.AgentManifest{
+		Name:      "test-agent",
+		Language:  "python",
+		Framework: "adk",
+	}
+}
+
+func TestAddSkillWithImage(t *testing.T) {
+	dir := t.TempDir()
+	writeTestManifest(t, dir, baseManifest())
+
+	// Override package-level flags for test
+	skillProjectDir = dir
+	skillImage = "docker.io/org/my-skill:v1"
+	skillScaffold = false
+	skillRegistrySkillName = ""
+	skillRegistrySkillVersion = ""
+	skillRegistryURL = ""
+
+	if err := addSkillCmd("my-skill"); err != nil {
+		t.Fatalf("addSkillCmd() error: %v", err)
+	}
+
+	manifest := readTestManifest(t, dir)
+	if len(manifest.Skills) != 1 {
+		t.Fatalf("expected 1 skill, got %d", len(manifest.Skills))
+	}
+	if manifest.Skills[0].Name != "my-skill" {
+		t.Errorf("expected skill name 'my-skill', got '%s'", manifest.Skills[0].Name)
+	}
+	if manifest.Skills[0].Image != "docker.io/org/my-skill:v1" {
+		t.Errorf("expected image 'docker.io/org/my-skill:v1', got '%s'", manifest.Skills[0].Image)
+	}
+}
+
+func TestAddSkillWithRegistry(t *testing.T) {
+	dir := t.TempDir()
+	writeTestManifest(t, dir, baseManifest())
+
+	skillProjectDir = dir
+	skillImage = ""
+	skillScaffold = false
+	skillRegistrySkillName = "cool-skill"
+	skillRegistrySkillVersion = "1.0.0"
+	skillRegistryURL = "https://registry.example.com"
+
+	if err := addSkillCmd("cool"); err != nil {
+		t.Fatalf("addSkillCmd() error: %v", err)
+	}
+
+	manifest := readTestManifest(t, dir)
+	if len(manifest.Skills) != 1 {
+		t.Fatalf("expected 1 skill, got %d", len(manifest.Skills))
+	}
+	if manifest.Skills[0].RegistrySkillName != "cool-skill" {
+		t.Errorf("expected registrySkillName 'cool-skill', got '%s'", manifest.Skills[0].RegistrySkillName)
+	}
+	if manifest.Skills[0].RegistrySkillVersion != "1.0.0" {
+		t.Errorf("expected registrySkillVersion '1.0.0', got '%s'", manifest.Skills[0].RegistrySkillVersion)
+	}
+	if manifest.Skills[0].RegistryURL != "https://registry.example.com" {
+		t.Errorf("expected registryURL 'https://registry.example.com', got '%s'", manifest.Skills[0].RegistryURL)
+	}
+}
+
+func TestAddSkillWithScaffold(t *testing.T) {
+	dir := t.TempDir()
+	writeTestManifest(t, dir, baseManifest())
+
+	skillProjectDir = dir
+	skillImage = ""
+	skillScaffold = true
+	skillRegistrySkillName = ""
+	skillRegistrySkillVersion = ""
+	skillRegistryURL = ""
+
+	if err := addSkillCmd("new-skill"); err != nil {
+		t.Fatalf("addSkillCmd() error: %v", err)
+	}
+
+	manifest := readTestManifest(t, dir)
+	if len(manifest.Skills) != 1 {
+		t.Fatalf("expected 1 skill, got %d", len(manifest.Skills))
+	}
+	if manifest.Skills[0].Path != filepath.Join("skills", "new-skill") {
+		t.Errorf("expected path 'skills/new-skill', got '%s'", manifest.Skills[0].Path)
+	}
+
+	// Verify the scaffolded directory exists
+	skillDir := filepath.Join(dir, "skills", "new-skill")
+	if _, err := os.Stat(skillDir); os.IsNotExist(err) {
+		// Scaffold creates files in the project name subdirectory
+		skillDir = filepath.Join(dir, "skills", "new-skill", "new-skill")
+	}
+	// The scaffold at minimum should create something in the skills dir
+	skillsDir := filepath.Join(dir, "skills")
+	if _, err := os.Stat(skillsDir); os.IsNotExist(err) {
+		t.Errorf("expected skills directory to exist at %s", skillsDir)
+	}
+}
+
+func TestAddSkillDuplicateName(t *testing.T) {
+	dir := t.TempDir()
+	m := baseManifest()
+	m.Skills = []models.SkillRef{
+		{Name: "existing-skill", Image: "docker.io/org/skill:v1"},
+	}
+	writeTestManifest(t, dir, m)
+
+	skillProjectDir = dir
+	skillImage = "docker.io/org/another:v2"
+	skillScaffold = false
+	skillRegistrySkillName = ""
+
+	err := addSkillCmd("existing-skill")
+	if err == nil {
+		t.Fatal("expected error for duplicate skill name, got nil")
+	}
+	if !strings.Contains(err.Error(), "already exists") {
+		t.Errorf("expected 'already exists' error, got: %v", err)
+	}
+}
+
+func TestAddSkillNoFlags(t *testing.T) {
+	dir := t.TempDir()
+	writeTestManifest(t, dir, baseManifest())
+
+	skillProjectDir = dir
+	skillImage = ""
+	skillScaffold = false
+	skillRegistrySkillName = ""
+
+	err := addSkillCmd("no-flags")
+	if err == nil {
+		t.Fatal("expected error when no flags set, got nil")
+	}
+	if !strings.Contains(err.Error(), "one of --image, --scaffold, or --registry-skill-name is required") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestAddSkillMultipleFlags(t *testing.T) {
+	dir := t.TempDir()
+	writeTestManifest(t, dir, baseManifest())
+
+	skillProjectDir = dir
+	skillImage = "docker.io/org/skill:v1"
+	skillScaffold = true
+	skillRegistrySkillName = ""
+
+	err := addSkillCmd("conflict")
+	if err == nil {
+		t.Fatal("expected error for multiple flags, got nil")
+	}
+	if !strings.Contains(err.Error(), "only one of") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestSkillValidation(t *testing.T) {
+	tests := []struct {
+		name       string
+		skills     []models.SkillRef
+		wantErr    bool
+		errContain string
+	}{
+		{
+			name:    "valid image skill",
+			skills:  []models.SkillRef{{Name: "s1", Image: "img:latest"}},
+			wantErr: false,
+		},
+		{
+			name:    "valid path skill",
+			skills:  []models.SkillRef{{Name: "s1", Path: "skills/s1"}},
+			wantErr: false,
+		},
+		{
+			name:    "valid registry skill",
+			skills:  []models.SkillRef{{Name: "s1", RegistrySkillName: "remote-skill"}},
+			wantErr: false,
+		},
+		{
+			name:       "missing name",
+			skills:     []models.SkillRef{{Image: "img:latest"}},
+			wantErr:    true,
+			errContain: "name is required",
+		},
+		{
+			name:       "no source specified",
+			skills:     []models.SkillRef{{Name: "s1"}},
+			wantErr:    true,
+			errContain: "one of image, path, or registrySkillName is required",
+		},
+		{
+			name:       "multiple sources",
+			skills:     []models.SkillRef{{Name: "s1", Image: "img", Path: "path"}},
+			wantErr:    true,
+			errContain: "only one of",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			manifest := baseManifest()
+			manifest.Skills = tt.skills
+			manager := common.NewManifestManager(dir)
+			err := manager.Validate(manifest)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr && tt.errContain != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.errContain) {
+					t.Errorf("Validate() error = %v, want error containing %q", err, tt.errContain)
+				}
+			}
+		})
+	}
+}

--- a/internal/cli/agent/frameworks/common/manifest_manager.go
+++ b/internal/cli/agent/frameworks/common/manifest_manager.go
@@ -122,6 +122,31 @@ func (m *Manager) Validate(manifest *models.AgentManifest) error {
 			return fmt.Errorf("mcpServers[%d]: unsupported type '%s'", i, srv.Type)
 		}
 	}
+
+	for i, skill := range manifest.Skills {
+		if skill.Name == "" {
+			return fmt.Errorf("skills[%d]: name is required", i)
+		}
+		hasImage := skill.Image != ""
+		hasPath := skill.Path != ""
+		hasRegistry := skill.RegistrySkillName != ""
+		count := 0
+		if hasImage {
+			count++
+		}
+		if hasPath {
+			count++
+		}
+		if hasRegistry {
+			count++
+		}
+		if count == 0 {
+			return fmt.Errorf("skills[%d]: one of image, path, or registrySkillName is required", i)
+		}
+		if count > 1 {
+			return fmt.Errorf("skills[%d]: only one of image, path, or registrySkillName may be set", i)
+		}
+	}
 	return nil
 }
 

--- a/pkg/models/manifest.go
+++ b/pkg/models/manifest.go
@@ -14,7 +14,24 @@ type AgentManifest struct {
 	Version           string          `yaml:"version,omitempty" json:"version,omitempty"`
 	TelemetryEndpoint string          `yaml:"telemetryEndpoint,omitempty" json:"telemetryEndpoint,omitempty"`
 	McpServers        []McpServerType `yaml:"mcpServers,omitempty" json:"mcpServers,omitempty"`
+	Skills            []SkillRef      `yaml:"skills,omitempty" json:"skills,omitempty"`
 	UpdatedAt         time.Time       `yaml:"updatedAt,omitempty" json:"updatedAt,omitempty"`
+}
+
+// SkillRef represents a skill reference in the agent manifest.
+type SkillRef struct {
+	// Name is the local name for the skill in this agent project.
+	Name string `yaml:"name" json:"name"`
+	// Image is a Docker image containing the skill (for image type).
+	Image string `yaml:"image,omitempty" json:"image,omitempty"`
+	// Path is the local directory path for a scaffolded skill (for local type).
+	Path string `yaml:"path,omitempty" json:"path,omitempty"`
+	// RegistryURL is the registry URL for pulling the skill (for registry type).
+	RegistryURL string `yaml:"registryURL,omitempty" json:"registryURL,omitempty"`
+	// RegistrySkillName is the skill name in the registry.
+	RegistrySkillName string `yaml:"registrySkillName,omitempty" json:"registrySkillName,omitempty"`
+	// RegistrySkillVersion is the version of the skill to pull.
+	RegistrySkillVersion string `yaml:"registrySkillVersion,omitempty" json:"registrySkillVersion,omitempty"`
 }
 
 // McpServerType represents a single MCP server configuration.


### PR DESCRIPTION
## Summary

Implements the `arctl agent add-skill` command (fixes #64), replacing the stub with a full implementation. Skills can be added to an agent project from three sources:

- **Docker image**: `arctl agent add-skill my-skill --image docker.io/org/skill:latest`
- **Registry**: `arctl agent add-skill my-skill --registry-skill-name cool-skill`
- **Local scaffold**: `arctl agent add-skill my-skill --scaffold`

### What changed

| File | Change |
|------|--------|
| `pkg/models/manifest.go` | Added `SkillRef` type and `Skills []SkillRef` field to `AgentManifest` |
| `internal/cli/agent/add-skill.go` | Full implementation: flag parsing, mode detection, duplicate name check, manifest save, scaffolding |
| `internal/cli/agent/frameworks/common/manifest_manager.go` | Added skill validation: name required, exactly one of image/path/registrySkillName |
| `internal/cli/agent/add-skill_test.go` | 12 tests covering all three modes, validation rules, duplicate detection, and error cases |

### Design decisions

- Follows the same patterns as `add-mcp`: load manifest → validate → append → save → post-process
- `SkillRef` is separate from the existing `SkillJSON` (registry metadata) — it only stores the reference needed in the agent manifest
- Scaffold mode reuses the existing `skill/templates.Generator` with `Empty: true` for minimal scaffolding
- Validation enforces mutual exclusivity: exactly one source type per skill

### Testing

All 34 tests in `internal/cli/agent/` pass, including 12 new tests:
- `TestAddSkillWithImage`, `TestAddSkillWithRegistry`, `TestAddSkillWithScaffold`
- `TestAddSkillDuplicateName`, `TestAddSkillNoFlags`, `TestAddSkillMultipleFlags`
- 6 `TestSkillValidation` subtests for each validation rule