### PR TITLE
ci: Remove duplicate go mod download step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,9 +44,6 @@ jobs:
     - name: Build UI
       run: make build-ui
 
-    - name: Download Go dependencies
-      run: go mod download
-
     - name: Run Integration Tests
       run: |
         echo "Starting integration test services..."


### PR DESCRIPTION
The build.yml workflow was calling `go mod download` multiple times. Appears to be an oversight/cruft
and we cam remove the duplicate step.