### PR TITLE
add version to init, include runtime hint in publish

### DIFF
--- a/internal/cli/mcp/init.go
+++ b/internal/cli/mcp/init.go
@@ -33,6 +33,7 @@ var (
 	initEmail          string
 	initDescription    string
 	initNonInteractive bool
+	initVersion        string
 )
 
 func init() {
@@ -42,6 +43,7 @@ func init() {
 	InitCmd.PersistentFlags().StringVar(&initEmail, "email", "", "Author email for the project")
 	InitCmd.PersistentFlags().StringVar(&initDescription, "description", "", "Description for the project")
 	InitCmd.PersistentFlags().BoolVar(&initNonInteractive, "non-interactive", false, "Run in non-interactive mode")
+	InitCmd.PersistentFlags().StringVar(&initVersion, "version", "0.1.0", "Version for the project (default: 0.1.0)")
 }
 
 func runInit(cmd *cobra.Command, args []string) error {
@@ -73,7 +75,7 @@ func runInitFramework(
 	}
 
 	// Create project manifest
-	projectManifest := manifest.GetDefault(projectName, framework, initDescription, initAuthor, initEmail)
+	projectManifest := manifest.GetDefault(projectName, framework, initDescription, initAuthor, initEmail, initVersion)
 
 	// Check if directory exists
 	projectPath, err := filepath.Abs(projectName)

--- a/internal/cli/mcp/manifest/manager.go
+++ b/internal/cli/mcp/manifest/manager.go
@@ -135,7 +135,7 @@ func (m *Manager) RemoveTool(man *ProjectManifest, name string) error {
 }
 
 // GetDefault returns a new ProjectManifest with default values.
-func GetDefault(name, framework, description, author, email string) *ProjectManifest {
+func GetDefault(name, framework, description, author, email, version string) *ProjectManifest {
 	if description == "" {
 		description = fmt.Sprintf("MCP server built with %s", framework)
 	}
@@ -145,7 +145,7 @@ func GetDefault(name, framework, description, author, email string) *ProjectMani
 	return &ProjectManifest{
 		Name:        name,
 		Framework:   framework,
-		Version:     "0.1.0",
+		Version:     version,
 		Description: description,
 		Author:      author,
 		Email:       email,

--- a/internal/cli/mcp/publish.go
+++ b/internal/cli/mcp/publish.go
@@ -118,6 +118,8 @@ func runMCPServerPublish(cmd *cobra.Command, args []string) error {
 	}
 
 	var serverName, description, version string
+	var runtimeArgs []string
+	var runtimeHint string
 
 	// Check if input is a local path with mcp.yaml
 	absPath, _ := filepath.Abs(input)
@@ -133,6 +135,8 @@ func runMCPServerPublish(cmd *cobra.Command, args []string) error {
 		serverName = common.BuildMCPServerRegistryName(projectManifest.Author, projectManifest.Name)
 		description = projectManifest.Description
 		version = common.ResolveVersion(publishVersion, projectManifest.Version)
+		runtimeArgs = projectManifest.RuntimeArgs
+		runtimeHint = projectManifest.RuntimeHint
 	} else {
 		// Use command line arguments
 		serverName = strings.ToLower(input)
@@ -181,8 +185,9 @@ func runMCPServerPublish(cmd *cobra.Command, args []string) error {
 		RegistryType:     regType,
 		Identifier:       packageID,
 		PackageVersion:   pkgVersion,
-		RuntimeHint:      registryTypeRuntimeHints[regType],
 		PackageArguments: publishArgs,
+		RuntimeHint:      runtimeHint,
+		RuntimeArguments: runtimeArgs,
 		TransportType:    transportType,
 		TransportURL:     transportURL,
 	})


### PR DESCRIPTION
adds `--version` to mcp init and ensures the runtime hint/args are part of the mcp registry entry.