### PR TITLE
CLAUDE: Symlink to AGENTS.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
Claude Code on the web doesn't formally support AGENTS.md yet. The recommended workaround is to use CLAUDE.md and reference AGENTS.md via @AGENTS.md. This symlink lets cloud-based terminals pick up our project guidelines while keeping AGENTS.md as the canonical source.

See: https://github.com/anthropics/claude-code/issues/6235
Docs: https://code.claude.com/docs/en/claude-code-on-the-web#best-practices