### PR TITLE
golangci: Enable nestif linter, grandfather existing violations

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -21,6 +21,7 @@ linters:
     - misspell
     - modernize
     - nakedret
+    - nestif
     - nolintlint
     - staticcheck
     - unused

--- a/internal/cli/agent/add-mcp.go
+++ b/internal/cli/agent/add-mcp.go
@@ -73,7 +73,7 @@ func addMcpCmd(name string) error {
 
 	// If flags provided, build non-interactively; else run wizard
 	var res models.McpServerType
-	if remoteURL != "" || command != "" || image != "" || build != "" || registryURL != "" || registryServerName != "" {
+	if remoteURL != "" || command != "" || image != "" || build != "" || registryURL != "" || registryServerName != "" { //nolint:nestif
 		if remoteURL != "" {
 			headerMap, err := utils.ParseKeyValuePairs(headers)
 			if err != nil {

--- a/internal/cli/agent/run.go
+++ b/internal/cli/agent/run.go
@@ -87,7 +87,7 @@ func runFromDirectory(ctx context.Context, projectDir string) error {
 	var serversForConfig []common.PythonMCPServer
 
 	// Resolve registry-type MCP servers if present
-	if hasRegistryServers(manifest) {
+	if hasRegistryServers(manifest) { //nolint:nestif
 		if verbose {
 			fmt.Println("[registry-resolve] Detected registry-type MCP servers in manifest")
 			fmt.Printf("[registry-resolve] Total MCP servers in manifest: %d\n", len(manifest.McpServers))
@@ -204,7 +204,7 @@ func runFromManifest(ctx context.Context, manifest *models.AgentManifest, versio
 	useOverrides := overrides != nil
 	var serversForConfig []common.PythonMCPServer
 
-	if useOverrides {
+	if useOverrides { //nolint:nestif
 		// servers already resolved, compose already generated (i.e. from runFromDirectory)
 		if verbose {
 			fmt.Println("[registry-resolve] Using pre-resolved overrides from runFromDirectory")

--- a/internal/cli/agent/tui/chat.go
+++ b/internal/cli/agent/tui/chat.go
@@ -300,7 +300,7 @@ func (m *chatModel) handleMessageParts(msg protocol.Message, shouldDisplay bool)
 	var toolResults []toolResult
 
 	for _, part := range msg.Parts {
-		if tp, ok := part.(*protocol.TextPart); ok {
+		if tp, ok := part.(*protocol.TextPart); ok { //nolint:nestif
 			textParts = append(textParts, tp.Text)
 		} else if dp, ok := part.(*protocol.DataPart); ok {
 			if m.verbose {

--- a/internal/cli/agent/tui/mcp_wizard.go
+++ b/internal/cli/agent/tui/mcp_wizard.go
@@ -985,7 +985,7 @@ func (w *McpServerWizard) buildFinalResult(name string) {
 		return
 	}
 
-	if w.chosenType == serverTypes.Command.ID {
+	if w.chosenType == serverTypes.Command.ID { //nolint:nestif
 		w.result.Type = serverTypes.Command.ID
 		w.result.Name = name
 
@@ -1071,7 +1071,7 @@ func (w *McpServerWizard) tabRegistryServerPreferRemote(_ bool) tea.Cmd { return
 
 // tabRegistryEnv toggles focus between env key and value inputs.
 func (w *McpServerWizard) tabRegistryEnv(reverse bool) tea.Cmd {
-	if reverse {
+	if reverse { //nolint:nestif
 		if w.registryEnvValueInput.Focused() {
 			w.registryEnvKeyInput.Focus()
 			w.registryEnvValueInput.Blur()
@@ -1093,7 +1093,7 @@ func (w *McpServerWizard) tabRegistryEnv(reverse bool) tea.Cmd {
 
 // tabRemoteHeaders toggles focus between header key and value inputs.
 func (w *McpServerWizard) tabRemoteHeaders(reverse bool) tea.Cmd {
-	if reverse {
+	if reverse { //nolint:nestif
 		if w.headerValueInput.Focused() {
 			w.headerKeyInput.Focus()
 			w.headerValueInput.Blur()
@@ -1137,7 +1137,7 @@ func (w *McpServerWizard) tabCommandDetails(reverse bool) tea.Cmd {
 
 // tabArgsEnv toggles focus between args and env.
 func (w *McpServerWizard) tabArgsEnv(reverse bool) tea.Cmd {
-	if reverse {
+	if reverse { //nolint:nestif
 		if w.envInput.Focused() {
 			w.argsInput.Focus()
 			w.envInput.Blur()
@@ -1255,7 +1255,7 @@ func (w *McpServerWizard) renderCommandDetails() string {
 func (w *McpServerWizard) renderHeader() string {
 	idx := 1
 	var total int
-	if w.chosenType == serverTypes.Remote.ID || w.step == stepRemoteURL || w.step == stepRemoteHeaders {
+	if w.chosenType == serverTypes.Remote.ID || w.step == stepRemoteURL || w.step == stepRemoteHeaders { //nolint:nestif
 		// remote flow
 		if v, ok := wizardFlows.Remote.StepPositions[w.step]; ok {
 			idx = v

--- a/internal/cli/agent/utils/registry_resolver.go
+++ b/internal/cli/agent/utils/registry_resolver.go
@@ -123,7 +123,7 @@ func resolveRegistryServer(mcpServer models.McpServerType, verbose bool) (*model
 	manifestEnvVars := parseManifestEnvVars(mcpServer.Env)
 	maps.Copy(envOverrides, manifestEnvVars)
 
-	if verbose {
+	if verbose { //nolint:nestif
 		if len(envOverrides) > 0 {
 			fmt.Printf("[registry-resolver]   Collected %d environment variable overrides (from environment and manifest):\n", len(envOverrides))
 			for k, v := range envOverrides {

--- a/internal/cli/agent/utils/registry_translator.go
+++ b/internal/cli/agent/utils/registry_translator.go
@@ -21,7 +21,7 @@ func TranslateRegistryServer(
 	}
 
 	useRemote := len(serverSpec.Remotes) > 0 && (preferRemote || len(serverSpec.Packages) == 0)
-	if useRemote {
+	if useRemote { //nolint:nestif
 		remote := serverSpec.Remotes[0]
 		if remote.URL == "" {
 			return nil, fmt.Errorf("server %q remote has no URL", serverSpec.Name)

--- a/internal/cli/embeddings.go
+++ b/internal/cli/embeddings.go
@@ -119,7 +119,7 @@ func streamIndex(ctx context.Context, c *client.Client, req v0.IndexRequest) err
 		if line == "" {
 			continue
 		}
-		if len(line) > 5 && line[:5] == "data:" {
+		if len(line) > 5 && line[:5] == "data:" { //nolint:nestif
 			data := line[5:]
 			if len(data) > 0 && data[0] == ' ' {
 				data = data[1:]

--- a/internal/cli/mcp/add_tool.go
+++ b/internal/cli/mcp/add_tool.go
@@ -55,7 +55,7 @@ func runAddTool(_ *cobra.Command, args []string) error {
 
 	// Determine project directory
 	projectDirectory := addToolDir
-	if projectDirectory == "" {
+	if projectDirectory == "" { //nolint:nestif
 		var err error
 		projectDirectory, err = os.Getwd()
 		if err != nil {
@@ -131,7 +131,7 @@ func isValidIdentifier(name string) bool {
 	// Remaining characters must be letters, digits, or underscores
 	for i := 1; i < len(name); i++ {
 		c := name[i]
-		if c < 'a' || c > 'z' {
+		if c < 'a' || c > 'z' { //nolint:nestif
 			if c < 'A' || c > 'Z' {
 				if c < '0' || c > '9' {
 					if c != '_' {

--- a/internal/cli/mcp/helpers.go
+++ b/internal/cli/mcp/helpers.go
@@ -57,7 +57,7 @@ func selectServerVersion(resourceName, requestedVersion string, autoYes bool) (*
 	}
 
 	// If there are multiple versions, prompt the user (unless --yes is set)
-	if len(allVersions) > 1 {
+	if len(allVersions) > 1 { //nolint:nestif
 		fmt.Printf("✓ Found %d version(s) of MCP server '%s':\n", len(allVersions), resourceName)
 		for i, v := range allVersions {
 			marker := ""

--- a/internal/cli/mcp/publish.go
+++ b/internal/cli/mcp/publish.go
@@ -125,7 +125,7 @@ func runMCPServerPublish(cmd *cobra.Command, args []string) error {
 	absPath, _ := filepath.Abs(input)
 	manifestManager := manifest.NewManager(absPath)
 
-	if manifestManager.Exists() {
+	if manifestManager.Exists() { //nolint:nestif
 		// Load metadata from mcp.yaml
 		projectManifest, err := manifestManager.Load()
 		if err != nil {

--- a/internal/cli/mcp/publish_test.go
+++ b/internal/cli/mcp/publish_test.go
@@ -52,16 +52,16 @@ func TestResolveTransport(t *testing.T) {
 				if err == nil {
 					t.Errorf("expected error but got none")
 				}
-			} else {
-				if err != nil {
-					t.Errorf("unexpected error: %v", err)
-				}
-				if transport != tt.expectedTransportType {
-					t.Errorf("expected %s but got %s", tt.expectedTransportType, transport)
-				}
-				if url != tt.expectedTransportURL {
-					t.Errorf("expected %s but got %s", tt.expectedTransportURL, url)
-				}
+				return
+			}
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if transport != tt.expectedTransportType {
+				t.Errorf("expected %s but got %s", tt.expectedTransportType, transport)
+			}
+			if url != tt.expectedTransportURL {
+				t.Errorf("expected %s but got %s", tt.expectedTransportURL, url)
 			}
 		})
 	}
@@ -149,16 +149,16 @@ func TestBuildRepository(t *testing.T) {
 				if result != nil {
 					t.Errorf("expected nil but got %v", result)
 				}
-			} else {
-				if result == nil { //nolint:staticcheck
-					t.Error("expected non-nil result")
-				}
-				if result.URL != tt.githubURL { //nolint:staticcheck
-					t.Errorf("expected URL %s but got %s", tt.githubURL, result.URL)
-				}
-				if result.Source != "github" {
-					t.Errorf("expected source 'github' but got %s", result.Source)
-				}
+				return
+			}
+			if result == nil { //nolint:staticcheck
+				t.Error("expected non-nil result")
+			}
+			if result.URL != tt.githubURL { //nolint:staticcheck
+				t.Errorf("expected URL %s but got %s", tt.githubURL, result.URL)
+			}
+			if result.Source != "github" {
+				t.Errorf("expected source 'github' but got %s", result.Source)
 			}
 		})
 	}

--- a/internal/cli/mcp/show.go
+++ b/internal/cli/mcp/show.go
@@ -66,7 +66,7 @@ func runShow(cmd *cobra.Command, args []string) error {
 	}
 
 	// Handle JSON output format
-	if showOutputFormat == "json" {
+	if showOutputFormat == "json" { //nolint:nestif
 		if len(servers) == 1 {
 			// Single server - output as object
 			fmt.Println(servers[0])
@@ -89,7 +89,7 @@ func runShow(cmd *cobra.Command, args []string) error {
 	// Group servers by base name (same server, different versions)
 	serverGroups := groupServersByBaseName(servers)
 
-	if len(serverGroups) == 1 && len(serverGroups[0].Servers) == 1 {
+	if len(serverGroups) == 1 && len(serverGroups[0].Servers) == 1 { //nolint:nestif
 		// Single server, single version - show detailed view
 		showServerDetails(serverGroups[0].Servers[0], nil)
 	} else if len(serverGroups) == 1 {

--- a/internal/cli/skill/pull.go
+++ b/internal/cli/skill/pull.go
@@ -161,7 +161,7 @@ func copyNonEmptyContents(src, dst string) error {
 			continue
 		}
 
-		if entry.IsDir() {
+		if entry.IsDir() { //nolint:nestif
 			// Check if directory has any non-empty content
 			if !hasNonEmptyContent(srcPath, skipDirs) {
 				continue
@@ -207,7 +207,7 @@ func hasNonEmptyContent(dir string, skipDirs map[string]bool) bool {
 	for _, entry := range entries {
 		path := filepath.Join(dir, entry.Name())
 
-		if entry.IsDir() {
+		if entry.IsDir() { //nolint:nestif
 			if skipDirs[entry.Name()] {
 				continue
 			}

--- a/internal/registry/api/handlers/v0/auth/http_test.go
+++ b/internal/registry/api/handlers/v0/auth/http_test.go
@@ -377,7 +377,7 @@ func TestDefaultHTTPKeyFetcher(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if tt.handler != nil {
+			if tt.handler != nil { //nolint:nestif
 				srv := httptest.NewTLSServer(tt.handler)
 				defer srv.Close()
 				c := newClientForTLSServer(t, srv)

--- a/internal/registry/api/handlers/v0/servers.go
+++ b/internal/registry/api/handlers/v0/servers.go
@@ -31,7 +31,7 @@ func normalizeServerResponse(src *apiv0.ServerResponse) models.ServerResponse {
 	server := src.Server
 	var semanticScore *float64
 
-	if server.Meta != nil && server.Meta.PublisherProvided != nil {
+	if server.Meta != nil && server.Meta.PublisherProvided != nil { //nolint:nestif
 		if raw, ok := server.Meta.PublisherProvided[semanticMetadataKey]; ok {
 			if m, okm := raw.(map[string]any); okm {
 				if v, okv := m["score"].(float64); okv {
@@ -100,7 +100,7 @@ type ServerReadmeResponse struct {
 // RegisterServersEndpoints registers all server-related endpoints with a custom path prefix.
 func RegisterServersEndpoints(api huma.API, pathPrefix string, registry service.RegistryService) {
 	isAdmin := strings.Contains(pathPrefix, "admin")
-	if isAdmin {
+	if isAdmin { //nolint:nestif
 		huma.Register(api, huma.Operation{
 			OperationID: "delete-server-version" + strings.ReplaceAll(pathPrefix, "/", "-"),
 			Method:      http.MethodDelete,
@@ -269,7 +269,7 @@ func RegisterServersEndpoints(api huma.API, pathPrefix string, registry service.
 		var serverResponse *apiv0.ServerResponse
 
 		// Handle "latest" as a special version string
-		if version == "latest" {
+		if version == "latest" { //nolint:nestif
 			// Get all versions and find the latest one
 			servers, err := registry.GetAllVersionsByServerName(ctx, serverName)
 			if err != nil {

--- a/internal/registry/database/postgres.go
+++ b/internal/registry/database/postgres.go
@@ -117,7 +117,7 @@ func (db *PostgreSQL) ListServers(
 	args := []any{}
 	argIndex := 1
 
-	if filter != nil {
+	if filter != nil { //nolint:nestif
 		if filter.Name != nil {
 			whereConditions = append(whereConditions, fmt.Sprintf("server_name = $%d", argIndex))
 			args = append(args, *filter.Name)
@@ -1151,7 +1151,7 @@ func (db *PostgreSQL) ListAgents(ctx context.Context, tx pgx.Tx, filter *databas
 	args := []any{}
 	argIndex := 1
 
-	if filter != nil {
+	if filter != nil { //nolint:nestif
 		if filter.Name != nil {
 			whereConditions = append(whereConditions, fmt.Sprintf("agent_name = $%d", argIndex))
 			args = append(args, *filter.Name)
@@ -1860,7 +1860,7 @@ func (db *PostgreSQL) ListSkills(ctx context.Context, tx pgx.Tx, filter *databas
 	args := []any{}
 	argIndex := 1
 
-	if filter != nil {
+	if filter != nil { //nolint:nestif
 		if filter.Name != nil {
 			whereConditions = append(whereConditions, fmt.Sprintf("skill_name = $%d", argIndex))
 			args = append(args, *filter.Name)

--- a/internal/registry/database/testutil.go
+++ b/internal/registry/database/testutil.go
@@ -81,7 +81,7 @@ func ensureTemplateDB(ctx context.Context, adminConn *pgx.Conn) error {
 		return fmt.Errorf("failed to check template database: %w", err)
 	}
 
-	if !exists {
+	if !exists { //nolint:nestif
 		_, err = adminConn.Exec(ctx, fmt.Sprintf("CREATE DATABASE %s", templateDBName))
 		if err != nil {
 			// Ignore duplicate database name error - another process created it concurrently

--- a/internal/registry/importer/importer.go
+++ b/internal/registry/importer/importer.go
@@ -213,7 +213,7 @@ func (s *Service) importServer(
 	}
 
 	_, err := s.registry.CreateServer(ctx, srv)
-	if err != nil {
+	if err != nil { //nolint:nestif
 		// If duplicate version and update is enabled, try update path
 		if s.updateIfExists && errors.Is(err, database.ErrInvalidVersion) {
 			if _, uerr := s.registry.UpdateServer(ctx, srv.Name, srv.Version, srv, nil); uerr != nil {

--- a/internal/registry/registry_app.go
+++ b/internal/registry/registry_app.go
@@ -73,7 +73,7 @@ func App(_ context.Context, opts ...types.AppOptions) error {
 	// do not want a real PostgreSQL connection. In that case DatabaseFactory is required.
 	// For normal deployments, set DATABASE_URL to a real Postgres connection string.
 	var db database.Database
-	if cfg.DatabaseURL == "noop" {
+	if cfg.DatabaseURL == "noop" { //nolint:nestif
 		if options.DatabaseFactory == nil {
 			return fmt.Errorf("DATABASE_URL=noop requires DatabaseFactory to be set in AppOptions")
 		}

--- a/internal/registry/service/registry_service.go
+++ b/internal/registry/service/registry_service.go
@@ -193,7 +193,7 @@ func (s *registryServiceImpl) createServerInTransaction(ctx context.Context, tx 
 	}
 
 	// Generate embedding asynchronously (non-blocking, best-effort)
-	if s.shouldGenerateEmbeddingsOnPublish() {
+	if s.shouldGenerateEmbeddingsOnPublish() { //nolint:nestif
 		go func() {
 			bgCtx := context.Background()
 			payload := embeddings.BuildServerEmbeddingPayload(&serverJSON)
@@ -592,7 +592,7 @@ func (s *registryServiceImpl) createAgentInTransaction(ctx context.Context, tx p
 	}
 
 	// Generate embedding asynchronously (non-blocking, best-effort)
-	if s.shouldGenerateEmbeddingsOnPublish() {
+	if s.shouldGenerateEmbeddingsOnPublish() { //nolint:nestif
 		go func() {
 			bgCtx := context.Background()
 			payload := embeddings.BuildAgentEmbeddingPayload(&agentJSON)
@@ -664,7 +664,7 @@ func (s *registryServiceImpl) GetDeployments(ctx context.Context, filter *models
 
 	// If runtime filter includes kubernetes (or no filter i.e. default), fetch from K8s
 	includeK8s := filter == nil || filter.Runtime == nil || *filter.Runtime == "kubernetes"
-	if includeK8s {
+	if includeK8s { //nolint:nestif
 		// Use empty namespace to list all (or default)
 		k8sResources, err := s.listKubernetesDeployments(ctx, "")
 		if err != nil {
@@ -835,7 +835,7 @@ func (s *registryServiceImpl) RemoveDeployment(ctx context.Context, serverName s
 	}
 
 	// Clean up kubernetes resources
-	if deployment != nil && deployment.Runtime == "kubernetes" {
+	if deployment != nil && deployment.Runtime == "kubernetes" { //nolint:nestif
 		namespace := ""
 		if deployment.Config != nil {
 			namespace = deployment.Config["KAGENT_NAMESPACE"]

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -38,7 +38,7 @@ var _ types.DaemonManager = (*DefaultDaemonManager)(nil)
 
 func NewDaemonManager(config *types.DaemonConfig) *DefaultDaemonManager {
 	cfg := DefaultConfig()
-	if config != nil {
+	if config != nil { //nolint:nestif
 		if config.ProjectName != "" {
 			cfg.ProjectName = config.ProjectName
 		}


### PR DESCRIPTION
Enable the nestif linter to detect deeply nested if statements. Deeply nested conditionals harm readability by obscuring the main code path and making it harder to maintain line-of-sight through functions.

We grandfather existing violations with nolint directives rather than refactoring, since the nested code is often in CLI commands where complexity is inherent. Also flatten a couple test assertions using early returns.