### PR TITLE
cmd: Fix agent run example indentation

### DIFF
--- a/internal/cli/agent/run.go
+++ b/internal/cli/agent/run.go
@@ -34,7 +34,7 @@ launches the same chat interface.`,
 	Args: cobra.ExactArgs(1),
 	RunE: runRun,
 	Example: `arctl agent run ./my-agent
-  arctl agent run dice`,
+arctl agent run dice`,
 }
 
 var buildFlag bool


### PR DESCRIPTION
Previously, the second example in 'arctl agent run --help' had extra leading spaces:

```bash
$ ./bin/arctl agent run --help
...
Examples:
arctl agent run ./my-agent
  arctl agent run dice
```