### PR TITLE
ci: Add PR labeler workflow and PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,49 @@
+<!--
+Thanks for opening a PR! Please delete any sections that don't apply.
+-->
+
+# Description
+
+<!--
+A concise explanation of the change. You may include:
+- **Motivation:** why this change is needed
+- **What changed:** key implementation details
+- **Related issues:** e.g., `Fixes #123`
+-->
+
+# Change Type
+
+<!--
+Select one or more of the following by including the corresponding slash-command:
+```
+/kind breaking_change
+/kind bump
+/kind cleanup
+/kind design
+/kind deprecation
+/kind documentation
+/kind feature
+/kind fix
+/kind flake
+/kind install
+```
+-->
+
+# Changelog
+
+<!--
+Provide the exact line to appear in release notes for the chosen changelog type.
+
+If no, just write "NONE" in the release-note block below.
+If yes, a release note is required:
+-->
+
+```release-note
+
+```
+
+# Additional Notes
+
+<!--
+Any extra context or edge cases for reviewers.
+-->

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -1,0 +1,33 @@
+# This workflow parses the PR description to extract the change type and changelog for release notes.
+name: Labeler
+on:
+  pull_request_target:
+    types: [opened, edited, reopened, synchronize]
+  merge_group:
+    types: [checks_requested]
+
+permissions:
+  issues: write
+  pull-requests: write
+  contents: read
+
+jobs:
+  labeler:
+    runs-on: ubuntu-latest
+
+    steps:
+      # only run this step on PRs, not in the merge queue (we need to explicitly add the merge queue logic because making this check required
+      # causes it to get run in the merge queue as well)
+      - name: Conditional skip for merge queue
+        if: github.event_name == 'merge_group'
+        run: |
+          echo "Skipping check in merge queue"
+          exit 0
+
+      - if: github.event_name != 'merge_group'
+        uses: actions/checkout@v4
+      - name: Sync /kind labels & enforce changelog fields
+        if: github.event_name != 'merge_group'
+        uses: kgateway-dev/pr-kind-labeler@main
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This adds the pr-kind-labeler action from kgateway-dev to enforce structured PR descriptions. The workflow parses /kind commands and release-note blocks from PR bodies, syncing labels accordingly.

Used in the kgateway project & potentially in the agw project as well.

We also add a PR template that guides contributors to fill out Description, Change Type, and Changelog sections.