### PR TITLE
golangci: Enable testifylint

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -23,6 +23,7 @@ linters:
     - nakedret
     - nestif
     - nolintlint
+    - testifylint
     - staticcheck
     - unused
     - whitespace

--- a/internal/registry/api/cors_test.go
+++ b/internal/registry/api/cors_test.go
@@ -36,7 +36,7 @@ func TestCORSHeaders(t *testing.T) {
 	registryService := service.NewRegistryService(db, cfg, nil)
 
 	shutdownTelemetry, metrics, err := telemetry.InitMetrics("test")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer func() { _ = shutdownTelemetry(nil) }()
 
 	versionInfo := &v0.VersionBody{
@@ -150,7 +150,7 @@ func TestCORSHeaderValues(t *testing.T) {
 	registryService := service.NewRegistryService(db, cfg, nil)
 
 	shutdownTelemetry, metrics, err := telemetry.InitMetrics("test")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer func() { _ = shutdownTelemetry(nil) }()
 
 	versionInfo := &v0.VersionBody{

--- a/internal/registry/api/handlers/v0/auth/dns_test.go
+++ b/internal/registry/api/handlers/v0/auth/dns_test.go
@@ -187,13 +187,13 @@ func TestDNSAuthHandler_ExchangeToken(t *testing.T) {
 			result, err := handler.ExchangeToken(context.Background(), tt.domain, tt.timestamp, signedTimestamp)
 
 			if tt.expectError {
-				assert.Error(t, err)
+				require.Error(t, err)
 				if tt.errorContains != "" {
 					assert.Contains(t, err.Error(), tt.errorContains)
 				}
 				assert.Nil(t, result)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.NotNil(t, result)
 				assert.NotEmpty(t, result.RegistryToken)
 
@@ -621,13 +621,13 @@ func TestDNSAuthHandler_ExchangeToken_ECDSAP384(t *testing.T) {
 			result, err := handler.ExchangeToken(context.Background(), tt.domain, tt.timestamp, signedTimestamp)
 
 			if tt.expectError {
-				assert.Error(t, err)
+				require.Error(t, err)
 				if tt.errorContains != "" {
 					assert.Contains(t, err.Error(), tt.errorContains)
 				}
 				assert.Nil(t, result)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.NotNil(t, result)
 				assert.NotEmpty(t, result.RegistryToken)
 
@@ -892,7 +892,7 @@ func TestDNSAuthHandler_Ed25519_vs_ECDSAP384_Equivalence(t *testing.T) {
 			// Compare claims (excluding token-specific fields like timestamps)
 			assert.Equal(t, ed25519Claims.AuthMethod, ecdsaClaims.AuthMethod)
 			assert.Equal(t, ed25519Claims.AuthMethodSubject, ecdsaClaims.AuthMethodSubject)
-			assert.Equal(t, len(ed25519Claims.Permissions), len(ecdsaClaims.Permissions))
+			assert.Len(t, ecdsaClaims.Permissions, len(ed25519Claims.Permissions))
 
 			// Compare permission patterns
 			ed25519Patterns := make([]string, len(ed25519Claims.Permissions))

--- a/internal/registry/api/handlers/v0/auth/github_at_test.go
+++ b/internal/registry/api/handlers/v0/auth/github_at_test.go
@@ -71,7 +71,7 @@ func TestGitHubHandler_ExchangeToken(t *testing.T) {
 		require.NoError(t, err)
 		assert.NotNil(t, response)
 		assert.NotEmpty(t, response.RegistryToken)
-		assert.Greater(t, response.ExpiresAt, 0)
+		assert.Positive(t, response.ExpiresAt)
 
 		// Validate the JWT token
 		jwtManager := auth.NewJWTManager(cfg)

--- a/internal/registry/api/handlers/v0/auth/github_oidc_test.go
+++ b/internal/registry/api/handlers/v0/auth/github_oidc_test.go
@@ -92,13 +92,13 @@ func TestGitHubOIDCHandler_ExchangeToken(t *testing.T) {
 			response, err := handler.ExchangeToken(context.Background(), "test-oidc-token")
 
 			if tt.expectError {
-				assert.Error(t, err)
+				require.Error(t, err)
 				assert.Nil(t, response)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.NotNil(t, response)
 				assert.NotEmpty(t, response.RegistryToken)
-				assert.Greater(t, response.ExpiresAt, 0)
+				assert.Positive(t, response.ExpiresAt)
 
 				// Validate the generated JWT token
 				jwtManager := internalauth.NewJWTManager(cfg)
@@ -193,16 +193,16 @@ func TestBuildPermissionsFromOIDC(t *testing.T) {
 
 			if tt.expectedPerms == nil {
 				// For invalid names, we expect empty permissions but successful token generation
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.NotNil(t, response)
 
 				// Validate the JWT to check permissions
 				jwtManager := internalauth.NewJWTManager(cfg)
 				claims, err := jwtManager.ValidateToken(context.Background(), response.RegistryToken)
 				require.NoError(t, err)
-				assert.Len(t, claims.Permissions, 0)
+				assert.Empty(t, claims.Permissions)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.NotNil(t, response)
 
 				// Validate the JWT to check permissions

--- a/internal/registry/api/handlers/v0/auth/http_test.go
+++ b/internal/registry/api/handlers/v0/auth/http_test.go
@@ -250,13 +250,13 @@ func TestHTTPAuthHandler_ExchangeToken(t *testing.T) {
 			result, err := handler.ExchangeToken(context.Background(), tt.domain, tt.timestamp, signedTimestamp)
 
 			if tt.expectError {
-				assert.Error(t, err)
+				require.Error(t, err)
 				if tt.errorContains != "" {
 					assert.Contains(t, err.Error(), tt.errorContains)
 				}
 				assert.Nil(t, result)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.NotNil(t, result)
 				assert.NotEmpty(t, result.RegistryToken)
 
@@ -295,7 +295,7 @@ func TestDefaultHTTPKeyFetcher_FetchKey(t *testing.T) {
 	// Test that it returns an error for non-existent domains
 	// (This will fail with network error, which is expected)
 	_, err := fetcher.FetchKey(context.Background(), "nonexistent-test-domain-12345.com")
-	assert.Error(t, err)
+	require.Error(t, err)
 }
 
 func TestDefaultHTTPKeyFetcher(t *testing.T) {
@@ -913,13 +913,13 @@ func TestHTTPAuthHandler_ExchangeToken_ECDSAP384(t *testing.T) {
 			result, err := handler.ExchangeToken(context.Background(), tt.domain, tt.timestamp, signedTimestamp)
 
 			if tt.expectError {
-				assert.Error(t, err)
+				require.Error(t, err)
 				if tt.errorContains != "" {
 					assert.Contains(t, err.Error(), tt.errorContains)
 				}
 				assert.Nil(t, result)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.NotNil(t, result)
 				assert.NotEmpty(t, result.RegistryToken)
 
@@ -1205,7 +1205,7 @@ func TestHTTPAuthHandler_Ed25519_vs_ECDSAP384_Equivalence(t *testing.T) {
 			// Compare claims (excluding token-specific fields like timestamps)
 			assert.Equal(t, ed25519Claims.AuthMethod, ecdsaClaims.AuthMethod)
 			assert.Equal(t, ed25519Claims.AuthMethodSubject, ecdsaClaims.AuthMethodSubject)
-			assert.Equal(t, len(ed25519Claims.Permissions), len(ecdsaClaims.Permissions))
+			assert.Len(t, ecdsaClaims.Permissions, len(ed25519Claims.Permissions))
 
 			// Compare permission patterns (should be identical for HTTP auth)
 			ed25519Patterns := make([]string, len(ed25519Claims.Permissions))

--- a/internal/registry/api/handlers/v0/auth/none_test.go
+++ b/internal/registry/api/handlers/v0/auth/none_test.go
@@ -32,7 +32,7 @@ func TestNoneHandler_GetAnonymousToken(t *testing.T) {
 	tokenResponse, err := handler.GetAnonymousToken(ctx)
 	require.NoError(t, err)
 	assert.NotEmpty(t, tokenResponse.RegistryToken)
-	assert.Greater(t, tokenResponse.ExpiresAt, 0)
+	assert.Positive(t, tokenResponse.ExpiresAt)
 
 	// Validate the token claims
 	jwtManager := auth.NewJWTManager(cfg)

--- a/internal/registry/api/handlers/v0/auth/oidc_test.go
+++ b/internal/registry/api/handlers/v0/auth/oidc_test.go
@@ -94,13 +94,13 @@ func TestOIDCHandler_ExchangeToken(t *testing.T) {
 			response, err := handler.ExchangeToken(ctx, tt.token)
 
 			if tt.expectedError {
-				assert.Error(t, err)
+				require.Error(t, err)
 				assert.Nil(t, response)
 			} else {
 				require.NoError(t, err)
 				require.NotNil(t, response)
 				assert.NotEmpty(t, response.RegistryToken)
-				assert.Greater(t, response.ExpiresAt, 0)
+				assert.Positive(t, response.ExpiresAt)
 			}
 		})
 	}

--- a/internal/registry/api/handlers/v0/servers_test.go
+++ b/internal/registry/api/handlers/v0/servers_test.go
@@ -117,7 +117,7 @@ func TestListServersEndpoint(t *testing.T) {
 			if tt.expectedStatus == http.StatusOK {
 				var resp models.ServerListResponse
 				err := json.NewDecoder(w.Body).Decode(&resp)
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.Len(t, resp.Servers, tt.expectedCount)
 				assert.Equal(t, tt.expectedCount, resp.Metadata.Count)
 
@@ -289,7 +289,7 @@ func TestGetLatestServerVersionEndpoint(t *testing.T) {
 			if tt.expectedStatus == http.StatusOK {
 				var resp models.ServerListResponse
 				err := json.NewDecoder(w.Body).Decode(&resp)
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				require.Len(t, resp.Servers, 1, "Should return exactly one server")
 				server := resp.Servers[0]
 				assert.Equal(t, tt.serverName, server.Server.Name)
@@ -419,7 +419,7 @@ func TestGetServerVersionEndpoint(t *testing.T) {
 			if tt.expectedStatus == http.StatusOK {
 				var resp models.ServerListResponse
 				err := json.NewDecoder(w.Body).Decode(&resp)
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				require.Len(t, resp.Servers, 1, "Should return exactly one server")
 				server := resp.Servers[0]
 				assert.Equal(t, tt.serverName, server.Server.Name)
@@ -640,7 +640,7 @@ func TestGetAllVersionsEndpoint(t *testing.T) {
 			if tt.expectedStatus == http.StatusOK {
 				var resp models.ServerListResponse
 				err := json.NewDecoder(w.Body).Decode(&resp)
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.Len(t, resp.Servers, tt.expectedCount)
 				assert.Equal(t, tt.expectedCount, resp.Metadata.Count)
 
@@ -735,7 +735,7 @@ func TestServersEndpointEdgeCases(t *testing.T) {
 
 				var resp models.ServerListResponse
 				err := json.NewDecoder(w.Body).Decode(&resp)
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				require.Len(t, resp.Servers, 1, "Should return exactly one server")
 				assert.Equal(t, tt.serverName, resp.Servers[0].Server.Name)
 			})
@@ -771,7 +771,7 @@ func TestServersEndpointEdgeCases(t *testing.T) {
 				if tt.expectedStatus == http.StatusOK {
 					var resp models.ServerListResponse
 					err := json.NewDecoder(w.Body).Decode(&resp)
-					assert.NoError(t, err)
+					require.NoError(t, err)
 					assert.NotNil(t, resp.Metadata)
 				} else if tt.expectedError != "" {
 					assert.Contains(t, w.Body.String(), tt.expectedError)
@@ -791,7 +791,7 @@ func TestServersEndpointEdgeCases(t *testing.T) {
 
 		var resp models.ServerListResponse
 		err := json.NewDecoder(w.Body).Decode(&resp)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		// Verify metadata structure
 		assert.NotNil(t, resp.Metadata)

--- a/internal/registry/api/handlers/v0/telemetry_test.go
+++ b/internal/registry/api/handlers/v0/telemetry_test.go
@@ -46,7 +46,7 @@ func TestPrometheusHandler(t *testing.T) {
 		},
 		Version: "2.0.0",
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	cfg := testConfig
 	shutdownTelemetry, metrics, _ := telemetry.InitMetrics("dev")

--- a/internal/registry/database/postgres_test.go
+++ b/internal/registry/database/postgres_test.go
@@ -73,13 +73,13 @@ func TestPostgreSQL_CreateServer(t *testing.T) {
 			result, err := db.CreateServer(ctx, nil, tt.serverJSON, tt.officialMeta)
 
 			if tt.expectError {
-				assert.Error(t, err)
+				require.Error(t, err)
 				if tt.errorType != nil {
-					assert.ErrorIs(t, err, tt.errorType)
+					require.ErrorIs(t, err, tt.errorType)
 				}
 				assert.Nil(t, result)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.NotNil(t, result)
 				assert.Equal(t, tt.serverJSON.Name, result.Server.Name)
 				assert.Equal(t, tt.serverJSON.Version, result.Server.Version)
@@ -136,13 +136,13 @@ func TestPostgreSQL_GetServerByName(t *testing.T) {
 			result, err := db.GetServerByName(ctx, nil, tt.serverName)
 
 			if tt.expectError {
-				assert.Error(t, err)
+				require.Error(t, err)
 				if tt.errorType != nil {
-					assert.ErrorIs(t, err, tt.errorType)
+					require.ErrorIs(t, err, tt.errorType)
 				}
 				assert.Nil(t, result)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.NotNil(t, result)
 				assert.Equal(t, tt.serverName, result.Server.Name)
 				assert.NotNil(t, result.Meta.Official)
@@ -209,13 +209,13 @@ func TestPostgreSQL_GetServerByNameAndVersion(t *testing.T) {
 			result, err := db.GetServerByNameAndVersion(ctx, nil, tt.serverName, tt.version)
 
 			if tt.expectError {
-				assert.Error(t, err)
+				require.Error(t, err)
 				if tt.errorType != nil {
-					assert.ErrorIs(t, err, tt.errorType)
+					require.ErrorIs(t, err, tt.errorType)
 				}
 				assert.Nil(t, result)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.NotNil(t, result)
 				assert.Equal(t, tt.serverName, result.Server.Name)
 				assert.Equal(t, tt.version, result.Server.Version)
@@ -373,11 +373,11 @@ func TestPostgreSQL_ListServers(t *testing.T) {
 			results, nextCursor, err := db.ListServers(ctx, nil, tt.filter, tt.cursor, tt.limit)
 
 			if tt.expectError {
-				assert.Error(t, err)
+				require.Error(t, err)
 				return
 			}
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Len(t, results, tt.expectedCount)
 
 			if len(tt.expectedNames) > 0 {
@@ -459,13 +459,13 @@ func TestPostgreSQL_UpdateServer(t *testing.T) {
 			result, err := db.UpdateServer(ctxWithAuth, nil, tt.serverName, tt.version, tt.updatedServer)
 
 			if tt.expectError {
-				assert.Error(t, err)
+				require.Error(t, err)
 				if tt.errorType != nil {
-					assert.ErrorIs(t, err, tt.errorType)
+					require.ErrorIs(t, err, tt.errorType)
 				}
 				assert.Nil(t, result)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.NotNil(t, result)
 				assert.Equal(t, tt.updatedServer.Description, result.Server.Description)
 				assert.NotNil(t, result.Meta.Official)
@@ -534,13 +534,13 @@ func TestPostgreSQL_SetServerStatus(t *testing.T) {
 			result, err := db.SetServerStatus(ctxWithAuth, nil, tt.serverName, tt.version, tt.newStatus)
 
 			if tt.expectError {
-				assert.Error(t, err)
+				require.Error(t, err)
 				if tt.errorType != nil {
-					assert.ErrorIs(t, err, tt.errorType)
+					require.ErrorIs(t, err, tt.errorType)
 				}
 				assert.Nil(t, result)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.NotNil(t, result)
 				assert.Equal(t, model.Status(tt.newStatus), result.Meta.Official.Status)
 				assert.NotZero(t, result.Meta.Official.UpdatedAt)
@@ -571,11 +571,11 @@ func TestPostgreSQL_TransactionHandling(t *testing.T) {
 			return err
 		})
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		// Verify server was created
 		result, err := db.GetServerByName(ctx, nil, "com.example/transaction-success")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.NotNil(t, result)
 	})
 
@@ -602,13 +602,13 @@ func TestPostgreSQL_TransactionHandling(t *testing.T) {
 			return assert.AnError
 		})
 
-		assert.Error(t, err)
+		require.Error(t, err)
 		assert.Equal(t, assert.AnError, err)
 
 		// Verify server was NOT created due to rollback
 		result, err := db.GetServerByName(ctx, nil, "com.example/transaction-rollback")
-		assert.Error(t, err)
-		assert.ErrorIs(t, err, database.ErrNotFound)
+		require.Error(t, err)
+		require.ErrorIs(t, err, database.ErrNotFound)
 		assert.Nil(t, result)
 	})
 }
@@ -640,28 +640,28 @@ func TestPostgreSQL_HelperMethods(t *testing.T) {
 
 	t.Run("CountServerVersions", func(t *testing.T) {
 		count, err := db.CountServerVersions(ctx, nil, serverName)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, 3, count)
 
 		// Test non-existent server
 		count, err = db.CountServerVersions(ctx, nil, "com.example/non-existent")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, 0, count)
 	})
 
 	t.Run("CheckVersionExists", func(t *testing.T) {
 		exists, err := db.CheckVersionExists(ctx, nil, serverName, "1.1.0")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.True(t, exists)
 
 		exists, err = db.CheckVersionExists(ctx, nil, serverName, "3.0.0")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.False(t, exists)
 	})
 
 	t.Run("GetCurrentLatestVersion", func(t *testing.T) {
 		latest, err := db.GetCurrentLatestVersion(ctx, nil, serverName)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.NotNil(t, latest)
 		assert.Equal(t, "2.0.0", latest.Server.Version)
 		assert.True(t, latest.Meta.Official.IsLatest)
@@ -669,7 +669,7 @@ func TestPostgreSQL_HelperMethods(t *testing.T) {
 
 	t.Run("GetAllVersionsByServerName", func(t *testing.T) {
 		allVersions, err := db.GetAllVersionsByServerName(ctx, nil, serverName)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Len(t, allVersions, 3)
 
 		// Check versions are present
@@ -684,12 +684,12 @@ func TestPostgreSQL_HelperMethods(t *testing.T) {
 
 	t.Run("UnmarkAsLatest", func(t *testing.T) {
 		err := db.UnmarkAsLatest(ctx, nil, serverName)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		// Verify no version is marked as latest
 		latest, err := db.GetCurrentLatestVersion(ctx, nil, serverName)
-		assert.Error(t, err)
-		assert.ErrorIs(t, err, database.ErrNotFound)
+		require.Error(t, err)
+		require.ErrorIs(t, err, database.ErrNotFound)
 		assert.Nil(t, latest)
 	})
 }
@@ -701,12 +701,12 @@ func TestPostgreSQL_EdgeCases(t *testing.T) {
 	t.Run("input validation", func(t *testing.T) {
 		// Test nil inputs
 		_, err := db.CreateServer(ctx, nil, nil, nil)
-		assert.Error(t, err)
+		require.Error(t, err)
 		assert.Contains(t, err.Error(), "serverJSON and officialMeta are required")
 
 		// Test empty required fields
 		_, err = db.CreateServer(ctx, nil, &apiv0.ServerJSON{}, &apiv0.RegistryExtensions{})
-		assert.Error(t, err)
+		require.Error(t, err)
 		assert.Contains(t, err.Error(), "server name and version are required")
 	})
 
@@ -725,7 +725,7 @@ func TestPostgreSQL_EdgeCases(t *testing.T) {
 		}
 
 		_, err := db.CreateServer(ctx, nil, invalidServer, officialMeta)
-		assert.Error(t, err, "Should fail due to server name format constraint")
+		require.Error(t, err, "Should fail due to server name format constraint")
 	})
 
 	t.Run("pagination edge cases", func(t *testing.T) {
@@ -733,13 +733,13 @@ func TestPostgreSQL_EdgeCases(t *testing.T) {
 		results, cursor, err := db.ListServers(ctx, nil, &database.ServerFilter{
 			Name: stringPtr("com.example/non-existent-server"),
 		}, "", 10)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Empty(t, results)
 		assert.Empty(t, cursor)
 
 		// Test pagination with limit 0 (should use default)
 		_, _, err = db.ListServers(ctx, nil, nil, "", 0)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		// Should still work with default limit
 	})
 
@@ -772,7 +772,7 @@ func TestPostgreSQL_EdgeCases(t *testing.T) {
 		}
 
 		results, _, err := db.ListServers(ctx, nil, filter, "", 10)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Len(t, results, 1)
 		assert.Equal(t, serverName, results[0].Server.Name)
 	})
@@ -804,7 +804,7 @@ func TestPostgreSQL_EdgeCases(t *testing.T) {
 		ctxWithAuth := internaldb.WithTestSession(ctx)
 		for _, status := range statuses {
 			result, err := db.SetServerStatus(ctxWithAuth, nil, serverName, version, status)
-			assert.NoError(t, err, "Should allow transition to %s", status)
+			require.NoError(t, err, "Should allow transition to %s", status)
 			assert.Equal(t, model.Status(status), result.Meta.Official.Status)
 		}
 	})
@@ -835,12 +835,12 @@ func TestPostgreSQL_PerformanceScenarios(t *testing.T) {
 
 		// Test counting versions
 		count, err := db.CountServerVersions(ctx, nil, serverName)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, versionCount, count)
 
 		// Test getting all versions
 		allVersions, err := db.GetAllVersionsByServerName(ctx, nil, serverName)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Len(t, allVersions, versionCount)
 
 		// Test only one is marked as latest
@@ -877,7 +877,7 @@ func TestPostgreSQL_PerformanceScenarios(t *testing.T) {
 
 		for {
 			results, nextCursor, err := db.ListServers(ctx, nil, nil, cursor, pageSize)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			allResults = append(allResults, results...)
 
 			if nextCursor == "" || len(results) < pageSize {

--- a/internal/registry/importer/importer_test.go
+++ b/internal/registry/importer/importer_test.go
@@ -233,12 +233,12 @@ func TestImportService_ErrorHandling(t *testing.T) {
 			err := importerService.ImportFromPath(context.Background(), tt.path, false)
 
 			if tt.expectError {
-				assert.Error(t, err)
+				require.Error(t, err)
 				if tt.errorMsg != "" {
 					assert.Contains(t, err.Error(), tt.errorMsg)
 				}
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 		})
 	}

--- a/internal/registry/service/indexer_test.go
+++ b/internal/registry/service/indexer_test.go
@@ -3,7 +3,6 @@ package service
 
 import (
 	"context"
-	"errors"
 	"sync"
 	"testing"
 
@@ -57,7 +56,7 @@ func TestIndexer_Run_ProviderNil(t *testing.T) {
 	result, err := indexer.Run(context.Background(), opts, nil)
 
 	assert.Nil(t, result)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not configured")
 }
 
@@ -74,7 +73,7 @@ func TestIndexer_Run_NoTargetsSelected(t *testing.T) {
 	result, err := indexer.Run(context.Background(), opts, nil)
 
 	assert.Nil(t, result)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no targets")
 }
 
@@ -314,8 +313,8 @@ func TestIndexer_Run_ContextCancelled(t *testing.T) {
 	result, err := indexer.Run(ctx, opts, nil)
 
 	assert.Nil(t, result)
-	assert.Error(t, err)
-	assert.True(t, errors.Is(err, context.Canceled))
+	require.Error(t, err)
+	require.ErrorIs(t, err, context.Canceled)
 }
 
 func TestIndexer_Run_ProgressCallback(t *testing.T) {

--- a/internal/registry/service/registry_service_test.go
+++ b/internal/registry/service/registry_service_test.go
@@ -119,10 +119,10 @@ func TestValidateNoDuplicateRemoteURLs(t *testing.T) {
 			err := impl.validateNoDuplicateRemoteURLs(ctx, nil, tt.serverDetail)
 
 			if tt.expectError {
-				assert.Error(t, err)
+				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.errorMsg)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 		})
 	}
@@ -181,13 +181,13 @@ func TestGetServerByName(t *testing.T) {
 			result, err := service.GetServerByName(ctx, tt.serverName)
 
 			if tt.expectError {
-				assert.Error(t, err)
+				require.Error(t, err)
 				if tt.errorMsg != "" {
 					assert.Contains(t, err.Error(), tt.errorMsg)
 				}
 				assert.Nil(t, result)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.NotNil(t, result)
 				if tt.checkResult != nil {
 					tt.checkResult(t, result)
@@ -274,13 +274,13 @@ func TestGetServerByNameAndVersion(t *testing.T) {
 			result, err := service.GetServerByNameAndVersion(ctx, tt.serverName, tt.version)
 
 			if tt.expectError {
-				assert.Error(t, err)
+				require.Error(t, err)
 				if tt.errorMsg != "" {
 					assert.Contains(t, err.Error(), tt.errorMsg)
 				}
 				assert.Nil(t, result)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.NotNil(t, result)
 				if tt.checkResult != nil {
 					tt.checkResult(t, result)
@@ -362,11 +362,11 @@ func TestGetServerReadmeMissing(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = svc.GetServerReadmeByVersion(ctx, serverName, "1.0.0")
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Equal(t, database.ErrNotFound, err)
 
 	_, err = svc.GetServerReadmeLatest(ctx, serverName)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Equal(t, database.ErrNotFound, err)
 }
 
@@ -450,13 +450,13 @@ func TestGetAllVersionsByServerName(t *testing.T) {
 			result, err := service.GetAllVersionsByServerName(ctx, tt.serverName)
 
 			if tt.expectError {
-				assert.Error(t, err)
+				require.Error(t, err)
 				if tt.errorMsg != "" {
 					assert.Contains(t, err.Error(), tt.errorMsg)
 				}
 				assert.Empty(t, result)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.NotEmpty(t, result)
 				if tt.checkResult != nil {
 					tt.checkResult(t, result)
@@ -495,7 +495,7 @@ func TestCreateServerConcurrentVersionsNoRace(t *testing.T) {
 
 	// All publishes should succeed
 	for i, err := range errors {
-		assert.NoError(t, err, "create server %d failed", i)
+		require.NoError(t, err, "create server %d failed", i)
 	}
 
 	// All results should have the same server name
@@ -613,13 +613,13 @@ func TestUpdateServer(t *testing.T) {
 			result, err := service.UpdateServer(ctxWithAuth, tt.serverName, tt.version, tt.updatedServer, tt.newStatus)
 
 			if tt.expectError {
-				assert.Error(t, err)
+				require.Error(t, err)
 				if tt.errorMsg != "" {
 					assert.Contains(t, err.Error(), tt.errorMsg)
 				}
 				assert.Nil(t, result)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.NotNil(t, result)
 				if tt.checkResult != nil {
 					tt.checkResult(t, result)
@@ -690,7 +690,7 @@ func TestUpdateServer_SkipValidationForDeletedServers(t *testing.T) {
 
 	// This should succeed despite invalid packages because server is deleted
 	result, err := service.UpdateServer(ctxWithAuth, serverName, version, updatedInvalidServer, nil)
-	assert.NoError(t, err, "updating deleted server should skip registry validation")
+	require.NoError(t, err, "updating deleted server should skip registry validation")
 	assert.NotNil(t, result)
 	assert.Equal(t, "Updated description for deleted server", result.Server.Description)
 	assert.Equal(t, model.StatusDeleted, result.Meta.Official.Status)
@@ -720,7 +720,7 @@ func TestUpdateServer_SkipValidationForDeletedServers(t *testing.T) {
 	// Update server and set to deleted in same operation - should skip validation
 	newDeletedStatus := string(model.StatusDeleted)
 	result2, err := service.UpdateServer(ctxWithAuth, "com.example/being-deleted-test", "1.0.0", activeServer, &newDeletedStatus)
-	assert.NoError(t, err, "updating server being set to deleted should skip registry validation")
+	require.NoError(t, err, "updating server being set to deleted should skip registry validation")
 	assert.NotNil(t, result2)
 	assert.Equal(t, model.StatusDeleted, result2.Meta.Official.Status)
 }
@@ -802,11 +802,11 @@ func TestListServers(t *testing.T) {
 			results, nextCursor, err := service.ListServers(ctx, tt.filter, tt.cursor, tt.limit)
 
 			if tt.expectError {
-				assert.Error(t, err)
+				require.Error(t, err)
 				return
 			}
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Len(t, results, tt.expectedCount)
 
 			// Test cursor behavior

--- a/internal/registry/telemetry/metrics_test.go
+++ b/internal/registry/telemetry/metrics_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/exporters/prometheus"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/metric/noop"
@@ -34,7 +35,7 @@ func TestNewMetrics(t *testing.T) {
 			metrics, err := telemetry.NewMetrics(tt.meter)
 
 			// Ensure the metric is registered correctly
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.NotNil(t, metrics)
 			assert.NotNil(t, metrics.Requests)
 		})
@@ -74,9 +75,9 @@ func TestNewPrometheusMeterProvider(t *testing.T) {
 			mp, err := telemetry.NewPrometheusMeterProvider(res, exp)
 
 			if tt.wantErr {
-				assert.NotNil(t, err)
+				require.Error(t, err)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.NotNil(t, mp)
 			}
 		})

--- a/internal/registry/validators/registries/mcpb_test.go
+++ b/internal/registry/validators/registries/mcpb_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/agentregistry-dev/agentregistry/internal/registry/validators/registries"
 	"github.com/modelcontextprotocol/registry/pkg/model"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestValidateMCPB(t *testing.T) {
@@ -111,10 +112,10 @@ func TestValidateMCPB(t *testing.T) {
 			err := registries.ValidateMCPB(ctx, pkg, tt.serverName)
 
 			if tt.expectError {
-				assert.Error(t, err)
+				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.errorMessage)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 		})
 	}
@@ -178,10 +179,10 @@ func TestValidateMCPB_OptionalFields(t *testing.T) {
 			err := registries.ValidateMCPB(ctx, tt.pkg, "io.github.domdomegg/airtable-mcp-server")
 
 			if tt.expectError {
-				assert.Error(t, err)
+				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.errorMessage)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 		})
 	}

--- a/internal/registry/validators/registries/npm_test.go
+++ b/internal/registry/validators/registries/npm_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/agentregistry-dev/agentregistry/internal/registry/validators/registries"
 	"github.com/modelcontextprotocol/registry/pkg/model"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestValidateNPM_RealPackages(t *testing.T) {
@@ -127,10 +128,10 @@ func TestValidateNPM_RealPackages(t *testing.T) {
 			err := registries.ValidateNPM(ctx, pkg, tt.serverName)
 
 			if tt.expectError {
-				assert.Error(t, err)
+				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.errorMessage)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 		})
 	}

--- a/internal/registry/validators/registries/nuget_test.go
+++ b/internal/registry/validators/registries/nuget_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/agentregistry-dev/agentregistry/internal/registry/validators/registries"
 	"github.com/modelcontextprotocol/registry/pkg/model"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestValidateNuGet_RealPackages(t *testing.T) {
@@ -104,10 +105,10 @@ func TestValidateNuGet_RealPackages(t *testing.T) {
 			err := registries.ValidateNuGet(ctx, pkg, tt.serverName)
 
 			if tt.expectError {
-				assert.Error(t, err)
+				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.errorMessage)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 		})
 	}

--- a/internal/registry/validators/registries/oci_test.go
+++ b/internal/registry/validators/registries/oci_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/agentregistry-dev/agentregistry/internal/registry/validators/registries"
 	"github.com/modelcontextprotocol/registry/pkg/model"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestValidateOCI_RegistryAllowlist(t *testing.T) {
@@ -103,11 +104,11 @@ func TestValidateOCI_RegistryAllowlist(t *testing.T) {
 			err := registries.ValidateOCI(ctx, pkg, "com.example/test")
 
 			if tt.expectError {
-				assert.Error(t, err)
+				require.Error(t, err)
 				// Should contain the specific error message
 				assert.Contains(t, err.Error(), tt.errorMsg)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 		})
 	}
@@ -154,7 +155,7 @@ func TestValidateOCI_RejectsOldFormat(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			err := registries.ValidateOCI(ctx, tt.pkg, "com.example/test")
 
-			assert.Error(t, err)
+			require.Error(t, err)
 			assert.Contains(t, err.Error(), tt.errorMessage)
 		})
 	}
@@ -185,7 +186,7 @@ func TestValidateOCI_InvalidReferences(t *testing.T) {
 			}
 
 			err := registries.ValidateOCI(ctx, pkg, "com.example/test")
-			assert.Error(t, err)
+			require.Error(t, err)
 			assert.Contains(t, err.Error(), "invalid OCI reference")
 		})
 	}
@@ -200,7 +201,7 @@ func TestValidateOCI_EmptyIdentifier(t *testing.T) {
 	}
 
 	err := registries.ValidateOCI(ctx, pkg, "com.example/test")
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), "package identifier is required")
 }
 
@@ -214,7 +215,7 @@ func TestValidateOCI_SuccessfulValidation(t *testing.T) {
 	}
 
 	err := registries.ValidateOCI(ctx, pkg, "io.github.github/github-mcp-server")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestValidateOCI_LabelMismatch(t *testing.T) {
@@ -228,7 +229,7 @@ func TestValidateOCI_LabelMismatch(t *testing.T) {
 	}
 
 	err := registries.ValidateOCI(ctx, pkg, "io.github.github/github-mcp-server-mismatch")
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), "ownership validation failed")
 	assert.Contains(t, err.Error(), "Expected annotation")
 }

--- a/internal/registry/validators/registries/pypi_test.go
+++ b/internal/registry/validators/registries/pypi_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/agentregistry-dev/agentregistry/internal/registry/validators/registries"
 	"github.com/modelcontextprotocol/registry/pkg/model"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestValidatePyPI_RealPackages(t *testing.T) {
@@ -80,10 +81,10 @@ func TestValidatePyPI_RealPackages(t *testing.T) {
 			err := registries.ValidatePyPI(ctx, pkg, tt.serverName)
 
 			if tt.expectError {
-				assert.Error(t, err)
+				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.errorMessage)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 		})
 	}

--- a/internal/registry/validators/validators_test.go
+++ b/internal/registry/validators/validators_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/agentregistry-dev/agentregistry/internal/registry/config"
 	"github.com/agentregistry-dev/agentregistry/internal/registry/validators"
@@ -738,9 +739,9 @@ func TestValidate(t *testing.T) {
 			err := validators.ValidateServerJSON(&tt.serverDetail)
 
 			if tt.expectedError == "" {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			} else {
-				assert.Error(t, err)
+				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.expectedError)
 			}
 		})
@@ -894,10 +895,10 @@ func TestValidate_RemoteNamespaceMatch(t *testing.T) {
 			err := validators.ValidateServerJSON(&tt.serverDetail)
 
 			if tt.expectError {
-				assert.Error(t, err)
+				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.errorMsg)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 		})
 	}
@@ -978,10 +979,10 @@ func TestValidate_ServerNameFormat(t *testing.T) {
 			err := validators.ValidateServerJSON(&tt.serverDetail)
 
 			if tt.expectError {
-				assert.Error(t, err)
+				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.errorMsg)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 		})
 	}
@@ -1057,10 +1058,10 @@ func TestValidate_MultipleSlashesInServerName(t *testing.T) {
 			err := validators.ValidateServerJSON(&serverDetail)
 
 			if tt.expectError {
-				assert.Error(t, err)
+				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.errorMsg)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 		})
 	}
@@ -1109,7 +1110,7 @@ func TestValidateArgument_ValidNamedArguments(t *testing.T) {
 		t.Run("Valid_"+arg.Name, func(t *testing.T) {
 			server := createValidServerWithArgument(arg)
 			err := validators.ValidateServerJSON(&server)
-			assert.NoError(t, err, "Expected valid argument %+v", arg)
+			require.NoError(t, err, "Expected valid argument %+v", arg)
 		})
 	}
 }
@@ -1128,7 +1129,7 @@ func TestValidateArgument_ValidPositionalArguments(t *testing.T) {
 		t.Run(fmt.Sprintf("ValidPositional_%d", i), func(t *testing.T) {
 			server := createValidServerWithArgument(arg)
 			err := validators.ValidateServerJSON(&server)
-			assert.NoError(t, err, "Expected valid positional argument %+v", arg)
+			require.NoError(t, err, "Expected valid positional argument %+v", arg)
 		})
 	}
 }
@@ -1150,7 +1151,7 @@ func TestValidateArgument_InvalidNamedArgumentNames(t *testing.T) {
 		t.Run("Invalid_"+tc.name, func(t *testing.T) {
 			server := createValidServerWithArgument(tc.arg)
 			err := validators.ValidateServerJSON(&server)
-			assert.Error(t, err, "Expected error for invalid named argument name: %+v", tc.arg)
+			require.Error(t, err, "Expected error for invalid named argument name: %+v", tc.arg)
 		})
 	}
 }
@@ -1198,7 +1199,7 @@ func TestValidateArgument_InvalidValueFields(t *testing.T) {
 		t.Run("Invalid_"+tc.name, func(t *testing.T) {
 			server := createValidServerWithArgument(tc.arg)
 			err := validators.ValidateServerJSON(&server)
-			assert.Error(t, err, "Expected error for argument with value starting with name: %+v", tc.arg)
+			require.Error(t, err, "Expected error for argument with value starting with name: %+v", tc.arg)
 		})
 	}
 }
@@ -1254,7 +1255,7 @@ func TestValidateArgument_ValidValueFields(t *testing.T) {
 		t.Run("Valid_"+tc.name, func(t *testing.T) {
 			server := createValidServerWithArgument(tc.arg)
 			err := validators.ValidateServerJSON(&server)
-			assert.NoError(t, err, "Expected valid argument %+v", tc.arg)
+			require.NoError(t, err, "Expected valid argument %+v", tc.arg)
 		})
 	}
 }
@@ -1591,9 +1592,9 @@ func TestValidate_TransportValidation(t *testing.T) {
 			err := validators.ValidateServerJSON(&tt.serverDetail)
 
 			if tt.expectedError == "" {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			} else {
-				assert.Error(t, err)
+				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.expectedError)
 			}
 		})
@@ -1669,9 +1670,9 @@ func TestValidate_RegistryTypesAndUrls(t *testing.T) {
 				EnableRegistryValidation: true,
 			})
 			if tc.expectError {
-				assert.Error(t, err)
+				require.Error(t, err)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 		})
 	}
@@ -2019,9 +2020,9 @@ func TestValidateTitle(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			err := validators.ValidateServerJSON(&tt.serverDetail)
 			if tt.expectedError == "" {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			} else {
-				assert.Error(t, err)
+				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.expectedError)
 			}
 		})

--- a/pkg/registry/auth/jwt_test.go
+++ b/pkg/registry/auth/jwt_test.go
@@ -44,7 +44,7 @@ func TestJWTManager_GenerateAndVerifyToken(t *testing.T) {
 		tokenResponse, err := jwtManager.GenerateTokenResponse(ctx, claims)
 		require.NoError(t, err)
 		assert.NotEmpty(t, tokenResponse.RegistryToken)
-		assert.Greater(t, tokenResponse.ExpiresAt, 0)
+		assert.Positive(t, tokenResponse.ExpiresAt)
 
 		// Verify token
 		verifiedClaims, err := jwtManager.ValidateToken(ctx, tokenResponse.RegistryToken)
@@ -109,7 +109,7 @@ func TestJWTManager_GenerateAndVerifyToken(t *testing.T) {
 
 		// Verify token should fail
 		_, err = jwtManager.ValidateToken(ctx, tokenResponse.RegistryToken)
-		assert.Error(t, err)
+		require.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to parse token")
 	})
 
@@ -135,14 +135,14 @@ func TestJWTManager_GenerateAndVerifyToken(t *testing.T) {
 
 		// Try to verify with original key - should fail
 		_, err = jwtManager.ValidateToken(ctx, tokenResponse.RegistryToken)
-		assert.Error(t, err)
+		require.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to parse token")
 	})
 
 	t.Run("malformed token should fail", func(t *testing.T) {
 		// Try to validate a malformed token
 		_, err := jwtManager.ValidateToken(ctx, "not.a.valid.token")
-		assert.Error(t, err)
+		require.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to parse token")
 	})
 
@@ -315,7 +315,7 @@ func TestJWTManager_BlockedNamespaces(t *testing.T) {
 		}
 
 		tokenResponse, err := jwtManager.GenerateTokenResponse(ctx, claims)
-		assert.Error(t, err)
+		require.Error(t, err)
 		assert.Contains(t, err.Error(), "your namespace is blocked")
 		assert.Nil(t, tokenResponse)
 	})
@@ -368,7 +368,7 @@ func TestJWTManager_BlockedNamespaces(t *testing.T) {
 		}
 
 		tokenResponse, err := jwtManager.GenerateTokenResponse(ctx, claims)
-		assert.Error(t, err)
+		require.Error(t, err)
 		assert.Contains(t, err.Error(), "your namespace is blocked")
 		assert.Nil(t, tokenResponse)
 	})


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don't apply.
-->

# Description

<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

Enable testifylint to enforce testify best practices. We fix all violations by using require.NoError/require.Error instead of assert for error checks. This is the correct pattern since there's no point continuing a test after an error assertion fails.

This is a linter enabled in a couple of different projects (gateway-api comes immediate to mind).

# Change Type

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bump
/kind cleanup
/kind design
/kind deprecation
/kind documentation
/kind feature
/kind fix
/kind flake
/kind install
```
-->

/kind cleanup

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
NONE
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
