### PR TITLE
ci: Extract lint jobs into standalone workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,26 +46,3 @@ jobs:
 
     - name: Run Integration Tests
       run: make test
-
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-
-    - uses: actions/setup-go@v6
-      with:
-        go-version-file: "go.mod"
-
-    - name: Set up Node.js
-      uses: actions/setup-node@v4
-      with:
-        node-version: 20.9.x
-
-    - name: Build UI
-      run: make build-ui
-
-    - name: Lint Go
-      run: make lint
-
-    - name: Lint UI
-      run: cd ui && npm run lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,33 @@
+name: Lint
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint-go:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: "go.mod"
+
+      - name: Lint Go
+        run: make lint
+
+  lint-ui:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.9.x
+
+      - name: Lint UI
+        run: make lint-ui

--- a/Makefile
+++ b/Makefile
@@ -245,6 +245,10 @@ GOLANGCI_LINT_ARGS ?= --fix
 lint: ## Run golangci-lint linter
 	$(GOLANGCI_LINT) run $(GOLANGCI_LINT_ARGS)
 
+.PHONY: lint-ui
+lint-ui: install-ui ## Run eslint on UI code
+	cd ui && npm run lint
+
 .PHONY: verify
 verify: mod-tidy ## Run all verification checks
 	git diff --exit-code


### PR DESCRIPTION
# Description

Extracts linting from build.yml into a dedicated lint.yml workflow. The previous setup unnecessarily ran a full Next.js production build before linting. Now we have parallel lint-go and lint-ui jobs, with a new lint-ui Makefile target that only installs dependencies.

/kind cleanup

```release-note
NONE
```