### PR TITLE
fix(cli): Fix Docker image tag duplication in skill publish

### DIFF
--- a/internal/cli/skill/publish.go
+++ b/internal/cli/skill/publish.go
@@ -172,13 +172,12 @@ func buildSkillDockerImage(skillPath string) (*models.SkillJSON, error) {
 	}
 
 	// 2) Determine image reference and build
-	// sanitize name for docker (lowercase, slashes to dashes)
-	repoName := common.BuildLocalImageName(fm.Name, ver)
 	if dockerUrl == "" {
 		return nil, fmt.Errorf("docker url is required")
 	}
 
-	imageRef := common.BuildRegistryImageName(strings.TrimSuffix(dockerUrl, "/"), repoName, ver)
+	// BuildRegistryImageName sanitizes the name for docker (lowercase, kebab-case)
+	imageRef := common.BuildRegistryImageName(strings.TrimSuffix(dockerUrl, "/"), fm.Name, ver)
 	// Build only if not dry-run
 	if dryRunFlag {
 		printer.PrintInfo("[DRY RUN] Would build Docker image: " + imageRef)


### PR DESCRIPTION
# Description

`arctl skill publish` produces invalid Docker image references with duplicated
tags (e.g., `docker.io/user/my-project:latest:latest`).

**Root cause:** In `buildSkillDockerImage`, `BuildRegistryImageName` was called
with the output of `BuildLocalImageName` (which already includes a version tag)
instead of the raw name. Since `BuildRegistryImageName` internally calls
`BuildLocalImageName`, the tag was applied twice.

**Fix:** Pass `fm.Name` directly to `BuildRegistryImageName`, matching the
existing pattern in `GetImageNameFromManifest` (common.go:58).

Fixes #178

# Change Type

/kind fix

# Changelog

```release-note
Fix Docker image tag duplication (`:latest:latest`) in `arctl skill publish`
```

# Additional Notes

- Added 2 test cases to `TestBuildRegistryImageName` covering registry URLs with path components
- Added `TestBuildRegistryImageName_NoDoubleTag` regression test asserting no double-tag patterns
- Removed unused `repoName` variable