### PR TITLE
fix(cli): Allow hyphens in agent names

### DIFF
--- a/internal/cli/agent/frameworks/adk/python/generator.go
+++ b/internal/cli/agent/frameworks/adk/python/generator.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/agentregistry-dev/agentregistry/internal/cli/agent/frameworks/common"
 	"github.com/agentregistry-dev/agentregistry/pkg/models"
+	"github.com/agentregistry-dev/agentregistry/pkg/validators"
 )
 
 //go:embed templates/* templates/agent/* templates/mcp_server/* dice-agent-instruction.md
@@ -30,6 +31,9 @@ func (g *PythonGenerator) Generate(agentConfig *common.AgentConfig) error {
 	if agentConfig == nil {
 		return fmt.Errorf("agent config is required")
 	}
+
+	// Convert agent name to Python-safe identifier (hyphens to underscores)
+	agentConfig.Name = validators.PythonSafeName(agentConfig.Name)
 
 	projectPackageDir := filepath.Join(agentConfig.Directory, agentConfig.Name)
 	if err := os.MkdirAll(projectPackageDir, 0o755); err != nil {

--- a/internal/cli/agent/frameworks/adk/python/generator.go
+++ b/internal/cli/agent/frameworks/adk/python/generator.go
@@ -32,7 +32,9 @@ func (g *PythonGenerator) Generate(agentConfig *common.AgentConfig) error {
 		return fmt.Errorf("agent config is required")
 	}
 
-	// Convert agent name to Python-safe identifier (hyphens to underscores)
+	// Python identifiers cannot contain hyphens (e.g., "my-agent" is parsed as
+	// "my minus agent"), so convert to underscores for the package directory and
+	// module name.
 	agentConfig.Name = validators.PythonSafeName(agentConfig.Name)
 
 	projectPackageDir := filepath.Join(agentConfig.Directory, agentConfig.Name)

--- a/pkg/validators/names.go
+++ b/pkg/validators/names.go
@@ -57,20 +57,22 @@ func ValidateProjectName(name string) error {
 	return nil
 }
 
-// agentNameRegex enforces the strictest rule - names that work BOTH as Python identifiers AND as publishable agent names.
-// Must start with a letter, followed by alphanumeric only, minimum 2 characters.
-var agentNameRegex = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9]+$`)
+// agentNameRegex enforces names that work as publishable agent names.
+// Must start with a letter, end with a letter or digit, can contain hyphens in the middle.
+// Dots are intentionally excluded to avoid .well-known URL path routing ambiguity.
+// Minimum 2 characters.
+var agentNameRegex = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9-]*[a-zA-Z0-9]$`)
 
 // ValidateAgentName checks if the agent name is valid.
-// Allowed: letters and digits only, must start with a letter, minimum 2 characters.
-// Not allowed: underscores, dots, hyphens, or Python keywords.
+// Allowed: letters, digits, and hyphens; must start with a letter, end with a letter or digit.
+// Not allowed: underscores, dots, or Python keywords.
 func ValidateAgentName(name string) error {
 	if name == "" {
 		return fmt.Errorf("agent name cannot be empty")
 	}
 
 	if !agentNameRegex.MatchString(name) {
-		return fmt.Errorf("agent name must start with a letter and contain only letters and digits (minimum 2 characters)")
+		return fmt.Errorf("agent name must start with a letter, end with a letter or digit, and contain only letters, digits, and hyphens (minimum 2 characters)")
 	}
 
 	// Reject Python keywords to avoid issues in generated code
@@ -79,6 +81,12 @@ func ValidateAgentName(name string) error {
 	}
 
 	return nil
+}
+
+// PythonSafeName converts an agent name to a valid Python identifier
+// by replacing hyphens with underscores.
+func PythonSafeName(name string) string {
+	return strings.ReplaceAll(name, "-", "_")
 }
 
 // ValidateMCPServerName checks if the MCP server name matches the required format.


### PR DESCRIPTION
# Description

Agent names with hyphens (e.g., `my-agent`) are rejected by the Go validator
even though the database constraint already allows them. This is a common
naming convention that users expect to work.

**Root cause:** `agentNameRegex` was `^[a-zA-Z][a-zA-Z0-9]+$`, which only
allowed letters and digits after the initial letter.

**Changes:**
- Relax `agentNameRegex` to `^[a-zA-Z][a-zA-Z0-9-]*[a-zA-Z0-9]$`
- Dots intentionally remain excluded to avoid `.well-known` URL path ambiguity
- Add `PythonSafeName()` helper that converts hyphens to underscores
- Python generator converts agent name before code generation so packages
  remain importable (e.g., `my-agent` -> `my_agent/` directory)

Fixes #158

# Change Type

/kind fix

# Changelog

```release-note
Allow hyphens in agent names, with automatic conversion to underscores for Python code generation
```

# Additional Notes

- Database constraint already allows hyphens - no migration needed
- Dots kept out of validator intentionally (different from DB constraint)
  to avoid routing conflicts with `.well-known` paths
- Only the Python generator converts names; future non-Python frameworks
  can use hyphens directly
- Filed #204 for a pre-existing mutation pattern in `PythonGenerator.Generate`