### PR TITLE
docs: Remove CHANGELOG.md reference from CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -260,7 +260,7 @@ refactor(db): simplify query methods
 1. Update documentation
 2. Add/update tests
 3. Ensure CI passes
-4. Update CHANGELOG.md
+4. Include a `release-note` block in your PR description (see PR template)
 5. Request review
 
 ### PR Checklist


### PR DESCRIPTION
# Description

CONTRIBUTING.md lists "Update CHANGELOG.md" as step 4 of the Pull Request Process, but no CHANGELOG.md file exists in the repository. The project uses `release-note` blocks in PR descriptions instead.

This PR replaces the outdated CHANGELOG.md reference with guidance to include a `release-note` block in the PR description, which matches the actual project workflow.

Fixes #203

# Change Type

/kind cleanup

# Changelog

```release-note
NONE
```

# Additional Notes

None