### PR TITLE
ap: refactor deployment apis to provider+id-based model

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -647,15 +647,15 @@ func (c *Client) DeployServer(name, version string, deploymentEnv map[string]str
 	return &deployment, nil
 }
 
-// DeployAgent deploys an agent with configuration
-func (c *Client) DeployAgent(name, version string, config map[string]string, providerID string) (*DeploymentResponse, error) {
+// DeployAgent deploys an agent with deployment environment variables.
+func (c *Client) DeployAgent(name, version string, deploymentEnv map[string]string, providerID string) (*DeploymentResponse, error) {
 	if providerID == "" {
 		providerID = string(ProviderPlatformLocal)
 	}
 	payload := internalv0.DeploymentRequest{
 		ServerName:   name,
 		Version:      version,
-		Env:          config,
+		Env:          deploymentEnv,
 		ResourceType: "agent",
 		ProviderID:   providerID,
 	}

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -30,6 +30,14 @@ const (
 	DefaultBaseURL = defaultBaseURL
 )
 
+// ProviderPlatform represents a provider platform type.
+type ProviderPlatform string
+
+const (
+	ProviderPlatformLocal      ProviderPlatform = "local"
+	ProviderPlatformKubernetes ProviderPlatform = "kubernetes"
+)
+
 // NewClientFromEnv constructs a client using environment variables
 func NewClientFromEnv() (*Client, error) {
 	return NewClientWithConfig(os.Getenv("ARCTL_API_BASE_URL"), os.Getenv("ARCTL_API_TOKEN"))
@@ -578,12 +586,11 @@ func asHTTPStatus(err error) int {
 
 // DeploymentResponse represents a deployment returned by the API
 type DeploymentResponse struct {
-	ID            string            `json:"id"`
-	Platform      string            `json:"platform"`
-	ProviderID    string            `json:"providerId,omitempty"`
+	ID           string            `json:"id"`
+	ProviderID   string            `json:"providerId,omitempty"`
 	ServerName   string            `json:"serverName"`
 	Version      string            `json:"version"`
-	Origin        string            `json:"origin"`
+	Origin       string            `json:"origin"`
 	DeployedAt   string            `json:"deployedAt"`
 	UpdatedAt    string            `json:"updatedAt"`
 	Status       string            `json:"status"`
@@ -621,7 +628,7 @@ func (c *Client) GetDeployedServers() ([]*DeploymentResponse, error) {
 // DeployServer deploys a server with configuration.
 func (c *Client) DeployServer(name, version string, config map[string]string, preferRemote bool, providerID string) (*DeploymentResponse, error) {
 	if providerID == "" {
-		providerID = "local"
+		providerID = string(ProviderPlatformLocal)
 	}
 	payload := internalv0.DeploymentRequest{
 		ServerName:   name,
@@ -643,7 +650,7 @@ func (c *Client) DeployServer(name, version string, config map[string]string, pr
 // DeployAgent deploys an agent with configuration
 func (c *Client) DeployAgent(name, version string, config map[string]string, providerID string) (*DeploymentResponse, error) {
 	if providerID == "" {
-		providerID = "local"
+		providerID = string(ProviderPlatformLocal)
 	}
 	payload := internalv0.DeploymentRequest{
 		ServerName:   name,

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -626,14 +626,14 @@ func (c *Client) GetDeployedServers() ([]*DeploymentResponse, error) {
 }
 
 // DeployServer deploys a server with configuration.
-func (c *Client) DeployServer(name, version string, config map[string]string, preferRemote bool, providerID string) (*DeploymentResponse, error) {
+func (c *Client) DeployServer(name, version string, deploymentEnv map[string]string, preferRemote bool, providerID string) (*DeploymentResponse, error) {
 	if providerID == "" {
 		providerID = string(ProviderPlatformLocal)
 	}
 	payload := internalv0.DeploymentRequest{
 		ServerName:   name,
 		Version:      version,
-		Config:       config,
+		Env:          deploymentEnv,
 		PreferRemote: preferRemote,
 		ResourceType: "mcp",
 		ProviderID:   providerID,
@@ -655,7 +655,7 @@ func (c *Client) DeployAgent(name, version string, config map[string]string, pro
 	payload := internalv0.DeploymentRequest{
 		ServerName:   name,
 		Version:      version,
-		Config:       config,
+		Env:          config,
 		ResourceType: "agent",
 		ProviderID:   providerID,
 	}

--- a/internal/mcp/registryserver/deployments_test.go
+++ b/internal/mcp/registryserver/deployments_test.go
@@ -194,7 +194,7 @@ func TestDeploymentTools_DeployRemove(t *testing.T) {
 		Arguments: map[string]any{
 			"serverName": "com.example/echo",
 			"version":    "1.0.0",
-			"config":     map[string]string{"ENV": "prod"},
+			"env":        map[string]string{"ENV": "prod"},
 		},
 	})
 	require.NoError(t, err)
@@ -211,7 +211,7 @@ func TestDeploymentTools_DeployRemove(t *testing.T) {
 		Arguments: map[string]any{
 			"serverName": "com.example/agent",
 			"version":    "2.0.0",
-			"config":     map[string]string{"FOO": "bar"},
+			"env":        map[string]string{"FOO": "bar"},
 		},
 	})
 	require.NoError(t, err)

--- a/internal/mcp/registryserver/server.go
+++ b/internal/mcp/registryserver/server.go
@@ -403,7 +403,7 @@ func addDeploymentTools(server *mcp.Server, registry service.RegistryService) {
 		if providerID == "" {
 			providerID = "local"
 		}
-		deployment, err := registry.DeployServer(ctx, args.ServerName, args.Version, args.Config, args.PreferRemote, providerID)
+		deployment, err := registry.DeployServer(ctx, args.ServerName, args.Version, args.Env, args.PreferRemote, providerID)
 		if err != nil {
 			return nil, models.Deployment{}, err
 		}
@@ -423,7 +423,7 @@ func addDeploymentTools(server *mcp.Server, registry service.RegistryService) {
 		if providerID == "" {
 			providerID = "local"
 		}
-		deployment, err := registry.DeployAgent(ctx, args.ServerName, args.Version, args.Config, args.PreferRemote, providerID)
+		deployment, err := registry.DeployAgent(ctx, args.ServerName, args.Version, args.Env, args.PreferRemote, providerID)
 		if err != nil {
 			return nil, models.Deployment{}, err
 		}

--- a/internal/registry/api/handlers/v0/deployment_adapters.go
+++ b/internal/registry/api/handlers/v0/deployment_adapters.go
@@ -1,0 +1,98 @@
+package v0
+
+import (
+	"context"
+	"errors"
+
+	"github.com/agentregistry-dev/agentregistry/internal/registry/service"
+	"github.com/agentregistry-dev/agentregistry/pkg/models"
+	registrytypes "github.com/agentregistry-dev/agentregistry/pkg/types"
+)
+
+var errDeploymentNotSupported = errors.New("deployment operation is not supported for this provider platform type")
+
+type deploymentAdapterBase struct {
+	providerPlatform string
+	registry         service.RegistryService
+}
+
+func (a *deploymentAdapterBase) Platform() string {
+	return a.providerPlatform
+}
+
+func (a *deploymentAdapterBase) SupportedResourceTypes() []string {
+	return []string{"mcp", "agent"}
+}
+
+func (a *deploymentAdapterBase) Deploy(ctx context.Context, req *models.Deployment) (*models.Deployment, error) {
+	if req == nil {
+		return nil, errors.New("deployment request is required")
+	}
+	resourceType := req.ResourceType
+	if resourceType == "" {
+		resourceType = "mcp"
+	}
+	if req.ProviderID == "" && a.providerPlatform == "local" {
+		req.ProviderID = LocalProviderID
+	}
+
+	switch resourceType {
+	case "mcp":
+		return a.registry.DeployServer(ctx, req.ServerName, req.Version, req.Config, req.PreferRemote, req.ProviderID)
+	case "agent":
+		return a.registry.DeployAgent(ctx, req.ServerName, req.Version, req.Config, req.PreferRemote, req.ProviderID)
+	default:
+		return nil, errors.New("invalid resource type")
+	}
+}
+
+func (a *deploymentAdapterBase) Undeploy(ctx context.Context, deployment *models.Deployment) error {
+	if deployment == nil || deployment.ID == "" {
+		return errors.New("deployment id is required")
+	}
+	return a.registry.RemoveDeploymentByID(ctx, deployment.ID)
+}
+
+func (a *deploymentAdapterBase) GetLogs(_ context.Context, _ *models.Deployment) ([]string, error) {
+	return nil, errDeploymentNotSupported
+}
+
+func (a *deploymentAdapterBase) Cancel(_ context.Context, _ *models.Deployment) error {
+	return errDeploymentNotSupported
+}
+
+func (a *deploymentAdapterBase) Discover(_ context.Context, _ string) ([]*models.Deployment, error) {
+	// Built-in local/kubernetes runtime discovery is handled through existing
+	// reconciliation flows today; this adapter method is a no-op placeholder.
+	return []*models.Deployment{}, nil
+}
+
+type localDeploymentAdapter struct {
+	deploymentAdapterBase
+}
+
+type kubernetesDeploymentAdapter struct {
+	deploymentAdapterBase
+}
+
+// NOTE: local and kubernetes currently share the same adapter base behavior.
+// The registry service handles the runtime-specific paths today; keep these
+// concrete adapter types as explicit extension points for future divergence.
+
+// DefaultDeploymentPlatformAdapters returns OSS deployment adapters for local and kubernetes.
+func DefaultDeploymentPlatformAdapters(registry service.RegistryService) map[string]registrytypes.DeploymentPlatformAdapter {
+	return map[string]registrytypes.DeploymentPlatformAdapter{
+		"local": &localDeploymentAdapter{
+			deploymentAdapterBase: deploymentAdapterBase{
+				providerPlatform: "local",
+				registry:         registry,
+			},
+		},
+		"kubernetes": &kubernetesDeploymentAdapter{
+			deploymentAdapterBase: deploymentAdapterBase{
+				providerPlatform: "kubernetes",
+				registry:         registry,
+			},
+		},
+	}
+}

--- a/internal/registry/api/handlers/v0/deployment_adapters.go
+++ b/internal/registry/api/handlers/v0/deployment_adapters.go
@@ -35,12 +35,16 @@ func (a *deploymentAdapterBase) Deploy(ctx context.Context, req *models.Deployme
 	if req.ProviderID == "" && a.providerPlatform == "local" {
 		req.ProviderID = LocalProviderID
 	}
+	config, err := normalizeStringConfig(req.Config, req.ProviderConfig)
+	if err != nil {
+		return nil, err
+	}
 
 	switch resourceType {
 	case "mcp":
-		return a.registry.DeployServer(ctx, req.ServerName, req.Version, req.Config, req.PreferRemote, req.ProviderID)
+		return a.registry.DeployServer(ctx, req.ServerName, req.Version, config, req.PreferRemote, req.ProviderID)
 	case "agent":
-		return a.registry.DeployAgent(ctx, req.ServerName, req.Version, req.Config, req.PreferRemote, req.ProviderID)
+		return a.registry.DeployAgent(ctx, req.ServerName, req.Version, config, req.PreferRemote, req.ProviderID)
 	default:
 		return nil, errors.New("invalid resource type")
 	}
@@ -95,4 +99,12 @@ func DefaultDeploymentPlatformAdapters(registry service.RegistryService) map[str
 			},
 		},
 	}
+}
+
+func normalizeStringConfig(config map[string]string, providerConfig map[string]any) (map[string]string, error) {
+	_ = providerConfig // built-in adapters currently only support deployment env vars.
+	if len(config) > 0 {
+		return config, nil
+	}
+	return map[string]string{}, nil
 }

--- a/internal/registry/api/handlers/v0/deployments.go
+++ b/internal/registry/api/handlers/v0/deployments.go
@@ -240,6 +240,11 @@ func RegisterDeploymentsEndpoints(api huma.API, basePath string, registry servic
 			return nil, huma.Error500InternalServerError("Failed to retrieve deployment", err)
 		}
 
+		// Guard discovered deployments before provider/adapter resolution.
+		if deployment.Origin == "discovered" {
+			return nil, huma.Error409Conflict("Discovered deployments cannot be deleted directly")
+		}
+
 		platform := deploymentPlatform(ctx, registry, deployment)
 		adapter, ok := extensions.ResolveDeploymentAdapter(platform)
 		if !ok {

--- a/internal/registry/api/handlers/v0/deployments.go
+++ b/internal/registry/api/handlers/v0/deployments.go
@@ -17,12 +17,13 @@ const LocalProviderID = "local"
 
 // DeploymentRequest represents the input for deploying a server
 type DeploymentRequest struct {
-	ServerName   string            `json:"serverName" doc:"Server name to deploy" example:"io.github.user/weather"`
-	Version      string            `json:"version" doc:"Version to deploy (use 'latest' for latest version)" default:"latest" example:"1.0.0"`
-	Config       map[string]string `json:"config,omitempty" doc:"Configuration key-value pairs (env vars, args, headers)"`
-	PreferRemote bool              `json:"preferRemote,omitempty" doc:"Prefer remote deployment over local" default:"false"`
-	ResourceType string            `json:"resourceType,omitempty" doc:"Type of resource to deploy (mcp, agent)" default:"mcp" example:"mcp" enum:"mcp,agent"`
-	ProviderID   string            `json:"providerId,omitempty" doc:"Concrete provider instance ID. Defaults to local singleton when omitted."`
+	ServerName     string            `json:"serverName" doc:"Server name to deploy" example:"io.github.user/weather"`
+	Version        string            `json:"version" doc:"Version to deploy (use 'latest' for latest version)" default:"latest" example:"1.0.0"`
+	Env            map[string]string `json:"env,omitempty" doc:"Deployment environment variables."`
+	ProviderConfig map[string]any    `json:"providerConfig,omitempty" doc:"Optional provider-specific deployment configuration."`
+	PreferRemote   bool              `json:"preferRemote,omitempty" doc:"Prefer remote deployment over local" default:"false"`
+	ResourceType   string            `json:"resourceType,omitempty" doc:"Type of resource to deploy (mcp, agent)" default:"mcp" example:"mcp" enum:"mcp,agent"`
+	ProviderID     string            `json:"providerId,omitempty" doc:"Concrete provider instance ID. Defaults to local singleton when omitted."`
 }
 
 // DeploymentResponse represents a deployment
@@ -197,12 +198,13 @@ func RegisterDeploymentsEndpoints(api huma.API, basePath string, registry servic
 			return nil, unsupportedDeploymentPlatformError(platform)
 		}
 		deploymentReq := &models.Deployment{
-			ServerName:   input.Body.ServerName,
-			Version:      input.Body.Version,
-			Config:       input.Body.Config,
-			PreferRemote: input.Body.PreferRemote,
-			ResourceType: resourceType,
-			ProviderID:   providerID,
+			ServerName:     input.Body.ServerName,
+			Version:        input.Body.Version,
+			Config:         input.Body.Env,
+			ProviderConfig: input.Body.ProviderConfig,
+			PreferRemote:   input.Body.PreferRemote,
+			ResourceType:   resourceType,
+			ProviderID:     providerID,
 		}
 		deployment, err = adapter.Deploy(ctx, deploymentReq)
 

--- a/internal/registry/api/handlers/v0/deployments_test.go
+++ b/internal/registry/api/handlers/v0/deployments_test.go
@@ -1,0 +1,237 @@
+package v0_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	v0 "github.com/agentregistry-dev/agentregistry/internal/registry/api/handlers/v0"
+	servicetesting "github.com/agentregistry-dev/agentregistry/internal/registry/service/testing"
+	"github.com/agentregistry-dev/agentregistry/pkg/models"
+	"github.com/agentregistry-dev/agentregistry/pkg/registry/database"
+	registrytypes "github.com/agentregistry-dev/agentregistry/pkg/types"
+	"github.com/danielgtaylor/huma/v2"
+	"github.com/danielgtaylor/huma/v2/adapters/humago"
+	"github.com/stretchr/testify/assert"
+)
+
+type fakeDeploymentAdapter struct {
+	deployCalled   bool
+	undeployErr    error
+	getLogsErr     error
+	cancelErr      error
+	undeployCalled bool
+	getLogsCalled  bool
+	cancelCalled   bool
+}
+
+func (f *fakeDeploymentAdapter) Platform() string { return "local" }
+func (f *fakeDeploymentAdapter) SupportedResourceTypes() []string {
+	return []string{"mcp", "agent"}
+}
+func (f *fakeDeploymentAdapter) Deploy(_ context.Context, req *models.Deployment) (*models.Deployment, error) {
+	f.deployCalled = true
+	return &models.Deployment{
+		ID:           "adapter-dep-1",
+		ServerName:   req.ServerName,
+		Version:      req.Version,
+		ResourceType: req.ResourceType,
+		ProviderID:   req.ProviderID,
+		Status:       "deployed",
+		Origin:       "managed",
+		Config:       req.Config,
+	}, nil
+}
+func (f *fakeDeploymentAdapter) Undeploy(_ context.Context, _ *models.Deployment) error {
+	f.undeployCalled = true
+	return f.undeployErr
+}
+func (f *fakeDeploymentAdapter) GetLogs(_ context.Context, _ *models.Deployment) ([]string, error) {
+	f.getLogsCalled = true
+	if f.getLogsErr != nil {
+		return nil, f.getLogsErr
+	}
+	return []string{"line-1", "line-2"}, nil
+}
+func (f *fakeDeploymentAdapter) Cancel(_ context.Context, _ *models.Deployment) error {
+	f.cancelCalled = true
+	return f.cancelErr
+}
+func (f *fakeDeploymentAdapter) Discover(_ context.Context, _ string) ([]*models.Deployment, error) {
+	return []*models.Deployment{}, nil
+}
+
+func TestDeleteDeployment_DiscoveredReturnsConflict(t *testing.T) {
+	reg := servicetesting.NewFakeRegistry()
+	reg.GetDeploymentByIDFn = func(ctx context.Context, id string) (*models.Deployment, error) {
+		return &models.Deployment{
+			ID:         id,
+			ProviderID: "local",
+			Origin:     "discovered",
+		}, nil
+	}
+	reg.RemoveDeploymentByIDFn = func(ctx context.Context, id string) error {
+		return database.ErrInvalidInput
+	}
+	reg.GetProviderByIDFn = func(ctx context.Context, providerID string) (*models.Provider, error) {
+		return &models.Provider{ID: providerID, Platform: "local"}, nil
+	}
+
+	mux := http.NewServeMux()
+	api := humago.New(mux, huma.DefaultConfig("Test API", "1.0.0"))
+	adapter := &fakeDeploymentAdapter{undeployErr: database.ErrInvalidInput}
+	v0.RegisterDeploymentsEndpoints(api, "/v0", reg, v0.PlatformExtensions{
+		ProviderPlatforms: v0.DefaultProviderPlatformAdapters(reg),
+		DeploymentPlatforms: map[string]registrytypes.DeploymentPlatformAdapter{
+			"local": adapter,
+		},
+	})
+
+	req := httptest.NewRequest(http.MethodDelete, "/v0/deployments/dep-discovered-1", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusConflict, w.Code)
+	assert.Contains(t, w.Body.String(), "Discovered deployments cannot be deleted directly")
+}
+
+func TestCreateDeployment_UsesAdapterWhenRegistered(t *testing.T) {
+	reg := servicetesting.NewFakeRegistry()
+	reg.GetProviderByIDFn = func(ctx context.Context, providerID string) (*models.Provider, error) {
+		return &models.Provider{ID: providerID, Platform: "local"}, nil
+	}
+	reg.DeployServerFn = func(ctx context.Context, serverName, version string, config map[string]string, preferRemote bool, providerID string) (*models.Deployment, error) {
+		t.Fatalf("expected adapter dispatch, but DeployServer was called")
+		return nil, nil
+	}
+
+	adapter := &fakeDeploymentAdapter{}
+
+	mux := http.NewServeMux()
+	api := humago.New(mux, huma.DefaultConfig("Test API", "1.0.0"))
+	v0.RegisterDeploymentsEndpoints(api, "/v0", reg, v0.PlatformExtensions{
+		ProviderPlatforms: v0.DefaultProviderPlatformAdapters(reg),
+		DeploymentPlatforms: map[string]registrytypes.DeploymentPlatformAdapter{
+			"local": adapter,
+		},
+	})
+
+	body := map[string]any{
+		"serverName":   "io.github.user/weather",
+		"version":      "1.0.0",
+		"resourceType": "mcp",
+		"providerId":   "local",
+	}
+	payload, err := json.Marshal(body)
+	assert.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/v0/deployments", bytes.NewReader(payload))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	assert.True(t, adapter.deployCalled)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "adapter-dep-1")
+}
+
+func TestDeleteDeployment_UsesAdapterWhenRegistered(t *testing.T) {
+	reg := servicetesting.NewFakeRegistry()
+	reg.GetDeploymentByIDFn = func(ctx context.Context, id string) (*models.Deployment, error) {
+		return &models.Deployment{
+			ID:         id,
+			ProviderID: "local",
+			Status:     "deployed",
+		}, nil
+	}
+	reg.GetProviderByIDFn = func(ctx context.Context, providerID string) (*models.Provider, error) {
+		return &models.Provider{ID: providerID, Platform: "local"}, nil
+	}
+	reg.RemoveDeploymentByIDFn = func(ctx context.Context, id string) error {
+		t.Fatalf("expected adapter undeploy, but RemoveDeploymentByID was called")
+		return nil
+	}
+
+	adapter := &fakeDeploymentAdapter{}
+	mux := http.NewServeMux()
+	api := humago.New(mux, huma.DefaultConfig("Test API", "1.0.0"))
+	v0.RegisterDeploymentsEndpoints(api, "/v0", reg, v0.PlatformExtensions{
+		ProviderPlatforms: v0.DefaultProviderPlatformAdapters(reg),
+		DeploymentPlatforms: map[string]registrytypes.DeploymentPlatformAdapter{
+			"local": adapter,
+		},
+	})
+
+	req := httptest.NewRequest(http.MethodDelete, "/v0/deployments/dep-1", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNoContent, w.Code)
+	assert.True(t, adapter.undeployCalled)
+}
+
+func TestGetDeploymentLogs_UsesAdapterWhenRegistered(t *testing.T) {
+	reg := servicetesting.NewFakeRegistry()
+	reg.GetDeploymentByIDFn = func(ctx context.Context, id string) (*models.Deployment, error) {
+		return &models.Deployment{
+			ID:         id,
+			ProviderID: "local",
+			Status:     "deployed",
+		}, nil
+	}
+	reg.GetProviderByIDFn = func(ctx context.Context, providerID string) (*models.Provider, error) {
+		return &models.Provider{ID: providerID, Platform: "local"}, nil
+	}
+
+	adapter := &fakeDeploymentAdapter{}
+	mux := http.NewServeMux()
+	api := humago.New(mux, huma.DefaultConfig("Test API", "1.0.0"))
+	v0.RegisterDeploymentsEndpoints(api, "/v0", reg, v0.PlatformExtensions{
+		ProviderPlatforms: v0.DefaultProviderPlatformAdapters(reg),
+		DeploymentPlatforms: map[string]registrytypes.DeploymentPlatformAdapter{
+			"local": adapter,
+		},
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/v0/deployments/dep-2/logs", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNoContent, w.Code)
+	assert.True(t, adapter.getLogsCalled)
+}
+
+func TestCancelDeployment_UsesAdapterWhenRegistered(t *testing.T) {
+	reg := servicetesting.NewFakeRegistry()
+	reg.GetDeploymentByIDFn = func(ctx context.Context, id string) (*models.Deployment, error) {
+		return &models.Deployment{
+			ID:         id,
+			ProviderID: "local",
+			Status:     "deploying",
+		}, nil
+	}
+	reg.GetProviderByIDFn = func(ctx context.Context, providerID string) (*models.Provider, error) {
+		return &models.Provider{ID: providerID, Platform: "local"}, nil
+	}
+
+	adapter := &fakeDeploymentAdapter{}
+	mux := http.NewServeMux()
+	api := humago.New(mux, huma.DefaultConfig("Test API", "1.0.0"))
+	v0.RegisterDeploymentsEndpoints(api, "/v0", reg, v0.PlatformExtensions{
+		ProviderPlatforms: v0.DefaultProviderPlatformAdapters(reg),
+		DeploymentPlatforms: map[string]registrytypes.DeploymentPlatformAdapter{
+			"local": adapter,
+		},
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/v0/deployments/dep-3/cancel", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNoContent, w.Code)
+	assert.True(t, adapter.cancelCalled)
+}
+

--- a/internal/registry/api/handlers/v0/deployments_test.go
+++ b/internal/registry/api/handlers/v0/deployments_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/danielgtaylor/huma/v2"
 	"github.com/danielgtaylor/huma/v2/adapters/humago"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type fakeDeploymentAdapter struct {
@@ -126,7 +127,7 @@ func TestCreateDeployment_UsesAdapterWhenRegistered(t *testing.T) {
 		"providerId":   "local",
 	}
 	payload, err := json.Marshal(body)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	req := httptest.NewRequest(http.MethodPost, "/v0/deployments", bytes.NewReader(payload))
 	req.Header.Set("Content-Type", "application/json")
@@ -234,4 +235,3 @@ func TestCancelDeployment_UsesAdapterWhenRegistered(t *testing.T) {
 	assert.Equal(t, http.StatusNoContent, w.Code)
 	assert.True(t, adapter.cancelCalled)
 }
-

--- a/internal/registry/api/handlers/v0/deployments_test.go
+++ b/internal/registry/api/handlers/v0/deployments_test.go
@@ -27,6 +27,7 @@ type fakeDeploymentAdapter struct {
 	undeployCalled bool
 	getLogsCalled  bool
 	cancelCalled   bool
+	lastDeployReq  *models.Deployment
 }
 
 func (f *fakeDeploymentAdapter) Platform() string { return "local" }
@@ -35,6 +36,7 @@ func (f *fakeDeploymentAdapter) SupportedResourceTypes() []string {
 }
 func (f *fakeDeploymentAdapter) Deploy(_ context.Context, req *models.Deployment) (*models.Deployment, error) {
 	f.deployCalled = true
+	f.lastDeployReq = req
 	return &models.Deployment{
 		ID:           "adapter-dep-1",
 		ServerName:   req.ServerName,
@@ -45,6 +47,50 @@ func (f *fakeDeploymentAdapter) Deploy(_ context.Context, req *models.Deployment
 		Origin:       "managed",
 		Config:       req.Config,
 	}, nil
+}
+
+func TestCreateDeployment_PassesEnvAndProviderConfigSeparately(t *testing.T) {
+	reg := servicetesting.NewFakeRegistry()
+	reg.GetProviderByIDFn = func(ctx context.Context, providerID string) (*models.Provider, error) {
+		return &models.Provider{ID: providerID, Platform: "local"}, nil
+	}
+
+	adapter := &fakeDeploymentAdapter{}
+
+	mux := http.NewServeMux()
+	api := humago.New(mux, huma.DefaultConfig("Test API", "1.0.0"))
+	v0.RegisterDeploymentsEndpoints(api, "/v0", reg, v0.PlatformExtensions{
+		ProviderPlatforms: v0.DefaultProviderPlatformAdapters(reg),
+		DeploymentPlatforms: map[string]registrytypes.DeploymentPlatformAdapter{
+			"local": adapter,
+		},
+	})
+
+	body := map[string]any{
+		"serverName":   "io.github.user/weather",
+		"version":      "1.0.0",
+		"resourceType": "mcp",
+		"providerId":   "local",
+		"env": map[string]string{
+			"API_KEY": "abc",
+		},
+		"providerConfig": map[string]any{
+			"securityGroupId": "sg-123",
+		},
+	}
+	payload, err := json.Marshal(body)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/v0/deployments", bytes.NewReader(payload))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.True(t, adapter.deployCalled)
+	require.NotNil(t, adapter.lastDeployReq)
+	assert.Equal(t, "abc", adapter.lastDeployReq.Config["API_KEY"])
+	assert.Equal(t, "sg-123", adapter.lastDeployReq.ProviderConfig["securityGroupId"])
 }
 func (f *fakeDeploymentAdapter) Undeploy(_ context.Context, _ *models.Deployment) error {
 	f.undeployCalled = true

--- a/internal/registry/api/handlers/v0/extensions.go
+++ b/internal/registry/api/handlers/v0/extensions.go
@@ -1,0 +1,26 @@
+package v0
+
+import registrytypes "github.com/agentregistry-dev/agentregistry/pkg/types"
+
+// PlatformExtensions holds optional deployment adapter registries.
+// Provider CRUD is now fully service/DB-backed.
+type PlatformExtensions struct {
+	ProviderPlatforms   map[string]registrytypes.ProviderPlatformAdapter
+	DeploymentPlatforms map[string]registrytypes.DeploymentPlatformAdapter
+}
+
+func (e PlatformExtensions) ResolveProviderAdapter(platform string) (registrytypes.ProviderPlatformAdapter, bool) {
+	if e.ProviderPlatforms == nil {
+		return nil, false
+	}
+	adapter, ok := e.ProviderPlatforms[platform]
+	return adapter, ok
+}
+
+func (e PlatformExtensions) ResolveDeploymentAdapter(platform string) (registrytypes.DeploymentPlatformAdapter, bool) {
+	if e.DeploymentPlatforms == nil {
+		return nil, false
+	}
+	adapter, ok := e.DeploymentPlatforms[platform]
+	return adapter, ok
+}

--- a/internal/registry/api/handlers/v0/provider_adapters.go
+++ b/internal/registry/api/handlers/v0/provider_adapters.go
@@ -1,0 +1,98 @@
+package v0
+
+import (
+	"context"
+	"errors"
+
+	"github.com/agentregistry-dev/agentregistry/internal/registry/service"
+	"github.com/agentregistry-dev/agentregistry/pkg/models"
+	"github.com/agentregistry-dev/agentregistry/pkg/registry/database"
+	registrytypes "github.com/agentregistry-dev/agentregistry/pkg/types"
+)
+
+type providerAdapterBase struct {
+	providerPlatform string
+	registry         service.RegistryService
+}
+
+func (a *providerAdapterBase) Platform() string {
+	return a.providerPlatform
+}
+
+func (a *providerAdapterBase) ListProviders(ctx context.Context) ([]*models.Provider, error) {
+	platform := a.providerPlatform
+	return a.registry.ListProviders(ctx, &platform)
+}
+
+func (a *providerAdapterBase) CreateProvider(ctx context.Context, in *models.CreateProviderInput) (*models.Provider, error) {
+	if in == nil {
+		return nil, database.ErrInvalidInput
+	}
+	if in.Platform != a.providerPlatform {
+		return nil, database.ErrInvalidInput
+	}
+	return a.registry.CreateProvider(ctx, in)
+}
+
+func (a *providerAdapterBase) GetProvider(ctx context.Context, providerID string) (*models.Provider, error) {
+	provider, err := a.registry.GetProviderByID(ctx, providerID)
+	if err != nil {
+		return nil, err
+	}
+	if provider == nil || provider.Platform != a.providerPlatform {
+		return nil, database.ErrNotFound
+	}
+	return provider, nil
+}
+
+func (a *providerAdapterBase) UpdateProvider(ctx context.Context, providerID string, in *models.UpdateProviderInput) (*models.Provider, error) {
+	provider, err := a.GetProvider(ctx, providerID)
+	if err != nil {
+		return nil, err
+	}
+	updated, err := a.registry.UpdateProvider(ctx, provider.ID, in)
+	if err != nil {
+		return nil, err
+	}
+	if updated.Platform != a.providerPlatform {
+		return nil, errors.New("updated provider platform mismatch")
+	}
+	return updated, nil
+}
+
+func (a *providerAdapterBase) DeleteProvider(ctx context.Context, providerID string) error {
+	if _, err := a.GetProvider(ctx, providerID); err != nil {
+		return err
+	}
+	return a.registry.DeleteProvider(ctx, providerID)
+}
+
+type localProviderAdapter struct {
+	providerAdapterBase
+}
+
+type kubernetesProviderAdapter struct {
+	providerAdapterBase
+}
+
+// NOTE: local and kubernetes currently share the same adapter base behavior.
+// Provider CRUD remains extension-driven, and these concrete adapter types are
+// kept explicit so platform-specific validation can diverge later if needed.
+
+// DefaultProviderPlatformAdapters returns OSS provider adapters for local and kubernetes.
+func DefaultProviderPlatformAdapters(registry service.RegistryService) map[string]registrytypes.ProviderPlatformAdapter {
+	return map[string]registrytypes.ProviderPlatformAdapter{
+		"local": &localProviderAdapter{
+			providerAdapterBase: providerAdapterBase{
+				providerPlatform: "local",
+				registry:         registry,
+			},
+		},
+		"kubernetes": &kubernetesProviderAdapter{
+			providerAdapterBase: providerAdapterBase{
+				providerPlatform: "kubernetes",
+				registry:         registry,
+			},
+		},
+	}
+}

--- a/internal/registry/api/handlers/v0/providers.go
+++ b/internal/registry/api/handlers/v0/providers.go
@@ -1,0 +1,269 @@
+package v0
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"sort"
+	"strings"
+
+	"github.com/agentregistry-dev/agentregistry/internal/registry/service"
+	"github.com/agentregistry-dev/agentregistry/pkg/models"
+	"github.com/agentregistry-dev/agentregistry/pkg/registry/database"
+	"github.com/danielgtaylor/huma/v2"
+)
+
+type ProviderListInput struct {
+	Platform string `query:"platform" json:"platform,omitempty" doc:"Filter providers by platform type (local, kubernetes)"`
+}
+
+type ProviderByIDInput struct {
+	ProviderID string `path:"providerId" json:"providerId" doc:"Provider ID"`
+	Platform   string `query:"platform" json:"platform,omitempty" doc:"Provider platform hint (optional)"`
+}
+
+type CreateProviderRequest struct {
+	Body models.CreateProviderInput
+}
+
+type UpdateProviderRequest struct {
+	ProviderID string `path:"providerId" json:"providerId" doc:"Provider ID"`
+	Platform   string `query:"platform" json:"platform,omitempty" doc:"Provider platform hint (optional)"`
+	Body       models.UpdateProviderInput
+}
+
+type ProvidersListResponse struct {
+	Body struct {
+		Providers []models.Provider `json:"providers"`
+		Count     int               `json:"count"`
+	}
+}
+
+type ProviderResponse struct {
+	Body models.Provider
+}
+
+func adapterPlatformKeys(extensions PlatformExtensions) []string {
+	if len(extensions.ProviderPlatforms) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(extensions.ProviderPlatforms))
+	for platform := range extensions.ProviderPlatforms {
+		keys = append(keys, platform)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func unsupportedProviderPlatformError(platform string) error {
+	p := strings.TrimSpace(platform)
+	if p == "" {
+		p = "unknown"
+	}
+	return huma.Error400BadRequest("Provider platform is not supported: " + p)
+}
+
+func getProviderByID(ctx context.Context, registry service.RegistryService, extensions PlatformExtensions, providerID, platformHint string) (*models.Provider, error) {
+	if platformHint != "" {
+		platform := strings.ToLower(strings.TrimSpace(platformHint))
+		adapter, ok := extensions.ResolveProviderAdapter(platform)
+		if !ok {
+			return nil, unsupportedProviderPlatformError(platform)
+		}
+		provider, err := adapter.GetProvider(ctx, providerID)
+		if err == nil && provider != nil {
+			return provider, nil
+		}
+		if err != nil {
+			if errors.Is(err, database.ErrNotFound) {
+				return nil, huma.Error404NotFound("Provider not found")
+			}
+			return nil, huma.Error500InternalServerError("Failed to get provider", err)
+		}
+		return nil, huma.Error404NotFound("Provider not found")
+	}
+
+	for _, platform := range adapterPlatformKeys(extensions) {
+		adapter, ok := extensions.ResolveProviderAdapter(platform)
+		if !ok {
+			continue
+		}
+		provider, err := adapter.GetProvider(ctx, providerID)
+		if err == nil && provider != nil {
+			return provider, nil
+		}
+		if err != nil && !errors.Is(err, database.ErrNotFound) {
+			return nil, huma.Error500InternalServerError("Failed to get provider", err)
+		}
+	}
+
+	// Determine whether the provider exists but has an unsupported platform.
+	provider, err := registry.GetProviderByID(ctx, providerID)
+	if err == nil && provider != nil {
+		return nil, unsupportedProviderPlatformError(provider.Platform)
+	}
+	if err != nil && !errors.Is(err, database.ErrNotFound) {
+		return nil, huma.Error500InternalServerError("Failed to get provider", err)
+	}
+
+	return nil, huma.Error404NotFound("Provider not found")
+}
+
+// RegisterProvidersEndpoints registers provider CRUD endpoints.
+func RegisterProvidersEndpoints(api huma.API, basePath string, registry service.RegistryService, extensions PlatformExtensions) {
+	huma.Register(api, huma.Operation{
+		OperationID: "list-providers",
+		Method:      http.MethodGet,
+		Path:        basePath + "/providers",
+		Summary:     "List providers",
+		Description: "List configured deployment target providers.",
+		Tags:        []string{"providers"},
+	}, func(ctx context.Context, input *ProviderListInput) (*ProvidersListResponse, error) {
+		resp := &ProvidersListResponse{}
+		resp.Body.Providers = []models.Provider{}
+
+		seen := make(map[string]struct{})
+		appendProvider := func(p *models.Provider) {
+			if p == nil {
+				return
+			}
+			if _, ok := seen[p.ID]; ok {
+				return
+			}
+			seen[p.ID] = struct{}{}
+			resp.Body.Providers = append(resp.Body.Providers, *p)
+		}
+
+		if input.Platform != "" {
+			platform := strings.ToLower(strings.TrimSpace(input.Platform))
+			adapter, ok := extensions.ResolveProviderAdapter(platform)
+			if !ok {
+				return nil, unsupportedProviderPlatformError(platform)
+			}
+			providers, err := adapter.ListProviders(ctx)
+			if err != nil {
+				return nil, huma.Error500InternalServerError("Failed to list providers", err)
+			}
+			for _, p := range providers {
+				appendProvider(p)
+			}
+		} else {
+			for _, platform := range adapterPlatformKeys(extensions) {
+				adapter, ok := extensions.ResolveProviderAdapter(platform)
+				if !ok {
+					continue
+				}
+				providers, err := adapter.ListProviders(ctx)
+				if err != nil {
+					return nil, huma.Error500InternalServerError("Failed to list providers", err)
+				}
+				for _, p := range providers {
+					appendProvider(p)
+				}
+			}
+		}
+		resp.Body.Count = len(resp.Body.Providers)
+		return resp, nil
+	})
+
+	huma.Register(api, huma.Operation{
+		OperationID: "create-provider",
+		Method:      http.MethodPost,
+		Path:        basePath + "/providers",
+		Summary:     "Create provider",
+		Description: "Create a deployment target provider for a specific platform type.",
+		Tags:        []string{"providers"},
+	}, func(ctx context.Context, input *CreateProviderRequest) (*ProviderResponse, error) {
+		if input.Body.Platform == "" {
+			return nil, huma.Error400BadRequest("platform is required")
+		}
+
+		platform := strings.ToLower(strings.TrimSpace(input.Body.Platform))
+		input.Body.Platform = platform
+		adapter, ok := extensions.ResolveProviderAdapter(platform)
+		if !ok {
+			return nil, unsupportedProviderPlatformError(platform)
+		}
+		provider, err := adapter.CreateProvider(ctx, &input.Body)
+		if err != nil {
+			if errors.Is(err, database.ErrAlreadyExists) {
+				return nil, huma.Error409Conflict("Provider already exists")
+			}
+			if errors.Is(err, database.ErrInvalidInput) {
+				return nil, huma.Error400BadRequest("Invalid provider input")
+			}
+			return nil, huma.Error500InternalServerError("Failed to create provider", err)
+		}
+		return &ProviderResponse{Body: *provider}, nil
+	})
+
+	huma.Register(api, huma.Operation{
+		OperationID: "get-provider",
+		Method:      http.MethodGet,
+		Path:        basePath + "/providers/{providerId}",
+		Summary:     "Get provider",
+		Description: "Get a provider by ID.",
+		Tags:        []string{"providers"},
+	}, func(ctx context.Context, input *ProviderByIDInput) (*ProviderResponse, error) {
+		provider, err := getProviderByID(ctx, registry, extensions, input.ProviderID, input.Platform)
+		if err != nil {
+			return nil, err
+		}
+		return &ProviderResponse{Body: *provider}, nil
+	})
+
+	huma.Register(api, huma.Operation{
+		OperationID: "update-provider",
+		Method:      http.MethodPut,
+		Path:        basePath + "/providers/{providerId}",
+		Summary:     "Update provider",
+		Description: "Update mutable fields of a provider by ID.",
+		Tags:        []string{"providers"},
+	}, func(ctx context.Context, input *UpdateProviderRequest) (*ProviderResponse, error) {
+		provider, err := getProviderByID(ctx, registry, extensions, input.ProviderID, input.Platform)
+		if err != nil {
+			return nil, err
+		}
+
+		platform := strings.ToLower(strings.TrimSpace(provider.Platform))
+		adapter, ok := extensions.ResolveProviderAdapter(platform)
+		if !ok {
+			return nil, unsupportedProviderPlatformError(platform)
+		}
+		updated, err := adapter.UpdateProvider(ctx, input.ProviderID, &input.Body)
+		if err != nil {
+			if errors.Is(err, database.ErrNotFound) {
+				return nil, huma.Error404NotFound("Provider not found")
+			}
+			return nil, huma.Error500InternalServerError("Failed to update provider", err)
+		}
+		return &ProviderResponse{Body: *updated}, nil
+	})
+
+	huma.Register(api, huma.Operation{
+		OperationID: "delete-provider",
+		Method:      http.MethodDelete,
+		Path:        basePath + "/providers/{providerId}",
+		Summary:     "Delete provider",
+		Description: "Delete a provider by ID.",
+		Tags:        []string{"providers"},
+	}, func(ctx context.Context, input *ProviderByIDInput) (*struct{}, error) {
+		provider, err := getProviderByID(ctx, registry, extensions, input.ProviderID, input.Platform)
+		if err != nil {
+			return nil, err
+		}
+		platform := strings.ToLower(strings.TrimSpace(provider.Platform))
+		adapter, ok := extensions.ResolveProviderAdapter(platform)
+		if !ok {
+			return nil, unsupportedProviderPlatformError(platform)
+		}
+		err = adapter.DeleteProvider(ctx, input.ProviderID)
+		if err != nil {
+			if errors.Is(err, database.ErrNotFound) {
+				return nil, huma.Error404NotFound("Provider not found")
+			}
+			return nil, huma.Error500InternalServerError("Failed to delete provider", err)
+		}
+		return &struct{}{}, nil
+	})
+}

--- a/internal/registry/api/handlers/v0/providers_test.go
+++ b/internal/registry/api/handlers/v0/providers_test.go
@@ -1,0 +1,198 @@
+package v0_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	v0 "github.com/agentregistry-dev/agentregistry/internal/registry/api/handlers/v0"
+	servicetesting "github.com/agentregistry-dev/agentregistry/internal/registry/service/testing"
+	"github.com/agentregistry-dev/agentregistry/pkg/models"
+	"github.com/agentregistry-dev/agentregistry/pkg/registry/database"
+	registrytypes "github.com/agentregistry-dev/agentregistry/pkg/types"
+	"github.com/danielgtaylor/huma/v2"
+	"github.com/danielgtaylor/huma/v2/adapters/humago"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeProviderAdapter struct {
+	platform  string
+	providers map[string]*models.Provider
+}
+
+func (f *fakeProviderAdapter) Platform() string { return f.platform }
+
+func (f *fakeProviderAdapter) ListProviders(_ context.Context) ([]*models.Provider, error) {
+	out := make([]*models.Provider, 0, len(f.providers))
+	for _, p := range f.providers {
+		out = append(out, p)
+	}
+	return out, nil
+}
+
+func (f *fakeProviderAdapter) CreateProvider(_ context.Context, in *models.CreateProviderInput) (*models.Provider, error) {
+	p := &models.Provider{ID: "kubernetes-1", Name: in.Name, Platform: in.Platform, Config: in.Config}
+	if in.ID != "" {
+		p.ID = in.ID
+	}
+	f.providers[p.ID] = p
+	return p, nil
+}
+
+func (f *fakeProviderAdapter) GetProvider(_ context.Context, providerID string) (*models.Provider, error) {
+	p, ok := f.providers[providerID]
+	if !ok {
+		return nil, database.ErrNotFound
+	}
+	return p, nil
+}
+
+func (f *fakeProviderAdapter) UpdateProvider(_ context.Context, providerID string, in *models.UpdateProviderInput) (*models.Provider, error) {
+	p, ok := f.providers[providerID]
+	if !ok {
+		return nil, database.ErrNotFound
+	}
+	if in.Name != nil {
+		p.Name = *in.Name
+	}
+	if in.Config != nil {
+		p.Config = in.Config
+	}
+	return p, nil
+}
+
+func (f *fakeProviderAdapter) DeleteProvider(_ context.Context, providerID string) error {
+	if _, ok := f.providers[providerID]; !ok {
+		return database.ErrNotFound
+	}
+	delete(f.providers, providerID)
+	return nil
+}
+
+func TestListProviders_EmptyReturnsEmpty(t *testing.T) {
+	mux := http.NewServeMux()
+	api := humago.New(mux, huma.DefaultConfig("Test API", "1.0.0"))
+	fake := servicetesting.NewFakeRegistry()
+	kubernetesAdapter := &fakeProviderAdapter{platform: "kubernetes", providers: map[string]*models.Provider{}}
+	v0.RegisterProvidersEndpoints(api, "/v0", fake, v0.PlatformExtensions{
+		ProviderPlatforms: map[string]registrytypes.ProviderPlatformAdapter{
+			"kubernetes": kubernetesAdapter,
+		},
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/v0/providers", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), `"providers":[]`)
+	assert.Contains(t, w.Body.String(), `"count":0`)
+}
+
+func TestCreateAndGetProvider(t *testing.T) {
+	mux := http.NewServeMux()
+	api := humago.New(mux, huma.DefaultConfig("Test API", "1.0.0"))
+	fake := servicetesting.NewFakeRegistry()
+
+	fake.CreateProviderFn = func(_ context.Context, in *models.CreateProviderInput) (*models.Provider, error) {
+		return &models.Provider{
+			ID:       "kubernetes-1",
+			Name:     in.Name,
+			Platform: in.Platform,
+			Config:   in.Config,
+		}, nil
+	}
+	fake.GetProviderByIDFn = func(_ context.Context, providerID string) (*models.Provider, error) {
+		if providerID != "kubernetes-1" {
+			return nil, database.ErrNotFound
+		}
+		return &models.Provider{ID: "kubernetes-1", Name: "prod-account", Platform: "kubernetes"}, nil
+	}
+	kubernetesAdapter := &fakeProviderAdapter{platform: "kubernetes", providers: map[string]*models.Provider{}}
+	v0.RegisterProvidersEndpoints(api, "/v0", fake, v0.PlatformExtensions{
+		ProviderPlatforms: map[string]registrytypes.ProviderPlatformAdapter{
+			"kubernetes": kubernetesAdapter,
+		},
+	})
+
+	createBody := map[string]any{
+		"name":     "prod-account",
+		"platform": "kubernetes",
+		"config": map[string]any{
+			"region": "us-east-1",
+		},
+	}
+	payload, err := json.Marshal(createBody)
+	require.NoError(t, err)
+
+	createReq := httptest.NewRequest(http.MethodPost, "/v0/providers", bytes.NewReader(payload))
+	createReq.Header.Set("Content-Type", "application/json")
+	createW := httptest.NewRecorder()
+	mux.ServeHTTP(createW, createReq)
+
+	require.Equal(t, http.StatusOK, createW.Code)
+	assert.Contains(t, createW.Body.String(), `"platform":"kubernetes"`)
+	assert.Contains(t, createW.Body.String(), `"name":"prod-account"`)
+	assert.Contains(t, createW.Body.String(), `"id":"kubernetes-1"`)
+
+	getReq := httptest.NewRequest(http.MethodGet, "/v0/providers/kubernetes-1", nil)
+	getW := httptest.NewRecorder()
+	mux.ServeHTTP(getW, getReq)
+
+	require.Equal(t, http.StatusOK, getW.Code)
+	assert.Contains(t, getW.Body.String(), `"id":"kubernetes-1"`)
+	assert.Contains(t, getW.Body.String(), `"platform":"kubernetes"`)
+}
+
+func TestListProviders_WithData(t *testing.T) {
+	mux := http.NewServeMux()
+	api := humago.New(mux, huma.DefaultConfig("Test API", "1.0.0"))
+	fake := servicetesting.NewFakeRegistry()
+	localAdapter := &fakeProviderAdapter{
+		platform: "local",
+		providers: map[string]*models.Provider{
+			"local": {ID: "local", Name: "Local", Platform: "local"},
+		},
+	}
+	k8sAdapter := &fakeProviderAdapter{
+		platform: "kubernetes",
+		providers: map[string]*models.Provider{
+			"kubernetes-default": {ID: "kubernetes-default", Name: "Kubernetes Default", Platform: "kubernetes"},
+		},
+	}
+	v0.RegisterProvidersEndpoints(api, "/v0", fake, v0.PlatformExtensions{
+		ProviderPlatforms: map[string]registrytypes.ProviderPlatformAdapter{
+			"local":      localAdapter,
+			"kubernetes": k8sAdapter,
+		},
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/v0/providers", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), `"id":"local"`)
+	assert.Contains(t, w.Body.String(), `"platform":"local"`)
+	assert.Contains(t, w.Body.String(), `"id":"kubernetes-default"`)
+	assert.Contains(t, w.Body.String(), `"platform":"kubernetes"`)
+}
+
+func TestDeleteProvider_NotFound(t *testing.T) {
+	mux := http.NewServeMux()
+	api := humago.New(mux, huma.DefaultConfig("Test API", "1.0.0"))
+	fake := servicetesting.NewFakeRegistry()
+	fake.DeleteProviderFn = func(_ context.Context, providerID string) error {
+		return database.ErrNotFound
+	}
+	v0.RegisterProvidersEndpoints(api, "/v0", fake, v0.PlatformExtensions{})
+	req := httptest.NewRequest(http.MethodDelete, "/v0/providers/missing", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}

--- a/internal/registry/api/router/router.go
+++ b/internal/registry/api/router/router.go
@@ -161,6 +161,10 @@ func NewHumaAPI(cfg *config.Config, registry service.RegistryService, mux *http.
 			Description: "Operations for discovering and retrieving Agentic skills",
 		},
 		{
+			Name:        "providers",
+			Description: "Operations for managing deployment provider instances",
+		},
+		{
 			Name:        "publish",
 			Description: "Operations for publishing MCP servers to the registry",
 		},

--- a/internal/registry/api/router/v0.go
+++ b/internal/registry/api/router/v0.go
@@ -4,6 +4,7 @@ package router
 import (
 	"net/http"
 
+	registrytypes "github.com/agentregistry-dev/agentregistry/pkg/types"
 	"github.com/danielgtaylor/huma/v2"
 
 	v0 "github.com/agentregistry-dev/agentregistry/internal/registry/api/handlers/v0"
@@ -19,6 +20,10 @@ type RouteOptions struct {
 	Indexer    service.Indexer
 	JobManager *jobs.Manager
 	Mux        *http.ServeMux
+
+	// Optional deployment adapters keyed by provider platform type.
+	ProviderPlatforms   map[string]registrytypes.ProviderPlatformAdapter
+	DeploymentPlatforms map[string]registrytypes.DeploymentPlatformAdapter
 }
 
 // RegisterRoutes registers all API routes under /v0.
@@ -39,7 +44,13 @@ func RegisterRoutes(
 	v0.RegisterServersCreateEndpoint(api, pathPrefix, registry)
 	v0.RegisterEditEndpoints(api, pathPrefix, registry)
 	v0auth.RegisterAuthEndpoints(api, pathPrefix, cfg)
-	v0.RegisterDeploymentsEndpoints(api, pathPrefix, registry)
+	platformExt := v0.PlatformExtensions{}
+	if opts != nil {
+		platformExt.ProviderPlatforms = opts.ProviderPlatforms
+		platformExt.DeploymentPlatforms = opts.DeploymentPlatforms
+	}
+	v0.RegisterProvidersEndpoints(api, pathPrefix, registry, platformExt)
+	v0.RegisterDeploymentsEndpoints(api, pathPrefix, registry, platformExt)
 	v0.RegisterAgentsEndpoints(api, pathPrefix, registry)
 	v0.RegisterAgentsCreateEndpoint(api, pathPrefix, registry)
 	v0.RegisterSkillsEndpoints(api, pathPrefix, registry)

--- a/internal/registry/client_test.go
+++ b/internal/registry/client_test.go
@@ -14,6 +14,7 @@ func TestNewClient(t *testing.T) {
 
 	if client == nil {
 		t.Fatal("NewClient() returned nil")
+		return
 	}
 
 	if client.HTTPClient == nil {

--- a/internal/registry/database/migrations/001_initial_schema.sql
+++ b/internal/registry/database/migrations/001_initial_schema.sql
@@ -253,8 +253,8 @@ CREATE TABLE deployments (
     -- Resource type (mcp server or agent)
     resource_type VARCHAR(50) NOT NULL DEFAULT 'mcp',
     
-    -- Runtime target
-    runtime VARCHAR(50) NOT NULL DEFAULT 'local',
+    -- Deployment platform type
+    provider VARCHAR(50) NOT NULL DEFAULT 'local',
     
     -- Primary key
     CONSTRAINT deployments_pkey PRIMARY KEY (server_name, version)
@@ -266,7 +266,7 @@ CREATE INDEX idx_deployments_status ON deployments (status);
 CREATE INDEX idx_deployments_deployed_at ON deployments (deployed_at DESC);
 CREATE INDEX idx_deployments_updated_at ON deployments (updated_at DESC);
 CREATE INDEX idx_deployments_resource_type ON deployments (resource_type);
-CREATE INDEX idx_deployments_runtime ON deployments (runtime);
+CREATE INDEX idx_deployments_provider ON deployments (provider);
 
 -- GIN index for config JSONB queries
 CREATE INDEX idx_deployments_config_gin ON deployments USING GIN(config);
@@ -298,12 +298,12 @@ ALTER TABLE deployments ADD CONSTRAINT check_deployment_version_not_empty
 ALTER TABLE deployments ADD CONSTRAINT check_deployment_resource_type_valid
     CHECK (resource_type IN ('mcp', 'agent'));
 
-ALTER TABLE deployments ADD CONSTRAINT check_deployment_runtime_valid
-    CHECK (runtime IN ('local', 'kubernetes'));
+ALTER TABLE deployments ADD CONSTRAINT check_deployment_provider_valid
+    CHECK (provider IN ('local', 'kubernetes'));
 
 -- Add comments for documentation
 COMMENT ON COLUMN deployments.resource_type IS 'Type of resource deployed: mcp (MCP server) or agent';
-COMMENT ON COLUMN deployments.runtime IS 'Deployment runtime target: local or kubernetes';
+COMMENT ON COLUMN deployments.provider IS 'Deployment platform type: local or kubernetes';
 
 -- =============================================================================
 -- SERVER_READMES TABLE

--- a/internal/registry/database/migrations/004_unified_deployments_provider.sql
+++ b/internal/registry/database/migrations/004_unified_deployments_provider.sql
@@ -1,0 +1,47 @@
+-- Evolve OSS deployments toward unified provider-based model.
+-- Keeps existing columns for compatibility while introducing stable IDs
+-- and provider/origin metadata needed by enterprise extension points.
+
+ALTER TABLE deployments ADD COLUMN IF NOT EXISTS id TEXT;
+ALTER TABLE deployments ADD COLUMN IF NOT EXISTS provider VARCHAR(50);
+ALTER TABLE deployments ADD COLUMN IF NOT EXISTS origin VARCHAR(50) NOT NULL DEFAULT 'managed';
+ALTER TABLE deployments ADD COLUMN IF NOT EXISTS connection_id TEXT;
+ALTER TABLE deployments ADD COLUMN IF NOT EXISTS region TEXT;
+ALTER TABLE deployments ADD COLUMN IF NOT EXISTS cloud_resource_id TEXT;
+ALTER TABLE deployments ADD COLUMN IF NOT EXISTS cloud_metadata JSONB DEFAULT '{}'::jsonb;
+ALTER TABLE deployments ADD COLUMN IF NOT EXISTS deployed_by TEXT DEFAULT '';
+ALTER TABLE deployments ADD COLUMN IF NOT EXISTS error TEXT DEFAULT '';
+
+-- Backfill IDs and provider for existing rows.
+UPDATE deployments SET id = COALESCE(id, uuid_generate_v4()::text) WHERE id IS NULL OR id = '';
+UPDATE deployments SET provider = 'local' WHERE provider = 'docker';
+UPDATE deployments SET provider = COALESCE(NULLIF(provider, ''), 'local')
+WHERE provider IS NULL OR provider = '';
+
+-- Ensure ID exists and is unique.
+ALTER TABLE deployments ALTER COLUMN id SET NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_deployments_id ON deployments (id);
+
+-- Enforce provider/origin values.
+ALTER TABLE deployments ALTER COLUMN provider SET NOT NULL;
+ALTER TABLE deployments DROP CONSTRAINT IF EXISTS check_deployment_provider_valid;
+ALTER TABLE deployments ADD CONSTRAINT check_deployment_provider_valid
+    CHECK (provider IN ('local', 'kubernetes', 'gcp', 'aws'));
+ALTER TABLE deployments DROP CONSTRAINT IF EXISTS check_deployment_origin_valid;
+ALTER TABLE deployments ADD CONSTRAINT check_deployment_origin_valid
+    CHECK (origin IN ('managed', 'discovered'));
+
+-- Extend status vocabulary for unified async/cloud semantics.
+ALTER TABLE deployments DROP CONSTRAINT IF EXISTS check_deployment_status_valid;
+ALTER TABLE deployments ADD CONSTRAINT check_deployment_status_valid
+    CHECK (status IN ('active', 'deploying', 'deployed', 'failed', 'cancelled', 'discovered', 'stopped'));
+
+-- New indexes for provider/discovery queries.
+CREATE INDEX IF NOT EXISTS idx_deployments_provider ON deployments (provider);
+CREATE INDEX IF NOT EXISTS idx_deployments_origin ON deployments (origin);
+CREATE INDEX IF NOT EXISTS idx_deployments_connection_id ON deployments (connection_id);
+CREATE INDEX IF NOT EXISTS idx_deployments_cloud_resource_id ON deployments (cloud_resource_id);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_deployments_cloud_identity
+    ON deployments (connection_id, cloud_resource_id)
+    WHERE cloud_resource_id IS NOT NULL AND cloud_resource_id <> '';
+

--- a/internal/registry/database/migrations/005_drop_deployments_runtime_column.sql
+++ b/internal/registry/database/migrations/005_drop_deployments_runtime_column.sql
@@ -1,0 +1,5 @@
+-- Remove legacy runtime column now that provider is the only deployment discriminator.
+
+DROP INDEX IF EXISTS idx_deployments_runtime;
+ALTER TABLE deployments DROP CONSTRAINT IF EXISTS check_deployment_runtime_valid;
+ALTER TABLE deployments DROP COLUMN IF EXISTS runtime;

--- a/internal/registry/database/migrations/006_providers_table_and_deployment_provider_fk.sql
+++ b/internal/registry/database/migrations/006_providers_table_and_deployment_provider_fk.sql
@@ -1,0 +1,65 @@
+-- Introduce first-class providers and make deployments reference providers by ID.
+
+CREATE TABLE IF NOT EXISTS providers (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    platform VARCHAR(50) NOT NULL,
+    config JSONB NOT NULL DEFAULT '{}'::jsonb,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT check_provider_platform_valid CHECK (platform IN ('local', 'kubernetes', 'gcp', 'aws'))
+);
+
+INSERT INTO providers (id, name, platform, config)
+VALUES
+    ('local', 'Local', 'local', '{}'::jsonb),
+    ('kubernetes-default', 'Kubernetes Default', 'kubernetes', '{}'::jsonb)
+ON CONFLICT (id) DO NOTHING;
+
+ALTER TABLE deployments ADD COLUMN IF NOT EXISTS provider_id TEXT;
+
+UPDATE deployments
+SET provider_id = NULLIF(connection_id, '')
+WHERE provider_id IS NULL AND connection_id IS NOT NULL;
+
+INSERT INTO providers (id, name, platform, config)
+SELECT DISTINCT
+    d.provider_id,
+    d.provider_id,
+    COALESCE(NULLIF(TRIM(d.provider), ''), 'local'),
+    '{}'::jsonb
+FROM deployments d
+WHERE d.provider_id IS NOT NULL
+  AND d.provider_id <> ''
+ON CONFLICT (id) DO NOTHING;
+
+UPDATE deployments
+SET provider_id = 'local'
+WHERE provider_id IS NULL OR provider_id = '';
+
+ALTER TABLE deployments
+    ALTER COLUMN provider_id SET DEFAULT 'local',
+    ALTER COLUMN provider_id SET NOT NULL;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = 'fk_deployments_provider_id'
+    ) THEN
+        ALTER TABLE deployments
+            ADD CONSTRAINT fk_deployments_provider_id
+            FOREIGN KEY (provider_id) REFERENCES providers(id) ON DELETE RESTRICT;
+    END IF;
+END $$;
+
+DROP INDEX IF EXISTS idx_deployments_connection_id;
+DROP INDEX IF EXISTS idx_deployments_connection_resource;
+CREATE INDEX IF NOT EXISTS idx_deployments_provider_id ON deployments (provider_id);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_deployments_provider_resource
+    ON deployments (provider_id, cloud_resource_id)
+    WHERE provider_id IS NOT NULL AND cloud_resource_id IS NOT NULL;
+
+ALTER TABLE deployments DROP COLUMN IF EXISTS connection_id;
+ALTER TABLE deployments DROP COLUMN IF EXISTS provider;

--- a/internal/registry/registry_app.go
+++ b/internal/registry/registry_app.go
@@ -130,6 +130,32 @@ func App(_ context.Context, opts ...types.AppOptions) error {
 		registryService = baseRegistryService
 	}
 
+	// Initialize extension registries once and use them for both routing and service behavior.
+	providerPlatforms := v0.DefaultProviderPlatformAdapters(registryService)
+	for platform, adapter := range options.ProviderPlatforms {
+		providerPlatforms[platform] = adapter
+	}
+	deploymentPlatforms := v0.DefaultDeploymentPlatformAdapters(registryService)
+	for platform, adapter := range options.DeploymentPlatforms {
+		deploymentPlatforms[platform] = adapter
+	}
+
+	type platformAdapterConfigurer interface {
+		SetPlatformAdapters(
+			map[string]service.DeploymentPlatformDeployer,
+		)
+	}
+	deploymentDeployers := make(map[string]service.DeploymentPlatformDeployer, len(deploymentPlatforms))
+	for platform, adapter := range deploymentPlatforms {
+		deploymentDeployers[platform] = adapter
+	}
+	if cfgSvc, ok := baseRegistryService.(platformAdapterConfigurer); ok {
+		cfgSvc.SetPlatformAdapters(deploymentDeployers)
+	}
+	if cfgSvc, ok := registryService.(platformAdapterConfigurer); ok {
+		cfgSvc.SetPlatformAdapters(deploymentDeployers)
+	}
+
 	if options.OnServiceCreated != nil {
 		options.OnServiceCreated(registryService)
 	}
@@ -205,15 +231,17 @@ func App(_ context.Context, opts ...types.AppOptions) error {
 		}
 	}
 
-	// Initialize job manager and indexer for embeddings
-	var routeOpts *router.RouteOptions
+	routeOpts := &router.RouteOptions{
+		ProviderPlatforms:   providerPlatforms,
+		DeploymentPlatforms: deploymentPlatforms,
+	}
+
+	// Initialize job manager and indexer for embeddings.
 	if cfg.Embeddings.Enabled && embeddingProvider != nil {
 		jobManager := jobs.NewManager()
 		indexer := service.NewIndexer(registryService, embeddingProvider, cfg.Embeddings.Dimensions)
-		routeOpts = &router.RouteOptions{
-			Indexer:    indexer,
-			JobManager: jobManager,
-		}
+		routeOpts.Indexer = indexer
+		routeOpts.JobManager = jobManager
 		log.Println("Embeddings indexing API enabled")
 	}
 

--- a/internal/registry/registry_app.go
+++ b/internal/registry/registry_app.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"maps"
 	"net/http"
 	"os"
 	"os/signal"
@@ -132,13 +133,9 @@ func App(_ context.Context, opts ...types.AppOptions) error {
 
 	// Initialize extension registries once and use them for both routing and service behavior.
 	providerPlatforms := v0.DefaultProviderPlatformAdapters(registryService)
-	for platform, adapter := range options.ProviderPlatforms {
-		providerPlatforms[platform] = adapter
-	}
+	maps.Copy(providerPlatforms, options.ProviderPlatforms)
 	deploymentPlatforms := v0.DefaultDeploymentPlatformAdapters(registryService)
-	for platform, adapter := range options.DeploymentPlatforms {
-		deploymentPlatforms[platform] = adapter
-	}
+	maps.Copy(deploymentPlatforms, options.DeploymentPlatforms)
 
 	type platformAdapterConfigurer interface {
 		SetPlatformAdapters(

--- a/internal/registry/service/service.go
+++ b/internal/registry/service/service.go
@@ -70,18 +70,27 @@ type RegistryService interface {
 	CreateSkill(ctx context.Context, req *models.SkillJSON) (*models.SkillResponse, error)
 
 	// Deployments APIs
+	// ListProviders retrieves deployment target providers, optionally filtered by provider platform type.
+	ListProviders(ctx context.Context, platform *string) ([]*models.Provider, error)
+	// GetProviderByID retrieves a provider by ID.
+	GetProviderByID(ctx context.Context, providerID string) (*models.Provider, error)
+	// CreateProvider creates a deployment target provider.
+	CreateProvider(ctx context.Context, in *models.CreateProviderInput) (*models.Provider, error)
+	// UpdateProvider updates mutable fields for a provider.
+	UpdateProvider(ctx context.Context, providerID string, in *models.UpdateProviderInput) (*models.Provider, error)
+	// DeleteProvider deletes a provider by ID.
+	DeleteProvider(ctx context.Context, providerID string) error
+
 	// GetDeployments retrieves all deployed resources (MCP servers, agents)
 	GetDeployments(ctx context.Context, filter *models.DeploymentFilter) ([]*models.Deployment, error)
-	// GetDeploymentByName retrieves a specific deployment by resource name
-	GetDeploymentByNameAndVersion(ctx context.Context, resourceName string, version string, artifactType string) (*models.Deployment, error)
+	// GetDeploymentByID retrieves a specific deployment by UUID.
+	GetDeploymentByID(ctx context.Context, id string) (*models.Deployment, error)
 	// DeployServer deploys an MCP server with configuration
-	DeployServer(ctx context.Context, serverName, version string, config map[string]string, preferRemote bool, runtime string) (*models.Deployment, error)
+	DeployServer(ctx context.Context, serverName, version string, config map[string]string, preferRemote bool, providerID string) (*models.Deployment, error)
 	// DeployAgent deploys an agent with configuration (to be implemented)
-	DeployAgent(ctx context.Context, agentName, version string, config map[string]string, preferRemote bool, runtime string) (*models.Deployment, error)
-	// UpdateDeploymentConfig updates the configuration for a deployment
-	UpdateDeploymentConfig(ctx context.Context, resourceName string, version string, artifactType string, config map[string]string) (*models.Deployment, error)
-	// RemoveDeployment removes a deployment (works for any resource type)
-	RemoveDeployment(ctx context.Context, resourceName string, version string, artifactType string) error
+	DeployAgent(ctx context.Context, agentName, version string, config map[string]string, preferRemote bool, providerID string) (*models.Deployment, error)
+	// RemoveDeploymentByID removes a deployment by UUID.
+	RemoveDeploymentByID(ctx context.Context, id string) error
 
 	Reconciler
 }

--- a/internal/registry/service/testing/fake_registry.go
+++ b/internal/registry/service/testing/fake_registry.go
@@ -32,42 +32,42 @@ type FakeRegistry struct {
 	UpsertAgentEmbeddingCalls  int
 
 	// Function hooks for custom behavior (take precedence over data fields when set)
-	ListServersFn                   func(ctx context.Context, filter *database.ServerFilter, cursor string, limit int) ([]*apiv0.ServerResponse, string, error)
-	GetServerByNameFn               func(ctx context.Context, serverName string) (*apiv0.ServerResponse, error)
-	GetServerByNameAndVersionFn     func(ctx context.Context, serverName, version string) (*apiv0.ServerResponse, error)
-	GetAllVersionsByServerNameFn    func(ctx context.Context, serverName string) ([]*apiv0.ServerResponse, error)
-	CreateServerFn                  func(ctx context.Context, req *apiv0.ServerJSON) (*apiv0.ServerResponse, error)
-	UpdateServerFn                  func(ctx context.Context, serverName, version string, req *apiv0.ServerJSON, newStatus *string) (*apiv0.ServerResponse, error)
-	StoreServerReadmeFn             func(ctx context.Context, serverName, version string, content []byte, contentType string) error
-	GetServerReadmeLatestFn         func(ctx context.Context, serverName string) (*database.ServerReadme, error)
-	GetServerReadmeByVersionFn      func(ctx context.Context, serverName, version string) (*database.ServerReadme, error)
-	DeleteServerFn                  func(ctx context.Context, serverName, version string) error
-	UpsertServerEmbeddingFn         func(ctx context.Context, serverName, version string, embedding *database.SemanticEmbedding) error
-	GetServerEmbeddingMetadataFn    func(ctx context.Context, serverName, version string) (*database.SemanticEmbeddingMetadata, error)
-	ListAgentsFn                    func(ctx context.Context, filter *database.AgentFilter, cursor string, limit int) ([]*models.AgentResponse, string, error)
-	GetAgentByNameFn                func(ctx context.Context, agentName string) (*models.AgentResponse, error)
-	GetAgentByNameAndVersionFn      func(ctx context.Context, agentName, version string) (*models.AgentResponse, error)
-	GetAllVersionsByAgentNameFn     func(ctx context.Context, agentName string) ([]*models.AgentResponse, error)
-	CreateAgentFn                   func(ctx context.Context, req *models.AgentJSON) (*models.AgentResponse, error)
-	DeleteAgentFn                   func(ctx context.Context, agentName, version string) error
-	UpsertAgentEmbeddingFn          func(ctx context.Context, agentName, version string, embedding *database.SemanticEmbedding) error
-	GetAgentEmbeddingMetadataFn     func(ctx context.Context, agentName, version string) (*database.SemanticEmbeddingMetadata, error)
-	ListSkillsFn                    func(ctx context.Context, filter *database.SkillFilter, cursor string, limit int) ([]*models.SkillResponse, string, error)
-	GetSkillByNameFn                func(ctx context.Context, skillName string) (*models.SkillResponse, error)
-	GetSkillByNameAndVersionFn      func(ctx context.Context, skillName, version string) (*models.SkillResponse, error)
-	GetAllVersionsBySkillNameFn     func(ctx context.Context, skillName string) ([]*models.SkillResponse, error)
-	CreateSkillFn                   func(ctx context.Context, req *models.SkillJSON) (*models.SkillResponse, error)
-	GetDeploymentsFn                func(ctx context.Context, filter *models.DeploymentFilter) ([]*models.Deployment, error)
-	ListProvidersFn                func(ctx context.Context, platform *string) ([]*models.Provider, error)
-	GetProviderByIDFn              func(ctx context.Context, providerID string) (*models.Provider, error)
-	CreateProviderFn               func(ctx context.Context, in *models.CreateProviderInput) (*models.Provider, error)
-	UpdateProviderFn               func(ctx context.Context, providerID string, in *models.UpdateProviderInput) (*models.Provider, error)
-	DeleteProviderFn               func(ctx context.Context, providerID string) error
-	GetDeploymentByIDFn             func(ctx context.Context, id string) (*models.Deployment, error)
-	DeployServerFn                  func(ctx context.Context, serverName, version string, config map[string]string, preferRemote bool, providerID string) (*models.Deployment, error)
-	DeployAgentFn                   func(ctx context.Context, agentName, version string, config map[string]string, preferRemote bool, providerID string) (*models.Deployment, error)
-	RemoveDeploymentByIDFn          func(ctx context.Context, id string) error
-	ReconcileAllFn                  func(ctx context.Context) error
+	ListServersFn                func(ctx context.Context, filter *database.ServerFilter, cursor string, limit int) ([]*apiv0.ServerResponse, string, error)
+	GetServerByNameFn            func(ctx context.Context, serverName string) (*apiv0.ServerResponse, error)
+	GetServerByNameAndVersionFn  func(ctx context.Context, serverName, version string) (*apiv0.ServerResponse, error)
+	GetAllVersionsByServerNameFn func(ctx context.Context, serverName string) ([]*apiv0.ServerResponse, error)
+	CreateServerFn               func(ctx context.Context, req *apiv0.ServerJSON) (*apiv0.ServerResponse, error)
+	UpdateServerFn               func(ctx context.Context, serverName, version string, req *apiv0.ServerJSON, newStatus *string) (*apiv0.ServerResponse, error)
+	StoreServerReadmeFn          func(ctx context.Context, serverName, version string, content []byte, contentType string) error
+	GetServerReadmeLatestFn      func(ctx context.Context, serverName string) (*database.ServerReadme, error)
+	GetServerReadmeByVersionFn   func(ctx context.Context, serverName, version string) (*database.ServerReadme, error)
+	DeleteServerFn               func(ctx context.Context, serverName, version string) error
+	UpsertServerEmbeddingFn      func(ctx context.Context, serverName, version string, embedding *database.SemanticEmbedding) error
+	GetServerEmbeddingMetadataFn func(ctx context.Context, serverName, version string) (*database.SemanticEmbeddingMetadata, error)
+	ListAgentsFn                 func(ctx context.Context, filter *database.AgentFilter, cursor string, limit int) ([]*models.AgentResponse, string, error)
+	GetAgentByNameFn             func(ctx context.Context, agentName string) (*models.AgentResponse, error)
+	GetAgentByNameAndVersionFn   func(ctx context.Context, agentName, version string) (*models.AgentResponse, error)
+	GetAllVersionsByAgentNameFn  func(ctx context.Context, agentName string) ([]*models.AgentResponse, error)
+	CreateAgentFn                func(ctx context.Context, req *models.AgentJSON) (*models.AgentResponse, error)
+	DeleteAgentFn                func(ctx context.Context, agentName, version string) error
+	UpsertAgentEmbeddingFn       func(ctx context.Context, agentName, version string, embedding *database.SemanticEmbedding) error
+	GetAgentEmbeddingMetadataFn  func(ctx context.Context, agentName, version string) (*database.SemanticEmbeddingMetadata, error)
+	ListSkillsFn                 func(ctx context.Context, filter *database.SkillFilter, cursor string, limit int) ([]*models.SkillResponse, string, error)
+	GetSkillByNameFn             func(ctx context.Context, skillName string) (*models.SkillResponse, error)
+	GetSkillByNameAndVersionFn   func(ctx context.Context, skillName, version string) (*models.SkillResponse, error)
+	GetAllVersionsBySkillNameFn  func(ctx context.Context, skillName string) ([]*models.SkillResponse, error)
+	CreateSkillFn                func(ctx context.Context, req *models.SkillJSON) (*models.SkillResponse, error)
+	GetDeploymentsFn             func(ctx context.Context, filter *models.DeploymentFilter) ([]*models.Deployment, error)
+	ListProvidersFn              func(ctx context.Context, platform *string) ([]*models.Provider, error)
+	GetProviderByIDFn            func(ctx context.Context, providerID string) (*models.Provider, error)
+	CreateProviderFn             func(ctx context.Context, in *models.CreateProviderInput) (*models.Provider, error)
+	UpdateProviderFn             func(ctx context.Context, providerID string, in *models.UpdateProviderInput) (*models.Provider, error)
+	DeleteProviderFn             func(ctx context.Context, providerID string) error
+	GetDeploymentByIDFn          func(ctx context.Context, id string) (*models.Deployment, error)
+	DeployServerFn               func(ctx context.Context, serverName, version string, config map[string]string, preferRemote bool, providerID string) (*models.Deployment, error)
+	DeployAgentFn                func(ctx context.Context, agentName, version string, config map[string]string, preferRemote bool, providerID string) (*models.Deployment, error)
+	RemoveDeploymentByIDFn       func(ctx context.Context, id string) error
+	ReconcileAllFn               func(ctx context.Context) error
 }
 
 // NewFakeRegistry creates a new FakeRegistry with initialized maps.

--- a/pkg/cli/root_test.go
+++ b/pkg/cli/root_test.go
@@ -180,6 +180,7 @@ func TestRoot(t *testing.T) {
 	cmd := Root()
 	if cmd == nil {
 		t.Fatal("Root() returned nil")
+		return
 	}
 	if cmd.Use != "arctl" {
 		t.Errorf("Root().Use = %q, want %q", cmd.Use, "arctl")

--- a/pkg/models/deployment.go
+++ b/pkg/models/deployment.go
@@ -2,22 +2,35 @@ package models
 
 import "time"
 
-// Deployment represents a deployed server with its configuration
+// Deployment represents a deployed resource with unified deployment metadata.
 type Deployment struct {
-	ServerName   string            `json:"serverName"`
-	Version      string            `json:"version"`
-	DeployedAt   time.Time         `json:"deployedAt"`
-	UpdatedAt    time.Time         `json:"updatedAt"`
-	Status       string            `json:"status"`
-	Config       map[string]string `json:"config"`
-	PreferRemote bool              `json:"preferRemote"`
-	ResourceType string            `json:"resourceType"` // "mcp" or "agent"
-	Runtime      string            `json:"runtime"`      // "local" or "kubernetes"
-	IsExternal   bool              `json:"isExternal"`   // true if not managed by registry
+	ID              string            `json:"id"`
+	ServerName      string            `json:"serverName"` // resource name (legacy field name retained for compatibility)
+	Version         string            `json:"version"`
+	ProviderID      string            `json:"providerId,omitempty"`
+	ResourceType    string            `json:"resourceType"`
+	Status          string            `json:"status"` // deploying, deployed, failed, cancelled, discovered
+	Origin          string            `json:"origin"` // managed, discovered
+	Region          string            `json:"region,omitempty"`
+	CloudResourceID string            `json:"cloudResourceId,omitempty"`
+	CloudMetadata   map[string]any    `json:"cloudMetadata,omitempty"`
+	Config          map[string]string `json:"config"`
+	PreferRemote    bool              `json:"preferRemote"`
+	DeployedBy      string            `json:"deployedBy,omitempty"`
+	Error           string            `json:"error,omitempty"`
+	DeployedAt      time.Time         `json:"deployedAt"`
+	UpdatedAt       time.Time         `json:"updatedAt"`
+
+	IsExternal bool `json:"isExternal"`
 }
 
 // DeploymentFilter defines filtering options for deployment queries
 type DeploymentFilter struct {
-	Runtime      *string // "local" or "kubernetes"
-	ResourceType *string // "mcp" or "agent"
+	Platform      *string // local, kubernetes
+	ProviderID    *string
+	ResourceType  *string // mcp or agent
+	Status        *string
+	Origin        *string
+	ResourceName  *string // case-insensitive substring filter
+	CloudResource *string
 }

--- a/pkg/models/deployment.go
+++ b/pkg/models/deployment.go
@@ -15,6 +15,7 @@ type Deployment struct {
 	CloudResourceID string            `json:"cloudResourceId,omitempty"`
 	CloudMetadata   map[string]any    `json:"cloudMetadata,omitempty"`
 	Config          map[string]string `json:"config"`
+	ProviderConfig  map[string]any    `json:"providerConfig,omitempty"`
 	PreferRemote    bool              `json:"preferRemote"`
 	DeployedBy      string            `json:"deployedBy,omitempty"`
 	Error           string            `json:"error,omitempty"`

--- a/pkg/models/provider.go
+++ b/pkg/models/provider.go
@@ -1,0 +1,28 @@
+package models
+
+import "time"
+
+// Provider represents a concrete deployment target instance.
+// Examples: a specific kube cluster.
+type Provider struct {
+	ID        string         `json:"id"`
+	Name      string         `json:"name"`
+	Platform  string         `json:"platform"` // local, kubernetes
+	Config    map[string]any `json:"config,omitempty"`
+	CreatedAt time.Time      `json:"createdAt"`
+	UpdatedAt time.Time      `json:"updatedAt"`
+}
+
+// CreateProviderInput defines inputs for provider creation.
+type CreateProviderInput struct {
+	ID       string         `json:"id,omitempty"`
+	Name     string         `json:"name"`
+	Platform string         `json:"platform"`
+	Config   map[string]any `json:"config,omitempty"`
+}
+
+// UpdateProviderInput defines inputs for provider updates.
+type UpdateProviderInput struct {
+	Name   *string        `json:"name,omitempty"`
+	Config map[string]any `json:"config,omitempty"`
+}

--- a/pkg/registry/database/database.go
+++ b/pkg/registry/database/database.go
@@ -196,18 +196,27 @@ type Database interface {
 	UnmarkSkillAsLatest(ctx context.Context, tx pgx.Tx, skillName string) error
 
 	// Deployments API
+	// CreateProvider creates a new provider record.
+	CreateProvider(ctx context.Context, tx pgx.Tx, in *models.CreateProviderInput) (*models.Provider, error)
+	// ListProviders lists provider records, optionally filtered by platform.
+	ListProviders(ctx context.Context, tx pgx.Tx, platform *string) ([]*models.Provider, error)
+	// GetProviderByID returns a provider by ID.
+	GetProviderByID(ctx context.Context, tx pgx.Tx, providerID string) (*models.Provider, error)
+	// UpdateProvider updates mutable provider fields.
+	UpdateProvider(ctx context.Context, tx pgx.Tx, providerID string, in *models.UpdateProviderInput) (*models.Provider, error)
+	// DeleteProvider removes a provider by ID.
+	DeleteProvider(ctx context.Context, tx pgx.Tx, providerID string) error
+
 	// CreateDeployment creates a new deployment record
 	CreateDeployment(ctx context.Context, tx pgx.Tx, deployment *models.Deployment) error
 	// GetDeployments retrieves all deployed servers
-	GetDeployments(ctx context.Context, tx pgx.Tx) ([]*models.Deployment, error)
-	// GetDeploymentByName retrieves a specific deployment
-	GetDeploymentByNameAndVersion(ctx context.Context, tx pgx.Tx, serverName string, version string, artifactType string) (*models.Deployment, error)
-	// UpdateDeploymentConfig updates the configuration for a deployment
-	UpdateDeploymentConfig(ctx context.Context, tx pgx.Tx, serverName string, version string, artifactType string, config map[string]string) error
+	GetDeployments(ctx context.Context, tx pgx.Tx, filter *models.DeploymentFilter) ([]*models.Deployment, error)
+	// GetDeploymentByID retrieves a specific deployment by UUID.
+	GetDeploymentByID(ctx context.Context, tx pgx.Tx, id string) (*models.Deployment, error)
 	// UpdateDeploymentStatus updates the status of a deployment
 	UpdateDeploymentStatus(ctx context.Context, tx pgx.Tx, serverName, version, artifactType, status string) error
-	// RemoveDeployment removes a deployment
-	RemoveDeployment(ctx context.Context, tx pgx.Tx, serverName string, version string, artifactType string) error
+	// RemoveDeploymentByID removes a deployment by ID.
+	RemoveDeploymentByID(ctx context.Context, tx pgx.Tx, id string) error
 }
 
 // InTransactionT is a generic helper that wraps InTransaction for functions returning a value


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don't apply.
-->

# Description

<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

The deployments API had mixed identity models (name/version vs ID), outdated update semantics, and duplicated client/server code paths. This refactor aligns deployments on a single provider-based, ID-first model and removes legacy flows.


# Change Type

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bump
/kind cleanup
/kind design
/kind deprecation
/kind documentation
/kind feature
/kind fix
/kind flake
/kind install
```
-->

/kind breaking_change
/kind cleanup
/kind design

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
refactor deployment apis to provider+id-based model
```
