### PR TITLE
handle stale deployment records on redeploy (409 Conflict)

### DIFF
--- a/internal/registry/service/registry_service_test.go
+++ b/internal/registry/service/registry_service_test.go
@@ -875,13 +875,13 @@ func TestCleanupExistingDeployment(t *testing.T) {
 	ctx := context.Background()
 
 	tests := []struct {
-		name                string
-		existingDeployment  *models.Deployment
-		lookupErr           error
-		removeErr           error
-		expectError         bool
-		expectRemoveCalled  bool
-		resourceType        string
+		name               string
+		existingDeployment *models.Deployment
+		lookupErr          error
+		removeErr          error
+		expectError        bool
+		expectRemoveCalled bool
+		resourceType       string
 	}{
 		{
 			name: "removes stale local deployment",
@@ -983,7 +983,7 @@ func TestCleanupExistingDeployment(t *testing.T) {
 // deploymentMockDB is a minimal mock for database.Database that only implements
 // the methods needed for testing deployment cleanup logic. All other methods panic.
 type deploymentMockDB struct {
-	database.Database // embed interface so unimplemented methods panic
+	database.Database               // embed interface so unimplemented methods panic
 	getDeploymentByNameAndVersionFn func(ctx context.Context, tx pgx.Tx, serverName, version, artifactType string) (*models.Deployment, error)
 	removeDeploymentFn              func(ctx context.Context, tx pgx.Tx, serverName, version, resourceType string) error
 }


### PR DESCRIPTION
# Description

- Fix 409 Conflict error when redeploying an agent or MCP server whose
  runtime resources were removed externally but whose database record
  was not cleaned up
- Add `cleanupExistingDeployment` helper that removes stale DB records
  and attempts Kubernetes resource cleanup (non-fatal) before retrying
  the deployment insert
- Remove stray `fmt.Println` debug statement from `DeployServer`

# Change Type

```
/kind fix
```

# Changelog

```release-note
NONE
```

# Additional Notes

## Root cause
The `deployments` table uses `PRIMARY KEY (server_name, version)`. When
runtime resources (e.g. Kubernetes pods) are deleted externally—via
`kubectl`, namespace cleanup, or failed reconciliation—the corresponding
database record is not removed. Subsequent deploy attempts hit the
unique constraint, returning a 409 Conflict even though no actual
instance exists.

The error path is:
`CreateDeployment` INSERT → PG error 23505 → `ErrAlreadyExists` → `huma.Error409Conflict`

`ReconcileAll` cannot fix this because it runs *after* the INSERT
succeeds—it never gets a chance to execute when the INSERT itself fails.

## Fix
In `DeployServer` and `DeployAgent`, when `CreateDeployment` returns
`ErrAlreadyExists`:
1. Look up the existing deployment record
2. Attempt Kubernetes resource cleanup (non-fatal, since resources may
   already be gone)
3. Remove the stale DB record
4. Retry `CreateDeployment`
5. Proceed with `ReconcileAll` to create fresh runtime resources