### PR TITLE
fix: three bug fixes for MCP tools and background embedding generation

### DIFF
--- a/internal/mcp/registryserver/server.go
+++ b/internal/mcp/registryserver/server.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	restv0 "github.com/agentregistry-dev/agentregistry/internal/registry/api/handlers/v0"
@@ -369,10 +370,14 @@ func addDeploymentTools(server *mcp.Server, registry service.RegistryService) {
 		}
 		outIdx := 0
 		for _, d := range deployments {
-			if args.ResourceType != "" && d.ResourceType != args.ResourceType {
+			if args.ResourceType != "" && !strings.EqualFold(d.ResourceType, args.ResourceType) {
 				continue
 			}
-			resp.Deployments[outIdx] = *d
+			dep := *d
+			if dep.Config == nil {
+				dep.Config = map[string]string{}
+			}
+			resp.Deployments[outIdx] = dep
 			outIdx++
 		}
 		resp.Deployments = resp.Deployments[:outIdx]
@@ -392,7 +397,11 @@ func addDeploymentTools(server *mcp.Server, registry service.RegistryService) {
 		if err != nil {
 			return nil, models.Deployment{}, err
 		}
-		return nil, *deployment, nil
+		dep := *deployment
+		if dep.Config == nil {
+			dep.Config = map[string]string{}
+		}
+		return nil, dep, nil
 	})
 
 	// Deploy server

--- a/internal/registry/service/registry_service.go
+++ b/internal/registry/service/registry_service.go
@@ -17,6 +17,7 @@ import (
 	"github.com/agentregistry-dev/agentregistry/internal/runtime/translation/kagent"
 	"github.com/agentregistry-dev/agentregistry/internal/runtime/translation/registry"
 	"github.com/agentregistry-dev/agentregistry/pkg/models"
+	"github.com/agentregistry-dev/agentregistry/pkg/registry/auth"
 	"github.com/agentregistry-dev/agentregistry/pkg/registry/database"
 	"github.com/jackc/pgx/v5"
 	apiv0 "github.com/modelcontextprotocol/registry/pkg/api/v0"
@@ -195,7 +196,7 @@ func (s *registryServiceImpl) createServerInTransaction(ctx context.Context, tx 
 	// Generate embedding asynchronously (non-blocking, best-effort)
 	if s.shouldGenerateEmbeddingsOnPublish() { //nolint:nestif
 		go func() {
-			bgCtx := context.Background()
+			bgCtx := auth.WithSystemContext(context.Background())
 			payload := embeddings.BuildServerEmbeddingPayload(&serverJSON)
 			if strings.TrimSpace(payload) == "" {
 				return
@@ -594,7 +595,7 @@ func (s *registryServiceImpl) createAgentInTransaction(ctx context.Context, tx p
 	// Generate embedding asynchronously (non-blocking, best-effort)
 	if s.shouldGenerateEmbeddingsOnPublish() { //nolint:nestif
 		go func() {
-			bgCtx := context.Background()
+			bgCtx := auth.WithSystemContext(context.Background())
 			payload := embeddings.BuildAgentEmbeddingPayload(&agentJSON)
 			if strings.TrimSpace(payload) == "" {
 				return

--- a/internal/runtime/translation/kagent/kagent_translator.go
+++ b/internal/runtime/translation/kagent/kagent_translator.go
@@ -239,6 +239,10 @@ func (t *translator) translateLocalMCPServer(server *api.MCPServer) (*kmcpv1alph
 	case api.TransportTypeStdio:
 		spec.TransportType = kmcpv1alpha1.TransportType("stdio")
 		spec.StdioTransport = &kmcpv1alpha1.StdioTransport{}
+		// Default port for transport adapter (matches KMCP CLI default)
+		if spec.Deployment.Port == 0 {
+			spec.Deployment.Port = 3000
+		}
 	default:
 		return nil, fmt.Errorf("unsupported MCP transport type %q for %s", server.Local.TransportType, server.Name)
 	}


### PR DESCRIPTION
```
/kind fix
```

# Description

Three bug fixes found while integrating AgentRegistry into a production Kubernetes platform.

1. **`auth.WithSystemContext` for background embedding goroutines** — bare `context.Background()` lacks the system auth session, causing embedding updates to fail silently. Matches the pattern already used in `embeddings_sse.go` and `embeddings.go`.

2. **Nil Config map initialization** — `get_deployment` and `list_deployments` MCP tools return `null` for Config when the map is nil, breaking downstream JSON consumers. Also adds case-insensitive `resource_type` filtering.

3. **Default port 3000 for stdio transport** — the kagent translator leaves `Deployment.Port` at 0 for stdio servers, which is invalid. Defaults to 3000 to match the KMCP CLI.

Fixes #217

## Changes

| File | Change |
|------|--------|
| `internal/registry/service/registry_service.go` | `context.Background()` → `auth.WithSystemContext(context.Background())` in 2 goroutines |
| `internal/mcp/registryserver/server.go` | Init nil Config maps, `strings.EqualFold` for resource type filter |
| `internal/runtime/translation/kagent/kagent_translator.go` | Default port 3000 for stdio transport |

## Test plan

- [ ] Publish a server with `EMBEDDINGS_ENABLED=true` → verify embedding column is populated (not NULL)
- [ ] Call `get_deployment` for a deployment with no config → verify Config is `{}` not `null`
- [ ] Call `list_deployments` with `resource_type=server` (lowercase) → verify results returned
- [ ] Deploy a stdio MCP server via kagent translator → verify port is 3000

```release-note
Fix background embedding generation silently failing due to missing auth context, nil Config map in deployment MCP tool responses, and missing default port for stdio transport in kagent translator.
```