### PR TITLE
internal: Fix duplicate v in CLI version display

### DIFF
--- a/internal/cli/agent/delete.go
+++ b/internal/cli/agent/delete.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"fmt"
 
+	"github.com/agentregistry-dev/agentregistry/internal/cli/common"
 	"github.com/agentregistry-dev/agentregistry/pkg/printer"
 	"github.com/spf13/cobra"
 )
@@ -52,7 +53,7 @@ func runDelete(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to delete agent: %w", err)
 	}
 
-	printer.PrintSuccess(fmt.Sprintf("Deleted: %s (v%s)", agentName, deleteVersion))
+	printer.PrintSuccess(fmt.Sprintf("Deleted: %s (%s)", agentName, common.FormatVersionForDisplay(deleteVersion)))
 	return nil
 }
 

--- a/internal/cli/agent/list.go
+++ b/internal/cli/agent/list.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/agentregistry-dev/agentregistry/internal/cli/common"
 	"github.com/agentregistry-dev/agentregistry/internal/client"
 	"github.com/agentregistry-dev/agentregistry/pkg/models"
 	"github.com/agentregistry-dev/agentregistry/pkg/printer"
@@ -125,7 +126,7 @@ func printAgentsTable(agents []*models.AgentResponse, deployedAgents []*client.D
 			if deployment.Version == a.Agent.Version {
 				deployedStatus = "True"
 			} else {
-				deployedStatus = fmt.Sprintf("True (v%s)", deployment.Version)
+				deployedStatus = fmt.Sprintf("True (%s)", common.FormatVersionForDisplay(deployment.Version))
 			}
 		}
 

--- a/internal/cli/agent/publish.go
+++ b/internal/cli/agent/publish.go
@@ -164,7 +164,7 @@ func buildAgentJSONDirect(agentName string) (*models.AgentJSON, error) {
 // checkAndHandleExistingAgent checks if an agent version already exists in the registry
 // and handles the overwrite logic if needed.
 func checkAndHandleExistingAgent(agentName, version string) error {
-	printer.PrintInfo(fmt.Sprintf("Publishing agent: %s (v%s)", agentName, version))
+	printer.PrintInfo(fmt.Sprintf("Publishing agent: %s (%s)", agentName, clicommon.FormatVersionForDisplay(version)))
 
 	exists, err := isAgentPublished(agentName, version)
 	if err != nil {
@@ -194,6 +194,6 @@ func publishToRegistry(agentJSON *models.AgentJSON) error {
 	if err != nil {
 		return fmt.Errorf("failed to publish to registry: %w", err)
 	}
-	printer.PrintSuccess(fmt.Sprintf("Published: %s (v%s)", agentJSON.Name, agentJSON.Version))
+	printer.PrintSuccess(fmt.Sprintf("Published: %s (%s)", agentJSON.Name, clicommon.FormatVersionForDisplay(agentJSON.Version)))
 	return nil
 }

--- a/internal/cli/common/common.go
+++ b/internal/cli/common/common.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/agentregistry-dev/agentregistry/internal/cli/mcp/manifest"
+	versionpkg "github.com/agentregistry-dev/agentregistry/internal/version"
 	"github.com/agentregistry-dev/agentregistry/pkg/printer"
 	"github.com/stoewer/go-strcase"
 )
@@ -75,4 +76,9 @@ func ResolveVersion(flagVersion, manifestVersion string) string {
 		return manifestVersion
 	}
 	return "latest"
+}
+
+// FormatVersionForDisplay normalizes version display with a leading "v".
+func FormatVersionForDisplay(version string) string {
+	return versionpkg.EnsureVPrefix(version)
 }

--- a/internal/cli/common/common_test.go
+++ b/internal/cli/common/common_test.go
@@ -298,6 +298,26 @@ func TestResolveVersion(t *testing.T) {
 	}
 }
 
+func TestFormatVersionForDisplay(t *testing.T) {
+	tests := []struct {
+		name    string
+		version string
+		want    string
+	}{
+		{name: "adds v prefix when missing", version: "1.0.0", want: "v1.0.0"},
+		{name: "keeps existing v prefix", version: "v1.0.0", want: "v1.0.0"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FormatVersionForDisplay(tt.version)
+			if got != tt.want {
+				t.Errorf("FormatVersionForDisplay(%q) = %q, want %q", tt.version, got, tt.want)
+			}
+		})
+	}
+}
+
 // TestBuildRegistryImageName_NoDoubleTag is a regression test for
 // https://github.com/agentregistry-dev/agentregistry/issues/178.
 // BuildRegistryImageName must produce a single tag, not ":latest:latest".

--- a/internal/cli/mcp/delete.go
+++ b/internal/cli/mcp/delete.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"fmt"
 
+	"github.com/agentregistry-dev/agentregistry/internal/cli/common"
 	"github.com/agentregistry-dev/agentregistry/pkg/printer"
 	"github.com/spf13/cobra"
 )
@@ -52,6 +53,6 @@ func runDelete(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to delete server: %w", err)
 	}
 
-	printer.PrintSuccess(fmt.Sprintf("Deleted: %s (v%s)", serverName, deleteVersion))
+	printer.PrintSuccess(fmt.Sprintf("Deleted: %s (%s)", serverName, common.FormatVersionForDisplay(deleteVersion)))
 	return nil
 }

--- a/internal/cli/mcp/deploy.go
+++ b/internal/cli/mcp/deploy.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/agentregistry-dev/agentregistry/internal/cli/common"
 	"github.com/spf13/cobra"
 )
 
@@ -101,7 +102,7 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to deploy server: %w", err)
 	}
 
-	fmt.Printf("\n✓ Deployed %s (v%s) with providerId=%s\n", deployment.ServerName, deployment.Version, deployProviderID)
+	fmt.Printf("\n✓ Deployed %s (%s) with providerId=%s\n", deployment.ServerName, common.FormatVersionForDisplay(deployment.Version), deployProviderID)
 	if deployNamespace != "" {
 		ns := deployNamespace
 		fmt.Printf("Namespace: %s\n", ns)

--- a/internal/cli/mcp/publish.go
+++ b/internal/cli/mcp/publish.go
@@ -256,7 +256,7 @@ func buildArguments(args []string) []model.Argument {
 // checkAndHandleExistingServer checks if a server version already exists in the registry
 // and handles the overwrite logic if needed.
 func checkAndHandleExistingServer(serverName, version string) error {
-	printer.PrintInfo(fmt.Sprintf("Publishing MCP server: %s (v%s)", serverName, version))
+	printer.PrintInfo(fmt.Sprintf("Publishing MCP server: %s (%s)", serverName, common.FormatVersionForDisplay(version)))
 
 	isPublished, err := isServerPublished(serverName, version)
 	if err != nil {
@@ -286,7 +286,7 @@ func publishToRegistry(serverJSON *apiv0.ServerJSON, dryRun bool) error {
 	if err != nil {
 		return fmt.Errorf("failed to publish to registry: %w", err)
 	}
-	printer.PrintSuccess(fmt.Sprintf("Published: %s (v%s)", serverJSON.Name, serverJSON.Version))
+	printer.PrintSuccess(fmt.Sprintf("Published: %s (%s)", serverJSON.Name, common.FormatVersionForDisplay(serverJSON.Version)))
 	return nil
 }
 

--- a/internal/cli/skill/publish.go
+++ b/internal/cli/skill/publish.go
@@ -174,7 +174,7 @@ func runPublishDirect(skillName string) error {
 	}
 
 	if !dryRunFlag {
-		printer.PrintSuccess(fmt.Sprintf("Published: %s (v%s)", skillJson.Name, skillJson.Version))
+		printer.PrintSuccess(fmt.Sprintf("Published: %s (%s)", skillJson.Name, common.FormatVersionForDisplay(skillJson.Version)))
 	}
 
 	return nil


### PR DESCRIPTION
# Description

This fixes CLI output formatting that could render semantic versions with a duplicated prefix (for example, `vv0.0.1`) when the input version already included `v`.

```bash
$ /bin/arctl skill publish --github https://github.com/antfu/skills/tree/main/skills/vue vue --version v0.0.1
✓ Published: vue (vv0.0.1)
```

The change centralizes version display normalization in `internal/cli/common` and updates publish, delete, deploy, and agent list output paths to use it consistently.

Fixes https://github.com/agentregistry-dev/agentregistry/issues/227

# Change Type

/kind fix

# Changelog

```release-note
Fix duplicate `v` prefix in CLI version output across publish, delete, deploy, and list commands.
```
