### PR TITLE
fix: rename kubernetes-default provider ID to kubernetes

### DIFF
--- a/e2e/deploy_test.go
+++ b/e2e/deploy_test.go
@@ -38,7 +38,7 @@ var agentDeployTargets = []deployTarget{
 	},
 	{
 		name:     "kubernetes",
-		deplArgs: []string{"--provider-id", "kubernetes-default", "--namespace", "default"},
+		deplArgs: []string{"--provider-id", "kubernetes", "--namespace", "default"},
 		cleanup: func(t *testing.T, agentName string) {
 			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 			defer cancel()
@@ -65,7 +65,7 @@ var mcpDeployTargets = []deployTarget{
 	},
 	{
 		name:     "kubernetes",
-		deplArgs: []string{"--provider-id", "kubernetes-default", "--namespace", "default"},
+		deplArgs: []string{"--provider-id", "kubernetes", "--namespace", "default"},
 		cleanup: func(t *testing.T, mcpName string) {
 			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 			defer cancel()

--- a/internal/cli/agent/deploy.go
+++ b/internal/cli/agent/deploy.go
@@ -17,7 +17,7 @@ var DeployCmd = &cobra.Command{
 Example:
   arctl agent deploy my-agent --version latest
   arctl agent deploy my-agent --version 1.2.3
-  arctl agent deploy my-agent --version latest --provider-id kubernetes-default`,
+  arctl agent deploy my-agent --version latest --provider-id kubernetes`,
 	Args: cobra.ExactArgs(1),
 	RunE: runDeploy,
 }

--- a/internal/registry/api/handlers/v0/deployment_adapters.go
+++ b/internal/registry/api/handlers/v0/deployment_adapters.go
@@ -88,7 +88,7 @@ func (a *kubernetesDeploymentAdapter) Deploy(ctx context.Context, req *models.De
 	}
 	providerID := req.ProviderID
 	if providerID == "" {
-		providerID = "kubernetes-default"
+		providerID = "kubernetes"
 	}
 	env := req.Env
 	if env == nil {

--- a/internal/registry/api/handlers/v0/providers_test.go
+++ b/internal/registry/api/handlers/v0/providers_test.go
@@ -161,7 +161,7 @@ func TestListProviders_WithData(t *testing.T) {
 	k8sAdapter := &fakeProviderAdapter{
 		platform: "kubernetes",
 		providers: map[string]*models.Provider{
-			"kubernetes-default": {ID: "kubernetes-default", Name: "Kubernetes Default", Platform: "kubernetes"},
+			"kubernetes": {ID: "kubernetes", Name: "Kubernetes Default", Platform: "kubernetes"},
 		},
 	}
 	v0.RegisterProvidersEndpoints(api, "/v0", fake, v0.PlatformExtensions{
@@ -178,7 +178,7 @@ func TestListProviders_WithData(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Contains(t, w.Body.String(), `"id":"local"`)
 	assert.Contains(t, w.Body.String(), `"platform":"local"`)
-	assert.Contains(t, w.Body.String(), `"id":"kubernetes-default"`)
+	assert.Contains(t, w.Body.String(), `"id":"kubernetes"`)
 	assert.Contains(t, w.Body.String(), `"platform":"kubernetes"`)
 }
 

--- a/internal/registry/database/migrations/010_rename_kubernetes_default_provider.sql
+++ b/internal/registry/database/migrations/010_rename_kubernetes_default_provider.sql
@@ -1,0 +1,14 @@
+-- Rename the kubernetes-default provider ID to kubernetes for consistency.
+
+-- Insert the new provider if it doesn't exist yet.
+INSERT INTO providers (id, name, platform, config)
+VALUES ('kubernetes', 'Kubernetes', 'kubernetes', '{}'::jsonb)
+ON CONFLICT (id) DO NOTHING;
+
+-- Migrate any deployments referencing the old ID.
+UPDATE deployments
+SET provider_id = 'kubernetes'
+WHERE provider_id = 'kubernetes-default';
+
+-- Remove the old provider.
+DELETE FROM providers WHERE id = 'kubernetes-default';

--- a/internal/registry/service/registry_service.go
+++ b/internal/registry/service/registry_service.go
@@ -31,7 +31,7 @@ const (
 	maxServerVersionsPerServer = 10000
 
 	localProviderID      = "local"
-	kubernetesProviderID = "kubernetes-default"
+	kubernetesProviderID = "kubernetes"
 	platformLocal        = "local"
 	platformKubernetes   = "kubernetes"
 	resourceTypeMCP      = "mcp"


### PR DESCRIPTION
# Description

Renames the `kubernetes-default` provider ID to `kubernetes` across the codebase for consistency and clarity. The old name was a leftover from early development.

**What changed:**
- Renamed provider constant from `kubernetes-default` to `kubernetes`
- Added migration `010_rename_kubernetes_default_provider.sql` to handle existing database records
- Updated CLI examples, deployment adapters, service constants, and tests

Fixes #258

# Change Type

/kind fix

# Changelog

```release-note
Renamed kubernetes-default provider ID to kubernetes for consistency
```

# Additional Notes

Migration safely handles both fresh installs and upgrades (INSERT ON CONFLICT + UPDATE + DELETE).