### PR TITLE
fix: stop copying .env file into Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -23,6 +23,10 @@ internal/registry/api/ui/dist/
 *.swo
 *~
 
+# Environment files (may contain secrets)
+.env
+.env.*
+
 # OS files
 .DS_Store
 Thumbs.db

--- a/Makefile
+++ b/Makefile
@@ -176,7 +176,7 @@ docker-agentgateway:
 	echo "✓ Agent gateway image built successfully";
 
 
-docker-server: .env
+docker-server:
 	@echo "Building server Docker image..."
 	$(DOCKER_BUILDER) build $(DOCKER_BUILD_ARGS) -f docker/server.Dockerfile -t $(DOCKER_REGISTRY)/$(DOCKER_REPO)/server:$(VERSION) --build-arg LDFLAGS="$(LDFLAGS)" .
 	@echo "✓ Docker image built successfully"

--- a/docker/server.Dockerfile
+++ b/docker/server.Dockerfile
@@ -74,9 +74,6 @@ RUN DOCKER_CONFIG=${DOCKER_CONFIG:-$HOME/.docker} && \
 
 COPY --from=builder /app/bin/arctl-server /app/bin/arctl-server
 
-
-COPY .env .env
-
 LABEL org.opencontainers.image.source=https://github.com/agentregistry-dev/agentregistry
 LABEL org.opencontainers.image.description="Agent Registry Server"
 LABEL org.opencontainers.image.authors="Agent Registry Creators 🤖"


### PR DESCRIPTION
# Description

Remove `COPY .env .env` from server.Dockerfile to prevent secrets (GitHub OAuth, JWT keys, OpenAI API keys) from being baked into Docker images.

**What changed:**
- Removed `COPY .env .env` from server.Dockerfile
- Added `.env*` to .dockerignore as a safety net
- Removed `.env` prerequisite from Makefile `docker-server` target

Fixes #212

# Change Type

/kind fix

# Changelog

```release-note
Stop copying .env file into Docker images to prevent secret leakage
```

# Additional Notes

Environment variables should be injected at runtime (docker run --env-file or -e flags) rather than baked into the image at build time.