### PR TITLE
fix: include resource name in deployment not-found error

### DIFF
--- a/internal/registry/api/handlers/v0/deployments.go
+++ b/internal/registry/api/handlers/v0/deployments.go
@@ -82,8 +82,15 @@ func createDeploymentHTTPError(err error) error {
 		return huma.Error400BadRequest("Unsupported provider or platform for deployment")
 	case errors.Is(err, database.ErrInvalidInput):
 		return huma.Error400BadRequest(err.Error())
-	case errors.Is(err, database.ErrNotFound) || errors.Is(err, auth.ErrForbidden) || errors.Is(err, auth.ErrUnauthenticated):
+	case errors.Is(err, auth.ErrForbidden) || errors.Is(err, auth.ErrUnauthenticated):
 		return huma.Error404NotFound("Resource not found in registry")
+	case errors.Is(err, database.ErrNotFound):
+		// Preserve the descriptive message from the service layer (e.g. "server X not found in registry")
+		msg := err.Error()
+		if msg == "" || msg == database.ErrNotFound.Error() {
+			msg = "Resource not found in registry"
+		}
+		return huma.Error404NotFound(msg)
 	case errors.Is(err, database.ErrAlreadyExists):
 		return huma.Error409Conflict("Deployment with this ID already exists")
 	case err.Error() == "agent deployment is not yet implemented":

--- a/internal/registry/api/handlers/v0/deployments_test.go
+++ b/internal/registry/api/handlers/v0/deployments_test.go
@@ -240,6 +240,42 @@ func TestCreateDeployment_InvalidInputFromAdapterReturnsBadRequest(t *testing.T)
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
 
+func TestCreateDeployment_NotFoundPreservesResourceName(t *testing.T) {
+	reg := servicetesting.NewFakeRegistry()
+	reg.GetProviderByIDFn = func(ctx context.Context, providerID string) (*models.Provider, error) {
+		return &models.Provider{ID: providerID, Platform: "local"}, nil
+	}
+	reg.CreateDeploymentFn = func(ctx context.Context, req *models.Deployment, platform string) (*models.Deployment, error) {
+		return nil, fmt.Errorf("server my-mcp-server not found in registry: %w", database.ErrNotFound)
+	}
+
+	mux := http.NewServeMux()
+	api := humago.New(mux, huma.DefaultConfig("Test API", "1.0.0"))
+	v0.RegisterDeploymentsEndpoints(api, "/v0", reg, v0.PlatformExtensions{
+		ProviderPlatforms: v0.DefaultProviderPlatformAdapters(reg),
+		DeploymentPlatforms: map[string]registrytypes.DeploymentPlatformAdapter{
+			"local": &fakeDeploymentAdapter{},
+		},
+	})
+
+	body := map[string]any{
+		"serverName":   "my-mcp-server",
+		"version":      "1.0.0",
+		"resourceType": "mcp",
+		"providerId":   "local",
+	}
+	payload, err := json.Marshal(body)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/v0/deployments", bytes.NewReader(payload))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+	assert.Contains(t, w.Body.String(), "my-mcp-server")
+}
+
 func TestCreateDeployment_AllowsMultipleDeploymentsForSameArtifact(t *testing.T) {
 	reg := servicetesting.NewFakeRegistry()
 	reg.GetProviderByIDFn = func(ctx context.Context, providerID string) (*models.Provider, error) {


### PR DESCRIPTION
# Description

Improve the error message when deploying a resource that references a non-published MCP server or agent. The 404 response now includes the resource name instead of a generic "Resource not found in registry" message.

**What changed:**
- Split `ErrNotFound` from `ErrForbidden`/`ErrUnauthenticated` in `createDeploymentHTTPError`
- Not-found errors now include the resource name in the message
- Added `TestCreateDeployment_NotFoundPreservesResourceName` test

Fixes #239

# Change Type

/kind fix

# Changelog

```release-note
Include resource name in deployment not-found error messages
```