### PR TITLE
fix: three bugs in MCP tool handlers and kagent translator

### DIFF
--- a/internal/mcp/registryserver/deployments_test.go
+++ b/internal/mcp/registryserver/deployments_test.go
@@ -301,6 +301,63 @@ func TestDeploymentTools_FilterResourceType(t *testing.T) {
 	assert.Equal(t, "com.example/echo-agent", out.Deployments[0].ServerName)
 }
 
+func TestDeploymentTools_FilterResourceTypeCaseInsensitive(t *testing.T) {
+	ctx := context.Background()
+
+	deployments := []*models.Deployment{
+		{
+			ID:           "dep-mcp",
+			ServerName:   "com.example/weather",
+			ResourceType: "mcp",
+			Env:          map[string]string{},
+		},
+		{
+			ID:           "dep-agent",
+			ServerName:   "com.example/echo-agent",
+			ResourceType: "agent",
+			Env:          map[string]string{},
+		},
+	}
+
+	reg := servicetesting.NewFakeRegistry()
+	reg.GetDeploymentsFn = func(ctx context.Context, filter *models.DeploymentFilter) ([]*models.Deployment, error) {
+		return deployments, nil
+	}
+
+	server := NewServer(reg)
+	clientTransport, serverTransport := mcp.NewInMemoryTransports()
+	serverSession, err := server.Connect(ctx, serverTransport, nil)
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, serverSession.Wait())
+	}()
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "v0.0.1"}, nil)
+	clientSession, err := client.Connect(ctx, clientTransport, nil)
+	require.NoError(t, err)
+	defer func() {
+		_ = clientSession.Close()
+	}()
+
+	// Filter with different casing should still match
+	res, err := clientSession.CallTool(ctx, &mcp.CallToolParams{
+		Name: "list_deployments",
+		Arguments: map[string]any{
+			"resourceType": "MCP",
+		},
+	})
+	require.NoError(t, err)
+	raw, _ := json.Marshal(res.StructuredContent)
+	var out struct {
+		Deployments []models.Deployment `json:"deployments"`
+		Count       int                 `json:"count"`
+	}
+	require.NoError(t, json.Unmarshal(raw, &out))
+	assert.Equal(t, 1, out.Count)
+	require.Len(t, out.Deployments, 1)
+	assert.Equal(t, "com.example/weather", out.Deployments[0].ServerName)
+}
+
 func TestDeploymentTools_GetDeploymentRequiresID(t *testing.T) {
 	ctx := context.Background()
 	reg := servicetesting.NewFakeRegistry()

--- a/internal/mcp/registryserver/server.go
+++ b/internal/mcp/registryserver/server.go
@@ -387,8 +387,11 @@ func addDeploymentTools(server *mcp.Server, registry service.RegistryService) {
 		}
 		outIdx := 0
 		for _, d := range deployments {
-			if args.ResourceType != "" && d.ResourceType != args.ResourceType {
+			if args.ResourceType != "" && !strings.EqualFold(d.ResourceType, args.ResourceType) {
 				continue
+			}
+			if d.Env == nil {
+				d.Env = map[string]string{}
 			}
 			resp.Deployments[outIdx] = *d
 			outIdx++
@@ -409,6 +412,9 @@ func addDeploymentTools(server *mcp.Server, registry service.RegistryService) {
 		deployment, err := registry.GetDeploymentByID(ctx, args.ID)
 		if err != nil {
 			return nil, models.Deployment{}, err
+		}
+		if deployment.Env == nil {
+			deployment.Env = map[string]string{}
 		}
 		return nil, *deployment, nil
 	})

--- a/internal/registry/service/registry_service.go
+++ b/internal/registry/service/registry_service.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/agentregistry-dev/agentregistry/internal/registry/config"
 	"github.com/agentregistry-dev/agentregistry/internal/registry/embeddings"
+	"github.com/agentregistry-dev/agentregistry/pkg/registry/auth"
 	"github.com/agentregistry-dev/agentregistry/internal/registry/validators"
 	"github.com/agentregistry-dev/agentregistry/internal/runtime"
 	"github.com/agentregistry-dev/agentregistry/internal/runtime/translation/api"
@@ -261,7 +262,7 @@ func (s *registryServiceImpl) createServerInTransaction(ctx context.Context, tx 
 	// Generate embedding asynchronously (non-blocking, best-effort)
 	if s.shouldGenerateEmbeddingsOnPublish() { //nolint:nestif
 		go func() {
-			bgCtx := context.Background()
+			bgCtx := auth.WithSystemContext(context.Background())
 			payload := embeddings.BuildServerEmbeddingPayload(&serverJSON)
 			if strings.TrimSpace(payload) == "" {
 				return
@@ -660,7 +661,7 @@ func (s *registryServiceImpl) createAgentInTransaction(ctx context.Context, tx p
 	// Generate embedding asynchronously (non-blocking, best-effort)
 	if s.shouldGenerateEmbeddingsOnPublish() { //nolint:nestif
 		go func() {
-			bgCtx := context.Background()
+			bgCtx := auth.WithSystemContext(context.Background())
 			payload := embeddings.BuildAgentEmbeddingPayload(&agentJSON)
 			if strings.TrimSpace(payload) == "" {
 				return

--- a/internal/runtime/translation/kagent/kagent_translator.go
+++ b/internal/runtime/translation/kagent/kagent_translator.go
@@ -243,6 +243,9 @@ func (t *translator) translateLocalMCPServer(server *api.MCPServer) (*kmcpv1alph
 	case api.TransportTypeStdio:
 		spec.TransportType = kmcpv1alpha1.TransportType("stdio")
 		spec.StdioTransport = &kmcpv1alpha1.StdioTransport{}
+		if spec.Deployment.Port == 0 {
+			spec.Deployment.Port = 3000 // KMCP CLI default
+		}
 	default:
 		return nil, fmt.Errorf("unsupported MCP transport type %q for %s", server.Local.TransportType, server.Name)
 	}

--- a/internal/runtime/translation/kagent/kagent_translator_test.go
+++ b/internal/runtime/translation/kagent/kagent_translator_test.go
@@ -141,6 +141,43 @@ func TestTranslateRuntimeConfig_LocalMCP(t *testing.T) {
 	}
 }
 
+func TestTranslateRuntimeConfig_StdioDefaultPort(t *testing.T) {
+	translator := NewTranslator()
+	ctx := context.Background()
+
+	desired := &api.DesiredState{
+		MCPServers: []*api.MCPServer{
+			{
+				Name:          "stdio-server",
+				MCPServerType: api.MCPServerTypeLocal,
+				Local: &api.LocalMCPServer{
+					TransportType: api.TransportTypeStdio,
+					Deployment: api.MCPServerDeployment{
+						Image: "stdio-image:latest",
+					},
+				},
+			},
+		},
+	}
+
+	config, err := translator.TranslateRuntimeConfig(ctx, desired)
+	if err != nil {
+		t.Fatalf("TranslateRuntimeConfig failed: %v", err)
+	}
+
+	if len(config.Kubernetes.MCPServers) != 1 {
+		t.Fatalf("Expected 1 MCPServer, got %d", len(config.Kubernetes.MCPServers))
+	}
+
+	server := config.Kubernetes.MCPServers[0]
+	if server.Spec.Deployment.Port != 3000 {
+		t.Errorf("Expected default port 3000 for stdio transport, got %d", server.Spec.Deployment.Port)
+	}
+	if server.Spec.TransportType != "stdio" {
+		t.Errorf("Expected transport stdio, got %s", server.Spec.TransportType)
+	}
+}
+
 func TestTranslateRuntimeConfig_AgentWithMCPServers(t *testing.T) {
 	translator := NewTranslator()
 	ctx := context.Background()


### PR DESCRIPTION
# Description

Fix three bugs in MCP tool handlers and the kagent translator.

**What changed:**
1. Background embedding goroutines now use `auth.WithSystemContext()` instead of bare `context.Background()` (fixes auth failures)
2. Nil Config maps initialized to empty maps; `resource_type` filter is now case-insensitive
3. Stdio transport defaults port to 3000 (KMCP CLI default) when not specified

Fixes #217

# Change Type

/kind fix

# Changelog

```release-note
Fix auth context in background goroutines, case-insensitive resource_type filter, and stdio default port
```

# Additional Notes

Added tests for case-insensitive filter and stdio default port.