### PR TITLE
fix: include docker stderr in error messages

### DIFF
--- a/internal/cli/common/docker/docker.go
+++ b/internal/cli/common/docker/docker.go
@@ -39,8 +39,8 @@ func (e *Executor) CheckAvailability() error {
 }
 
 // Run executes docker with the provided arguments.
-// Stderr is both displayed to the user and captured so it can be included
-// in the returned error message when the command fails.
+// When Verbose is true, stdout and stderr are streamed to the terminal.
+// When Verbose is false, only the stderr is captured and is included in the returned error message.
 func (e *Executor) Run(args ...string) error {
 	if e.Verbose {
 		printer.PrintInfo(fmt.Sprintf("Running: docker %s", strings.Join(args, " ")))
@@ -49,19 +49,21 @@ func (e *Executor) Run(args ...string) error {
 		}
 	}
 
-	var stderrBuf bytes.Buffer
 	cmd := exec.Command("docker", args...)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = io.MultiWriter(os.Stderr, &stderrBuf)
 	if e.WorkDir != "" {
 		cmd.Dir = e.WorkDir
 	}
+
+	var stderrBuf bytes.Buffer
+	if e.Verbose {
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = io.MultiWriter(os.Stderr, &stderrBuf)
+	} else {
+		cmd.Stderr = &stderrBuf
+	}
+
 	if err := cmd.Run(); err != nil {
-		captured := strings.TrimSpace(stderrBuf.String())
-		if captured != "" {
-			return fmt.Errorf("%w\n%s", err, captured)
-		}
-		return err
+		return fmt.Errorf("%w\n%s", err, strings.TrimSpace(stderrBuf.String()))
 	}
 	return nil
 }


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don't apply.
-->

# Description

<!--
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

When Docker commands fail, only stdout was captured, making it difficult to diagnose build and deployment failures. Docker typically writes error details to stderr.

The `Executor.Run` method in `docker.go` now uses `io.MultiWriter(os.Stderr, &stderrBuf)` to both display stderr in real time and capture it for inclusion in the returned error message when the command fails.

To reduce log pollution, outputs are now backed by `--verbose` flag. Following a similar approach to the agentregistry-runtime, we print to both stderr + buffer error when verbose is enabled, else we simply output the buffer-captured error with the returned error message.

Fixes #193

## Validation

```sh
# init a skill
go run cmd/cli/main.go skill init test
```

Non-verbose output would only log the captured docker error
```sh
# invalid build without verbose logging
go run cmd/cli/main.go skill build test --image 'invalid!!tag'
```
```output
Building skill "hello-world-template" as Docker image: invalid!!tag
Error: build failed for skill "hello-world-template": docker build failed: exit status 1
ERROR: failed to build: invalid tag "invalid!!tag": invalid reference format
exit status 1
```

Verbose output will log std logs, the stderr, and final captured docker error (which technically leads to duplicated from stderr + captured err returned)
```sh
# invalid skill with verbose logging
go run cmd/cli/main.go skill build test --image 'invalid!!tag' --verbose
```
```output
Building skill "hello-world-template" as Docker image: invalid!!tag
Running: docker build -t invalid!!tag -f /var/folders/zy/pkk0_2ys5yx8y1syxw5xjxhh0000gn/T/skill-dockerfile-654053150 /Users/fabiangonz98/go/src/github.com/solo-io/agentregistry/test
Working directory: /Users/fabiangonz98/go/src/github.com/solo-io/agentregistry/test
ERROR: failed to build: invalid tag "invalid!!tag": invalid reference format
Error: build failed for skill "hello-world-template": docker build failed: exit status 1
ERROR: failed to build: invalid tag "invalid!!tag": invalid reference format
exit status 1
```

# Change Type

```
/kind fix
```

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
Include docker stderr in error messages for better debugging
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->