### PR TITLE
fix: allow hyphens and underscores in agent names

### DIFF
--- a/internal/cli/agent/frameworks/adk/python/generator.go
+++ b/internal/cli/agent/frameworks/adk/python/generator.go
@@ -31,7 +31,7 @@ func (g *PythonGenerator) Generate(agentConfig *common.AgentConfig) error {
 		return fmt.Errorf("agent config is required")
 	}
 
-	projectPackageDir := filepath.Join(agentConfig.Directory, agentConfig.Name)
+	projectPackageDir := filepath.Join(agentConfig.Directory, agentConfig.PackageName())
 	if err := os.MkdirAll(projectPackageDir, 0o755); err != nil {
 		return fmt.Errorf("failed to create package directory: %w", err)
 	}
@@ -111,7 +111,7 @@ func printSummary(cfg *common.AgentConfig) {
 	fmt.Printf("🤖 Model configuration: %s (%s)\n", cfg.ModelProvider, cfg.ModelName)
 	fmt.Printf("📁 Project structure:\n")
 	fmt.Printf("   %s/\n", cfg.Name)
-	fmt.Printf("   ├── %s/\n", cfg.Name)
+	fmt.Printf("   ├── %s/\n", cfg.PackageName())
 	fmt.Printf("   │   ├── __init__.py\n")
 	fmt.Printf("   │   ├── agent.py\n")
 	fmt.Printf("   │   ├── mcp_tools.py\n")

--- a/internal/cli/agent/frameworks/adk/python/templates/Dockerfile.tmpl
+++ b/internal/cli/agent/frameworks/adk/python/templates/Dockerfile.tmpl
@@ -7,7 +7,7 @@ FROM $DOCKER_REGISTRY/kagent-dev/kagent/kagent-adk:$VERSION
 
 WORKDIR /app
 
-COPY {{.Name}}/ {{.Name}}/
+COPY {{.PackageName}}/ {{.PackageName}}/
 COPY pyproject.toml pyproject.toml
 COPY README.md README.md
 COPY .python-version .python-version
@@ -16,5 +16,5 @@ RUN uv sync
 
 ENV OTEL_SERVICE_NAME={{.Name}}
 
-CMD ["{{.Name}}"]
+CMD ["{{.PackageName}}"]
 

--- a/internal/cli/agent/frameworks/adk/python/templates/README.md.tmpl
+++ b/internal/cli/agent/frameworks/adk/python/templates/README.md.tmpl
@@ -8,7 +8,7 @@ ADK Python agent wired for MCP tools and ready to publish through AgentRegistry.
 - Provider: **{{.ModelProvider}}**
 - Model: **{{.ModelName}}**
 
-Update `{{.Name}}/agent.py` if you need to switch providers, add tools, or
+Update `{{.PackageName}}/agent.py` if you need to switch providers, add tools, or
 change the root instructions.
 
 ## Local iteration
@@ -18,7 +18,7 @@ change the root instructions.
 
    ```bash
    uv sync
-   uv run {{.Name}}
+   uv run {{.PackageName}}
    ```
 
 3. Use `arctl agent run .` to launch the local chat experience with docker

--- a/internal/cli/agent/frameworks/adk/python/templates/docker-compose.yaml.tmpl
+++ b/internal/cli/agent/frameworks/adk/python/templates/docker-compose.yaml.tmpl
@@ -19,7 +19,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    command: ["{{.Name}}", "--local"]
+    command: ["{{.PackageName}}", "--local"]
     ports:
       - "8080:8080"
     environment:

--- a/internal/cli/agent/frameworks/common/base_generator.go
+++ b/internal/cli/agent/frameworks/common/base_generator.go
@@ -10,6 +10,7 @@ import (
 	"text/template"
 
 	"github.com/agentregistry-dev/agentregistry/pkg/models"
+	"github.com/agentregistry-dev/agentregistry/pkg/validators"
 )
 
 // AgentConfig captures the data required to render an agent project from templates.
@@ -33,6 +34,12 @@ type AgentConfig struct {
 	EnvVars    []string
 	Skills     []models.SkillRef
 	InitGit    bool
+}
+
+// PackageName returns the agent name normalized for use as a Python package name
+// (hyphens replaced with underscores).
+func (c AgentConfig) PackageName() string {
+	return validators.AgentNameToPackage(c.Name)
 }
 
 // HasSkills returns true when the agent has at least one skill configured.

--- a/internal/cli/agent/project/project.go
+++ b/internal/cli/agent/project/project.go
@@ -13,6 +13,7 @@ import (
 	"github.com/agentregistry-dev/agentregistry/internal/utils"
 	"github.com/agentregistry-dev/agentregistry/internal/version"
 	"github.com/agentregistry-dev/agentregistry/pkg/models"
+	"github.com/agentregistry-dev/agentregistry/pkg/validators"
 )
 
 // LoadManifest loads the agent manifest from the project directory.
@@ -65,7 +66,7 @@ func RegenerateMcpTools(projectDir string, manifest *models.AgentManifest, verbo
 		return fmt.Errorf("manifest missing name")
 	}
 
-	agentPackageDir := filepath.Join(projectDir, manifest.Name)
+	agentPackageDir := filepath.Join(projectDir, validators.AgentNameToPackage(manifest.Name))
 	if _, err := os.Stat(agentPackageDir); err != nil {
 		// Not an ADK layout; nothing to do.
 		return nil
@@ -102,7 +103,7 @@ func RegeneratePromptsLoader(projectDir string, manifest *models.AgentManifest, 
 		return fmt.Errorf("manifest missing name")
 	}
 
-	agentPackageDir := filepath.Join(projectDir, manifest.Name)
+	agentPackageDir := filepath.Join(projectDir, validators.AgentNameToPackage(manifest.Name))
 	if _, err := os.Stat(agentPackageDir); err != nil {
 		// Not an ADK layout; nothing to do.
 		return nil
@@ -152,6 +153,7 @@ func RegenerateDockerCompose(projectDir string, manifest *models.AgentManifest, 
 		HasSkills         bool
 		EnvVars           []string
 		McpServers        []models.McpServerType
+		PackageName       string
 	}{
 		Name:              manifest.Name,
 		Version:           sanitizedVersion,
@@ -162,6 +164,7 @@ func RegenerateDockerCompose(projectDir string, manifest *models.AgentManifest, 
 		HasSkills:         len(manifest.Skills) > 0,
 		EnvVars:           envVars,
 		McpServers:        manifest.McpServers,
+		PackageName:       validators.AgentNameToPackage(manifest.Name),
 	})
 	if err != nil {
 		return fmt.Errorf("failed to render docker-compose: %w", err)

--- a/internal/cli/agent/run.go
+++ b/internal/cli/agent/run.go
@@ -20,6 +20,7 @@ import (
 	"github.com/agentregistry-dev/agentregistry/internal/cli/common/docker"
 	"github.com/agentregistry-dev/agentregistry/internal/utils"
 	"github.com/agentregistry-dev/agentregistry/pkg/models"
+	"github.com/agentregistry-dev/agentregistry/pkg/validators"
 	"github.com/spf13/cobra"
 	a2aclient "trpc.group/trpc-go/trpc-a2a-go/client"
 	"trpc.group/trpc-go/trpc-a2a-go/protocol"
@@ -393,6 +394,7 @@ func renderComposeFromManifest(manifest *models.AgentManifest, version string) (
 		HasSkills         bool
 		EnvVars           []string
 		McpServers        []models.McpServerType
+		PackageName       string
 	}{
 		Name:              manifest.Name,
 		Version:           sanitizedVersion,
@@ -403,6 +405,7 @@ func renderComposeFromManifest(manifest *models.AgentManifest, version string) (
 		HasSkills:         len(manifest.Skills) > 0,
 		EnvVars:           project.EnvVarsFromManifest(manifest),
 		McpServers:        manifest.McpServers,
+		PackageName:       validators.AgentNameToPackage(manifest.Name),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to render docker-compose template: %w", err)

--- a/pkg/validators/names.go
+++ b/pkg/validators/names.go
@@ -57,28 +57,41 @@ func ValidateProjectName(name string) error {
 	return nil
 }
 
-// agentNameRegex enforces the strictest rule - names that work BOTH as Python identifiers AND as publishable agent names.
-// Must start with a letter, followed by alphanumeric only, minimum 2 characters.
-var agentNameRegex = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9]+$`)
+// agentNameRegex allows names with letters, digits, hyphens, and underscores.
+// Must start with a letter, minimum 2 characters. Hyphens/underscores cannot be
+// consecutive or appear at the end.
+var agentNameRegex = regexp.MustCompile(`^[a-zA-Z]([a-zA-Z0-9]|[-_][a-zA-Z0-9])*[a-zA-Z0-9]$`)
 
 // ValidateAgentName checks if the agent name is valid.
-// Allowed: letters and digits only, must start with a letter, minimum 2 characters.
-// Not allowed: underscores, dots, hyphens, or Python keywords.
+// Allowed: letters, digits, hyphens, and underscores. Must start with a letter,
+// end with a letter or digit, minimum 2 characters.
+// Hyphens are converted to underscores for Python package names automatically.
+// Not allowed: dots, consecutive hyphens/underscores, or Python keywords.
 func ValidateAgentName(name string) error {
 	if name == "" {
 		return fmt.Errorf("agent name cannot be empty")
 	}
 
 	if !agentNameRegex.MatchString(name) {
-		return fmt.Errorf("agent name must start with a letter and contain only letters and digits (minimum 2 characters)")
+		return fmt.Errorf("agent name must start with a letter, end with a letter or digit, and contain only letters, digits, hyphens (-), and underscores (_) (minimum 2 characters)")
 	}
 
-	// Reject Python keywords to avoid issues in generated code
+	// Reject Python keywords (check the underscore-normalized form too)
+	normalized := strings.ReplaceAll(name, "-", "_")
 	if _, isKeyword := pythonKeywords[name]; isKeyword {
 		return fmt.Errorf("agent name %q is a Python keyword and cannot be used", name)
 	}
+	if _, isKeyword := pythonKeywords[normalized]; isKeyword {
+		return fmt.Errorf("agent name %q normalizes to Python keyword %q and cannot be used", name, normalized)
+	}
 
 	return nil
+}
+
+// AgentNameToPackage converts an agent name to a valid Python package name
+// by replacing hyphens with underscores.
+func AgentNameToPackage(name string) string {
+	return strings.ReplaceAll(name, "-", "_")
 }
 
 // ValidateMCPServerName checks if the MCP server name matches the required format.

--- a/pkg/validators/names_test.go
+++ b/pkg/validators/names_test.go
@@ -46,16 +46,18 @@ func TestValidateAgentName(t *testing.T) {
 		input   string
 		wantErr bool
 	}{
-		// Valid cases - letters and digits only, starts with letter, min 2 chars
+		// Valid cases
 		{"valid simple", "myagent", false},
 		{"valid alphanumeric", "agent123", false},
 		{"valid mixed case", "MyAgent2", false},
 		{"valid two chars", "ab", false},
+		{"valid with hyphen", "my-agent", false},
+		{"valid with underscore", "my_agent", false},
+		{"valid complex", "my-cool-agent123", false},
+		{"valid mixed separators", "my_cool-agent", false},
 
-		// Invalid - special characters not allowed
-		{"hyphen not allowed", "my-agent", true},
+		// Invalid - dots and other special characters not allowed
 		{"dot not allowed", "my.agent", true},
-		{"underscore not allowed", "my_agent", true},
 		{"contains slash", "my/agent", true},
 		{"contains space", "my agent", true},
 
@@ -63,6 +65,16 @@ func TestValidateAgentName(t *testing.T) {
 		{"starts with number", "123agent", true},
 		{"starts with dot", ".agent", true},
 		{"starts with hyphen", "-agent", true},
+		{"starts with underscore", "_agent", true},
+
+		// Invalid - must end with letter or digit
+		{"ends with hyphen", "agent-", true},
+		{"ends with underscore", "agent_", true},
+
+		// Invalid - consecutive separators
+		{"double hyphen", "my--agent", true},
+		{"double underscore", "my__agent", true},
+		{"hyphen underscore", "my-_agent", true},
 
 		// Invalid - too short
 		{"single char", "a", true},
@@ -72,6 +84,9 @@ func TestValidateAgentName(t *testing.T) {
 		{"python keyword class", "class", true},
 		{"python keyword import", "import", true},
 		{"python keyword return", "return", true},
+
+		// Invalid - normalizes to Python keyword
+		{"normalizes to keyword", "or", true},
 	}
 
 	for _, tt := range tests {
@@ -80,6 +95,28 @@ func TestValidateAgentName(t *testing.T) {
 			if (err != nil) != tt.wantErr {
 				t.Errorf("ValidateAgentName(%q) error = %v, wantErr %v",
 					tt.input, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestAgentNameToPackage(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"myagent", "myagent"},
+		{"my-agent", "my_agent"},
+		{"my-cool-agent", "my_cool_agent"},
+		{"my_agent", "my_agent"},
+		{"agent123", "agent123"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := AgentNameToPackage(tt.input)
+			if got != tt.want {
+				t.Errorf("AgentNameToPackage(%q) = %q, want %q", tt.input, got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- Agent names like `my-agent` and `my_agent` are now accepted by `arctl agent init`
- Hyphens are automatically converted to underscores for the Python package directory, following standard Python packaging conventions (PEP 503)
- Updated `ValidateAgentName` regex to allow hyphens/underscores (no consecutive, no trailing)
- Added `AgentNameToPackage()` helper and `PackageName()` method on `AgentConfig`
- Updated Dockerfile, docker-compose, and README templates to use `PackageName` where a valid Python identifier is needed
- Added comprehensive tests for the new validation rules and name conversion

Fixes #158

## Test plan
- [x] All existing validator tests pass
- [x] New test cases for hyphens, underscores, consecutive separators, trailing separators
- [x] `TestAgentNameToPackage` verifies hyphen-to-underscore conversion
- [x] `TestRenderComposeFromManifest` tests pass with PackageName field
- [x] Full `go build ./...` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)