### PR TITLE
fix: use user-provided name for MCP server k8s resources

### DIFF
--- a/internal/registry/service/registry_service.go
+++ b/internal/registry/service/registry_service.go
@@ -1229,6 +1229,7 @@ func (s *registryServiceImpl) resolveAgentManifestMCPServers(ctx context.Context
 			EnvValues:      make(map[string]string),
 			ArgValues:      make(map[string]string),
 			HeaderValues:   make(map[string]string),
+			Name:           mcpServer.Name,
 		})
 	}
 

--- a/internal/runtime/agentregistry_runtime.go
+++ b/internal/runtime/agentregistry_runtime.go
@@ -510,8 +510,13 @@ func createResolvedMCPServerConfigs(requests []*registry.MCPServerRunRequest) []
 			continue
 		}
 
+		// Use user-provided name when available, otherwise fall back to registry name
+		effectiveName := serverReq.Name
+		if effectiveName == "" {
+			effectiveName = server.Name
+		}
 		config := api.ResolvedMCPServerConfig{
-			Name: registry.GenerateInternalNameForDeployment(server.Name, serverReq.DeploymentID),
+			Name: registry.GenerateInternalNameForDeployment(effectiveName, serverReq.DeploymentID),
 		}
 
 		useRemote := len(server.Remotes) > 0 && (serverReq.PreferRemote || len(server.Packages) == 0)

--- a/internal/runtime/agentregistry_runtime_unit_test.go
+++ b/internal/runtime/agentregistry_runtime_unit_test.go
@@ -182,3 +182,29 @@ func TestCreateResolvedMCPServerConfigs_UsesDeploymentScopedNames(t *testing.T) 
 		t.Fatalf("expected non-scoped name for second config, got %q", configs[1].Name)
 	}
 }
+
+func TestCreateResolvedMCPServerConfigs_UsesUserProvidedName(t *testing.T) {
+	req := parseServerReqUnit(t, `{
+        "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
+        "name": "user/my-mcp-server",
+        "description": "Demo",
+        "version": "1.0.0",
+        "packages": [{
+          "registryType": "npm",
+          "identifier": "@example/mcp",
+          "version": "1.0.0",
+          "transport": {"type": "stdio"}
+        }]
+      }`)
+	// User provides a short name in agent.yaml
+	req.Name = "my-mcp-server"
+
+	configs := createResolvedMCPServerConfigs([]*registry.MCPServerRunRequest{req})
+	if len(configs) != 1 {
+		t.Fatalf("expected 1 resolved config, got %d", len(configs))
+	}
+	// Should use user-provided name, not the registry name
+	if configs[0].Name != "my-mcp-server" {
+		t.Fatalf("expected user-provided name 'my-mcp-server', got %q", configs[0].Name)
+	}
+}

--- a/internal/runtime/translation/registry/internal_registry_translator.go
+++ b/internal/runtime/translation/registry/internal_registry_translator.go
@@ -25,6 +25,9 @@ type MCPServerRunRequest struct {
 	EnvValues      map[string]string
 	ArgValues      map[string]string
 	HeaderValues   map[string]string
+	// Name is the user-provided name from agent.yaml. When set, it is used as
+	// the Kubernetes service/resource name instead of the registry server name.
+	Name string
 }
 
 type AgentRunRequest struct {
@@ -100,11 +103,18 @@ func (t *registryTranslator) TranslateMCPServer(
 	useRemote := len(req.RegistryServer.Remotes) > 0 && (req.PreferRemote || len(req.RegistryServer.Packages) == 0)
 	usePackage := len(req.RegistryServer.Packages) > 0 && (!req.PreferRemote || len(req.RegistryServer.Remotes) == 0)
 
+	// Use user-provided name when available, otherwise fall back to registry name
+	effectiveName := req.Name
+	if effectiveName == "" {
+		effectiveName = req.RegistryServer.Name
+	}
+
 	switch {
 	case useRemote:
 		return translateRemoteMCPServer(
 			ctx,
 			req.RegistryServer,
+			effectiveName,
 			req.DeploymentID,
 			req.HeaderValues,
 		)
@@ -112,6 +122,7 @@ func (t *registryTranslator) TranslateMCPServer(
 		return translateLocalMCPServer(
 			ctx,
 			req.RegistryServer,
+			effectiveName,
 			req.DeploymentID,
 			req.EnvValues,
 			req.ArgValues,
@@ -124,6 +135,7 @@ func (t *registryTranslator) TranslateMCPServer(
 func translateRemoteMCPServer(
 	ctx context.Context,
 	registryServer *apiv0.ServerJSON,
+	name string,
 	deploymentID string,
 	headerValues map[string]string,
 ) (*api.MCPServer, error) {
@@ -149,7 +161,7 @@ func translateRemoteMCPServer(
 	}
 
 	return &api.MCPServer{
-		Name:          GenerateInternalName(registryServer.Name),
+		Name:          GenerateInternalName(name),
 		DeploymentID:  deploymentID,
 		MCPServerType: api.MCPServerTypeRemote,
 		Remote: &api.RemoteMCPServer{
@@ -164,6 +176,7 @@ func translateRemoteMCPServer(
 func translateLocalMCPServer(
 	ctx context.Context,
 	registryServer *apiv0.ServerJSON,
+	name string,
 	deploymentID string,
 	envValues map[string]string,
 	argValues map[string]string,
@@ -246,7 +259,7 @@ func translateLocalMCPServer(
 	}
 
 	return &api.MCPServer{
-		Name:          GenerateInternalName(registryServer.Name),
+		Name:          GenerateInternalName(name),
 		DeploymentID:  deploymentID,
 		MCPServerType: api.MCPServerTypeLocal,
 		Local: &api.LocalMCPServer{


### PR DESCRIPTION
# Description

- When `agent.yaml` specifies a `name` for a registry-type MCP server (e.g. `name: my-mcp-server`), that name is now used as the k8s service/resource name instead of the full registry name (`user/my-mcp-server` → `user-my-mcp-server`)
- Ensures the k8s service name matches what gets written to `mcp-servers.json`, allowing the agent to connect
- Falls back to registry server name when no user-provided name is set (backward compatible)

Fixes #146

# Change Type 

```
/kind fix
```

# Changelog

```release-note
use user-provided name for MCP server (not the registry name)
```

## Test plan
- [x] New unit test: `TestCreateResolvedMCPServerConfigs_UsesUserProvidedName`
- [x] Existing tests pass unchanged
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)