### PR TITLE
fix: unlock EMBEDDINGS_DIMENSIONS from hardcoded 1536

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -58,6 +58,9 @@ AGENT_REGISTRY_AGENT_GATEWAY_PORT=8081
 AGENT_REGISTRY_EMBEDDINGS_ENABLED=false
 AGENT_REGISTRY_EMBEDDINGS_PROVIDER=openai
 AGENT_REGISTRY_EMBEDDINGS_MODEL=text-embedding-3-small
+# Dimensions must match your embedding provider/model (e.g., 1536 for OpenAI text-embedding-3-small,
+# 1024 for Voyage AI voyage-3, 3072 for OpenAI text-embedding-3-large).
+# On startup the server reconciles the database schema to match this value.
 AGENT_REGISTRY_EMBEDDINGS_DIMENSIONS=1536
 AGENT_REGISTRY_EMBEDDINGS_ON_PUBLISH=false
 AGENT_REGISTRY_OPENAI_API_KEY=

--- a/internal/registry/config/validate.go
+++ b/internal/registry/config/validate.go
@@ -12,9 +12,8 @@ func Validate(cfg *Config) error {
 		if cfg.Embeddings.Dimensions <= 0 {
 			return fmt.Errorf("embeddings dimensions must be positive (got %d)", cfg.Embeddings.Dimensions)
 		}
-		// Database schema currently provisions vector(1536). Reject mismatches early.
-		if cfg.Embeddings.Dimensions != 1536 {
-			return fmt.Errorf("embeddings dimensions must equal 1536 to match database schema (got %d)", cfg.Embeddings.Dimensions)
+		if cfg.Embeddings.Dimensions > 16384 {
+			return fmt.Errorf("embeddings dimensions must not exceed 16384 (got %d)", cfg.Embeddings.Dimensions)
 		}
 		if cfg.Embeddings.Model == "" {
 			return fmt.Errorf("embeddings model must be specified when embeddings are enabled")

--- a/internal/registry/config/validate_test.go
+++ b/internal/registry/config/validate_test.go
@@ -1,0 +1,62 @@
+package config
+
+import (
+	"testing"
+)
+
+func TestValidate_EmbeddingsDimensions(t *testing.T) {
+	tests := []struct {
+		name       string
+		dimensions int
+		wantErr    bool
+		errMsg     string
+	}{
+		{"valid default 1536", 1536, false, ""},
+		{"valid 1024 (Voyage AI)", 1024, false, ""},
+		{"valid 3072 (OpenAI large)", 3072, false, ""},
+		{"valid 768", 768, false, ""},
+		{"zero dimensions", 0, true, "must be positive"},
+		{"negative dimensions", -1, true, "must be positive"},
+		{"exceeds max", 16385, true, "must not exceed 16384"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &Config{
+				Embeddings: EmbeddingsConfig{
+					Enabled:    true,
+					Dimensions: tt.dimensions,
+					Model:      "test-model",
+					Provider:   "openai",
+				},
+			}
+			err := Validate(cfg)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("Validate() expected error containing %q, got nil", tt.errMsg)
+				} else if tt.errMsg != "" {
+					if !containsSubstring(err.Error(), tt.errMsg) {
+						t.Errorf("Validate() error = %q, want substring %q", err.Error(), tt.errMsg)
+					}
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Validate() unexpected error: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func containsSubstring(s, substr string) bool {
+	return len(s) >= len(substr) && searchSubstring(s, substr)
+}
+
+func searchSubstring(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/registry/database/reconcile_embeddings.go
+++ b/internal/registry/database/reconcile_embeddings.go
@@ -1,0 +1,120 @@
+package database
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// ReconcileEmbeddingDimensions ensures the vector column dimensions in the
+// database match the configured EMBEDDINGS_DIMENSIONS value. When a mismatch
+// is detected it drops the HNSW indexes, clears stale embeddings, alters the
+// column type, and recreates the indexes inside a single transaction.
+//
+// This is safe because:
+//   - Existing deployments with matching dimensions are a no-op.
+//   - Clearing embeddings on dimension change is correct (old vectors are
+//     incompatible with the new dimension).
+//   - The reconciliation runs once on startup, not per-request.
+// ReconcileEmbeddingDimensions reconciles embedding column dimensions using
+// the database's connection pool.
+func (db *PostgreSQL) ReconcileEmbeddingDimensions(ctx context.Context, dimensions int) error {
+	return reconcileEmbeddingDimensions(ctx, db.pool, dimensions)
+}
+
+func reconcileEmbeddingDimensions(ctx context.Context, pool *pgxpool.Pool, dimensions int) error {
+	if dimensions <= 0 {
+		return fmt.Errorf("reconcile embeddings: dimensions must be positive (got %d)", dimensions)
+	}
+
+	// Check current vector column dimension from the servers table.
+	var currentDim int
+	err := pool.QueryRow(ctx, `
+		SELECT atttypmod
+		FROM pg_attribute
+		WHERE attrelid = 'servers'::regclass
+		  AND attname = 'semantic_embedding'
+		  AND NOT attisdropped
+	`).Scan(&currentDim)
+	if err != nil {
+		// If the column doesn't exist yet (e.g., embeddings never enabled),
+		// skip reconciliation — migrations will handle creation.
+		slog.Info("skipping embedding dimension reconciliation: could not read column info", "error", err)
+		return nil
+	}
+
+	if currentDim == dimensions {
+		slog.Info("embedding dimensions match database schema", "dimensions", dimensions)
+		return nil
+	}
+
+	slog.Warn("embedding dimension mismatch detected, reconciling",
+		"current", currentDim,
+		"configured", dimensions,
+	)
+
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("reconcile embeddings: begin transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	// Drop HNSW indexes (must be dropped before altering column type).
+	for _, idx := range []string{
+		"idx_servers_semantic_embedding_hnsw",
+		"idx_agents_semantic_embedding_hnsw",
+	} {
+		if _, err := tx.Exec(ctx, fmt.Sprintf("DROP INDEX IF EXISTS %s", idx)); err != nil {
+			return fmt.Errorf("reconcile embeddings: drop index %s: %w", idx, err)
+		}
+	}
+
+	// Clear stale embeddings — old vectors are incompatible with new dimensions.
+	for _, table := range []string{"servers", "agents"} {
+		if _, err := tx.Exec(ctx, fmt.Sprintf(`
+			UPDATE %s SET
+				semantic_embedding = NULL,
+				semantic_embedding_provider = NULL,
+				semantic_embedding_model = NULL,
+				semantic_embedding_dimensions = NULL,
+				semantic_embedding_checksum = NULL,
+				semantic_embedding_generated_at = NULL
+		`, table)); err != nil {
+			return fmt.Errorf("reconcile embeddings: clear %s embeddings: %w", table, err)
+		}
+	}
+
+	// Alter column types to the new dimension.
+	for _, table := range []string{"servers", "agents"} {
+		sql := fmt.Sprintf("ALTER TABLE %s ALTER COLUMN semantic_embedding TYPE vector(%d)", table, dimensions)
+		if _, err := tx.Exec(ctx, sql); err != nil {
+			return fmt.Errorf("reconcile embeddings: alter %s column: %w", table, err)
+		}
+	}
+
+	// Recreate HNSW indexes with the new dimension.
+	for _, spec := range []struct{ table, index string }{
+		{"servers", "idx_servers_semantic_embedding_hnsw"},
+		{"agents", "idx_agents_semantic_embedding_hnsw"},
+	} {
+		sql := fmt.Sprintf(
+			"CREATE INDEX %s ON %s USING hnsw (semantic_embedding vector_cosine_ops)",
+			spec.index, spec.table,
+		)
+		if _, err := tx.Exec(ctx, sql); err != nil {
+			return fmt.Errorf("reconcile embeddings: create index %s: %w", spec.index, err)
+		}
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return fmt.Errorf("reconcile embeddings: commit: %w", err)
+	}
+
+	slog.Info("embedding dimensions reconciled successfully",
+		"old", currentDim,
+		"new", dimensions,
+	)
+	return nil
+}

--- a/internal/registry/database/reconcile_embeddings_test.go
+++ b/internal/registry/database/reconcile_embeddings_test.go
@@ -1,0 +1,107 @@
+package database
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestReconcileEmbeddingDimensions_MatchingDimensions(t *testing.T) {
+	db := NewTestDB(t)
+	pg, ok := db.(*PostgreSQL)
+	if !ok {
+		t.Skip("test requires PostgreSQL backend")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// Default schema uses vector(1536). Reconciling with 1536 should be a no-op.
+	err := pg.ReconcileEmbeddingDimensions(ctx, 1536)
+	require.NoError(t, err)
+
+	// Verify column is still 1536.
+	var dim int
+	err = pg.pool.QueryRow(ctx, `
+		SELECT atttypmod
+		FROM pg_attribute
+		WHERE attrelid = 'servers'::regclass
+		  AND attname = 'semantic_embedding'
+		  AND NOT attisdropped
+	`).Scan(&dim)
+	require.NoError(t, err)
+	require.Equal(t, 1536, dim)
+}
+
+func TestReconcileEmbeddingDimensions_ChangeDimensions(t *testing.T) {
+	db := NewTestDB(t)
+	pg, ok := db.(*PostgreSQL)
+	if !ok {
+		t.Skip("test requires PostgreSQL backend")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// Change from default 1536 to 1024.
+	err := pg.ReconcileEmbeddingDimensions(ctx, 1024)
+	require.NoError(t, err)
+
+	// Verify servers column is now 1024.
+	var serversDim int
+	err = pg.pool.QueryRow(ctx, `
+		SELECT atttypmod
+		FROM pg_attribute
+		WHERE attrelid = 'servers'::regclass
+		  AND attname = 'semantic_embedding'
+		  AND NOT attisdropped
+	`).Scan(&serversDim)
+	require.NoError(t, err)
+	require.Equal(t, 1024, serversDim)
+
+	// Verify agents column is also 1024.
+	var agentsDim int
+	err = pg.pool.QueryRow(ctx, `
+		SELECT atttypmod
+		FROM pg_attribute
+		WHERE attrelid = 'agents'::regclass
+		  AND attname = 'semantic_embedding'
+		  AND NOT attisdropped
+	`).Scan(&agentsDim)
+	require.NoError(t, err)
+	require.Equal(t, 1024, agentsDim)
+
+	// Verify HNSW indexes were recreated.
+	for _, idx := range []string{
+		"idx_servers_semantic_embedding_hnsw",
+		"idx_agents_semantic_embedding_hnsw",
+	} {
+		var exists bool
+		err = pg.pool.QueryRow(ctx,
+			"SELECT EXISTS(SELECT 1 FROM pg_indexes WHERE indexname = $1)", idx,
+		).Scan(&exists)
+		require.NoError(t, err)
+		require.True(t, exists, "HNSW index %s should exist after reconciliation", idx)
+	}
+}
+
+func TestReconcileEmbeddingDimensions_InvalidDimensions(t *testing.T) {
+	db := NewTestDB(t)
+	pg, ok := db.(*PostgreSQL)
+	if !ok {
+		t.Skip("test requires PostgreSQL backend")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	err := pg.ReconcileEmbeddingDimensions(ctx, 0)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "must be positive")
+
+	err = pg.ReconcileEmbeddingDimensions(ctx, -1)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "must be positive")
+}

--- a/internal/registry/registry_app.go
+++ b/internal/registry/registry_app.go
@@ -90,6 +90,15 @@ func App(_ context.Context, opts ...types.AppOptions) error {
 			return fmt.Errorf("failed to connect to PostgreSQL: %w", err)
 		}
 
+		// Reconcile embedding vector column dimensions if embeddings are enabled.
+		// This ensures the database schema matches EMBEDDINGS_DIMENSIONS, allowing
+		// providers with non-1536 dimensions (e.g., Voyage AI 1024, OpenAI 3072).
+		if cfg.Embeddings.Enabled {
+			if err := baseDB.ReconcileEmbeddingDimensions(ctx, cfg.Embeddings.Dimensions); err != nil {
+				return fmt.Errorf("failed to reconcile embedding dimensions: %w", err)
+			}
+		}
+
 		// Allow implementors to wrap the database and run additional migrations
 		db = baseDB
 		if options.DatabaseFactory != nil {


### PR DESCRIPTION
# Description

**Motivation:** The `EMBEDDINGS_DIMENSIONS` env var exists but is locked to `1536` by a validation check, making it impossible to use embedding providers with different default dimensions (Voyage AI 1024, Cohere 1024, OpenAI text-embedding-3-large 3072).

**What changed:**
- Removed the hardcoded `== 1536` validation in `validate.go`, replaced with a reasonable upper bound (16384)
- Added `ReconcileEmbeddingDimensions` to the database layer that runs at startup when embeddings are enabled
- On dimension mismatch: drops HNSW indexes, clears stale embeddings, alters vector columns, recreates indexes — all in a single transaction
- When dimensions match (default 1536 case): no-op

Fixes #221

# Change Type

/kind fix

# Changelog

```release-note
EMBEDDINGS_DIMENSIONS is no longer locked to 1536. Operators can now configure any dimension to match their embedding provider (e.g., 1024 for Voyage AI, 3072 for OpenAI text-embedding-3-large). The database schema is reconciled automatically at startup.
```

# Additional Notes

- Existing 1536 deployments are completely unaffected (reconciliation is a no-op when dimensions match)
- Clearing embeddings on dimension change is correct — old vectors are incompatible with new dimensions and must be regenerated
- Added unit tests for validation and integration tests for the reconciliation logic