### PR TITLE
feat(cli): add `arctl skill build` command

### DIFF
--- a/internal/cli/skill/build.go
+++ b/internal/cli/skill/build.go
@@ -1,0 +1,113 @@
+package skill
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/agentregistry-dev/agentregistry/internal/cli/common"
+	"github.com/agentregistry-dev/agentregistry/internal/cli/common/docker"
+	"github.com/agentregistry-dev/agentregistry/pkg/printer"
+	"github.com/spf13/cobra"
+)
+
+var BuildCmd = &cobra.Command{
+	Use:   "build <skill-folder-path>",
+	Short: "Build a skill as a Docker image",
+	Long: `Build a skill from a local folder containing SKILL.md.
+
+This command builds a Docker image for the skill without publishing
+it to the registry. Use 'arctl skill publish' to publish afterward.`,
+	Args:          cobra.ExactArgs(1),
+	RunE:          runSkillBuild,
+	SilenceUsage:  true,
+	SilenceErrors: false,
+	Example: `  arctl skill build ./my-skill
+  arctl skill build ./my-skill --docker-url docker.io/myorg
+  arctl skill build ./my-skill --docker-url docker.io/myorg --push
+  arctl skill build ./my-skill --tag v1.0.0 --platform linux/amd64,linux/arm64`,
+}
+
+var (
+	buildDockerURL  string
+	buildTag        string
+	buildPlatform   string
+	buildPush       bool
+	buildDockerName string
+)
+
+func init() {
+	BuildCmd.Flags().StringVar(&buildDockerURL, "docker-url", "", "Docker registry URL prefix (e.g., docker.io/myorg)")
+	BuildCmd.Flags().StringVar(&buildTag, "tag", "latest", "Docker image tag")
+	BuildCmd.Flags().StringVar(&buildPlatform, "platform", "", "Target platform (e.g., linux/amd64,linux/arm64)")
+	BuildCmd.Flags().BoolVar(&buildPush, "push", false, "Push Docker image after building")
+	BuildCmd.Flags().StringVarP(&buildDockerName, "name", "n", "", "Override Docker image name (default: skill name from SKILL.md)")
+}
+
+func runSkillBuild(_ *cobra.Command, args []string) error {
+	skillPath := args[0]
+
+	// Validate the skill folder
+	info, err := os.Stat(skillPath)
+	if err != nil {
+		return fmt.Errorf("skill path does not exist: %s", skillPath)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("skill path is not a directory: %s", skillPath)
+	}
+
+	// Resolve skill name from SKILL.md frontmatter
+	name, _, err := resolveSkillMeta(skillPath)
+	if err != nil {
+		return fmt.Errorf("failed to read skill metadata: %w", err)
+	}
+
+	if buildDockerName != "" {
+		name = buildDockerName
+	}
+
+	// Construct image reference
+	var imageRef string
+	if buildDockerURL != "" {
+		imageRef = common.BuildRegistryImageName(strings.TrimSuffix(buildDockerURL, "/"), name, buildTag)
+	} else {
+		imageRef = common.BuildLocalImageName(name, buildTag)
+	}
+
+	printer.PrintInfo(fmt.Sprintf("Building Docker image: %s", imageRef))
+
+	// Build using inline Dockerfile (same approach as skill publish)
+	buildArgs := []string{"build", "-t", imageRef}
+	if buildPlatform != "" {
+		buildArgs = append(buildArgs, "--platform", buildPlatform)
+	}
+	buildArgs = append(buildArgs, "-f", "-", skillPath)
+
+	if verbose {
+		printer.PrintInfo("Running: docker " + strings.Join(buildArgs, " "))
+	}
+
+	cmd := exec.Command("docker", buildArgs...)
+	cmd.Dir = skillPath
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Stdin = strings.NewReader("FROM scratch\nCOPY . .\n")
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("docker build failed: %w", err)
+	}
+
+	printer.PrintSuccess(fmt.Sprintf("Built Docker image: %s", imageRef))
+
+	// Push if requested
+	if buildPush {
+		printer.PrintInfo(fmt.Sprintf("Pushing Docker image: %s", imageRef))
+		executor := docker.NewExecutor(false, "")
+		if err := executor.Push(imageRef); err != nil {
+			return fmt.Errorf("docker push failed: %w", err)
+		}
+		printer.PrintSuccess(fmt.Sprintf("Pushed Docker image: %s", imageRef))
+	}
+
+	return nil
+}

--- a/internal/cli/skill/build_test.go
+++ b/internal/cli/skill/build_test.go
@@ -1,0 +1,60 @@
+package skill
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRunSkillBuild_MissingPath(t *testing.T) {
+	err := runSkillBuild(nil, []string{"/nonexistent/path"})
+	if err == nil {
+		t.Fatal("expected error for nonexistent path, got nil")
+	}
+}
+
+func TestRunSkillBuild_NotADirectory(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "notadir")
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+
+	err = runSkillBuild(nil, []string{f.Name()})
+	if err == nil {
+		t.Fatal("expected error for non-directory path, got nil")
+	}
+}
+
+func TestRunSkillBuild_MissingSkillMd(t *testing.T) {
+	dir := t.TempDir()
+	err := runSkillBuild(nil, []string{dir})
+	if err == nil {
+		t.Fatal("expected error for missing SKILL.md, got nil")
+	}
+}
+
+func TestRunSkillBuild_ValidSkillMd(t *testing.T) {
+	dir := t.TempDir()
+	skillMd := `---
+name: test-skill
+description: A test skill
+---
+# Test Skill
+`
+	if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(skillMd), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// This will fail because Docker isn't available in test, but it should
+	// get past the metadata parsing stage
+	err := runSkillBuild(nil, []string{dir})
+	if err == nil {
+		// Docker might actually be available; that's OK too
+		return
+	}
+	// Should fail at Docker build stage, not at metadata parsing
+	if err.Error() == "failed to read skill metadata" {
+		t.Errorf("should have parsed SKILL.md successfully, got: %v", err)
+	}
+}

--- a/internal/cli/skill/skill.go
+++ b/internal/cli/skill/skill.go
@@ -19,6 +19,7 @@ var SkillCmd = &cobra.Command{
 	Args:  cobra.ArbitraryArgs,
 	Example: `arctl skill list
 arctl skill show my-skill
+arctl skill build ./my-skill
 arctl skill publish ./my-skill
 arctl skill delete my-skill --version 1.0.0`,
 }
@@ -27,6 +28,7 @@ func init() {
 	SkillCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Enable verbose output")
 
 	SkillCmd.AddCommand(InitCmd)
+	SkillCmd.AddCommand(BuildCmd)
 	SkillCmd.AddCommand(ListCmd)
 	SkillCmd.AddCommand(PublishCmd)
 	SkillCmd.AddCommand(DeleteCmd)


### PR DESCRIPTION
# Description

Adds a standalone `arctl skill build` command that mirrors the existing `arctl mcp build` pattern. This separates the Docker image build step from `arctl skill publish`, so users can build and test skill images locally before publishing to the registry.

**What changed:**
- New `internal/cli/skill/build.go` implementing the build command
- New `internal/cli/skill/build_test.go` with unit tests for validation logic
- Registered `BuildCmd` in the skill command group

**Usage:**
```bash
arctl skill build ./my-skill                                     # Build local image
arctl skill build ./my-skill --docker-url docker.io/myorg        # Build with registry prefix
arctl skill build ./my-skill --docker-url docker.io/myorg --push # Build and push
arctl skill build ./my-skill --tag v1.0.0 --platform linux/amd64 # With tag and platform
```

**Flags:**
- `--docker-url` — Docker registry URL prefix (e.g., `docker.io/myorg`)
- `--tag` — Docker image tag (default: `latest`)
- `--platform` — Target platform (e.g., `linux/amd64,linux/arm64`)
- `--push` — Push image after building
- `-n, --name` — Override image name (default: skill name from SKILL.md)

Fixes #243

# Change Type

/kind feature

# Changelog

```release-note
Added `arctl skill build` command for building skill Docker images independently of publish
```

# Additional Notes

Follows the same pattern as `arctl mcp build` — uses the `docker` package for push, `common` package for image name construction, and reads SKILL.md frontmatter for the skill name.