### PR TITLE
fix: hide registry flags from init command help output

### DIFF
--- a/internal/cli/agent/init.go
+++ b/internal/cli/agent/init.go
@@ -11,6 +11,7 @@ import (
 	"github.com/agentregistry-dev/agentregistry/internal/version"
 	"github.com/agentregistry-dev/agentregistry/pkg/validators"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 const adkBaseImageVersion = "0.7.12"
@@ -55,6 +56,23 @@ func init() {
 	InitCmd.Flags().StringVar(&initDescription, "description", "", "Description for the agent")
 	InitCmd.Flags().StringVar(&initTelemetryEndpoint, "telemetry", "", "OTLP endpoint URL for OpenTelemetry traces (e.g., http://localhost:4318/v1/traces)")
 	InitCmd.Flags().StringVar(&initImage, "image", "", "Docker image name including tag (e.g., ghcr.io/myorg/myagent:v1.0, docker.io/user/image:latest)")
+
+	hideRegistryFlags(InitCmd)
+}
+
+// hideRegistryFlags hides the inherited --registry-url and --registry-token
+// flags from the help output of commands that don't interact with the registry.
+func hideRegistryFlags(cmd *cobra.Command) {
+	origHelp := cmd.HelpFunc()
+	cmd.SetHelpFunc(func(c *cobra.Command, args []string) {
+		for _, name := range []string{"registry-url", "registry-token"} {
+			if f := c.InheritedFlags().Lookup(name); f != nil {
+				f.Hidden = true
+				defer func(fl *pflag.Flag) { fl.Hidden = false }(f)
+			}
+		}
+		origHelp(c, args)
+	})
 }
 
 func runInit(cmd *cobra.Command, args []string) error {

--- a/internal/cli/mcp/init.go
+++ b/internal/cli/mcp/init.go
@@ -14,6 +14,7 @@ import (
 	"github.com/agentregistry-dev/agentregistry/pkg/validators"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 var InitCmd = &cobra.Command{
@@ -44,6 +45,23 @@ func init() {
 	InitCmd.PersistentFlags().StringVar(&initDescription, "description", "", "Description for the project")
 	InitCmd.PersistentFlags().BoolVar(&initNonInteractive, "non-interactive", false, "Run in non-interactive mode")
 	InitCmd.PersistentFlags().StringVar(&initVersion, "version", "0.1.0", "Version for the project (default: 0.1.0)")
+
+	hideRegistryFlags(InitCmd)
+}
+
+// hideRegistryFlags hides the inherited --registry-url and --registry-token
+// flags from the help output of commands that don't interact with the registry.
+func hideRegistryFlags(cmd *cobra.Command) {
+	origHelp := cmd.HelpFunc()
+	cmd.SetHelpFunc(func(c *cobra.Command, args []string) {
+		for _, name := range []string{"registry-url", "registry-token"} {
+			if f := c.InheritedFlags().Lookup(name); f != nil {
+				f.Hidden = true
+				defer func(fl *pflag.Flag) { fl.Hidden = false }(f)
+			}
+		}
+		origHelp(c, args)
+	})
 }
 
 func runInit(cmd *cobra.Command, args []string) error {

--- a/internal/cli/mcp/init_test.go
+++ b/internal/cli/mcp/init_test.go
@@ -1,0 +1,37 @@
+package mcp
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestInitCmd_HidesRegistryFlags(t *testing.T) {
+	// Simulate the root command hierarchy with persistent registry flags
+	root := &cobra.Command{Use: "arctl"}
+	root.PersistentFlags().String("registry-url", "", "Registry base URL")
+	root.PersistentFlags().String("registry-token", "", "Registry bearer token")
+
+	mcpCmd := &cobra.Command{Use: "mcp"}
+	root.AddCommand(mcpCmd)
+	mcpCmd.AddCommand(InitCmd)
+
+	// Capture the help output
+	buf := new(bytes.Buffer)
+	InitCmd.SetOut(buf)
+	InitCmd.SetErr(buf)
+	root.SetArgs([]string{"mcp", "init", "--help"})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("Execute() error: %v", err)
+	}
+
+	output := buf.String()
+	if strings.Contains(output, "registry-url") {
+		t.Error("--registry-url should be hidden from mcp init --help output")
+	}
+	if strings.Contains(output, "registry-token") {
+		t.Error("--registry-token should be hidden from mcp init --help output")
+	}
+}

--- a/internal/cli/skill/init.go
+++ b/internal/cli/skill/init.go
@@ -8,6 +8,7 @@ import (
 	"github.com/agentregistry-dev/agentregistry/pkg/validators"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 var InitCmd = &cobra.Command{
@@ -29,6 +30,23 @@ func init() {
 	InitCmd.PersistentFlags().BoolVar(&initNoGit, "no-git", false, "Skip git initialization")
 	InitCmd.PersistentFlags().BoolVar(&initVerbose, "verbose", false, "Enable verbose output during initialization")
 	InitCmd.PersistentFlags().BoolVar(&initEmpty, "empty", false, "Create an empty skill project")
+
+	hideRegistryFlags(InitCmd)
+}
+
+// hideRegistryFlags hides the inherited --registry-url and --registry-token
+// flags from the help output of commands that don't interact with the registry.
+func hideRegistryFlags(cmd *cobra.Command) {
+	origHelp := cmd.HelpFunc()
+	cmd.SetHelpFunc(func(c *cobra.Command, args []string) {
+		for _, name := range []string{"registry-url", "registry-token"} {
+			if f := c.InheritedFlags().Lookup(name); f != nil {
+				f.Hidden = true
+				defer func(fl *pflag.Flag) { fl.Hidden = false }(f)
+			}
+		}
+		origHelp(c, args)
+	})
 }
 
 func runInit(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
## Summary
- Hides `--registry-url` and `--registry-token` from `--help` output for `mcp init`, `agent init`, and `skill init` commands
- These init commands are local scaffolding operations that don't interact with the registry, so showing registry flags is confusing
- Uses a custom help function that temporarily hides inherited flags during rendering, then restores them so other commands still show them

Fixes #115

## Test plan
- [x] New `TestInitCmd_HidesRegistryFlags`: verifies registry flags are absent from `mcp init --help` output
- [x] All existing CLI tests pass
- [x] Manually verified: flags still visible for commands that need them (e.g., `mcp list --help`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)