### PR TITLE
fix: add --tag flag to mcp publish as alias for --version

### DIFF
--- a/internal/cli/mcp/publish.go
+++ b/internal/cli/mcp/publish.go
@@ -28,6 +28,7 @@ var (
 	dryRunFlag          bool
 	overwriteFlag       bool
 	publishVersion      string
+	publishTag          string
 	githubRepository    string
 	publishTransport    string
 	publishTransportURL string
@@ -44,6 +45,7 @@ func init() {
 	PublishCmd.Flags().BoolVar(&dryRunFlag, "dry-run", false, "Show what would be done without actually doing it")
 	PublishCmd.Flags().BoolVar(&overwriteFlag, "overwrite", false, "Overwrite if the version is already published")
 	PublishCmd.Flags().StringVar(&publishVersion, "version", "", "Server version")
+	PublishCmd.Flags().StringVar(&publishTag, "tag", "", "Server version (alias for --version)")
 	PublishCmd.Flags().StringVar(&githubRepository, "github", "", "GitHub repository URL")
 	PublishCmd.Flags().StringVar(&publishTransport, "transport", "", "Transport type: stdio or streamable-http")
 	PublishCmd.Flags().StringVar(&publishTransportURL, "transport-url", "", "Transport URL for streamable-http transport")
@@ -115,6 +117,11 @@ func runMCPServerPublish(cmd *cobra.Command, args []string) error {
 	input := "."
 	if len(args) > 0 {
 		input = args[0]
+	}
+
+	// Resolve --tag as alias for --version
+	if publishVersion == "" && publishTag != "" {
+		publishVersion = publishTag
 	}
 
 	var serverName, description, version string

--- a/internal/cli/mcp/publish_test.go
+++ b/internal/cli/mcp/publish_test.go
@@ -265,6 +265,64 @@ func TestBuildServerJSON(t *testing.T) {
 	}
 }
 
+func TestTagFlagResolvesToVersion(t *testing.T) {
+	tests := []struct {
+		name            string
+		version         string
+		tag             string
+		expectedVersion string
+	}{
+		{
+			name:            "version takes precedence over tag",
+			version:         "2.0.0",
+			tag:             "1.0.0",
+			expectedVersion: "2.0.0",
+		},
+		{
+			name:            "tag used when version is empty",
+			version:         "",
+			tag:             "1.0.0",
+			expectedVersion: "1.0.0",
+		},
+		{
+			name:            "both empty stays empty",
+			version:         "",
+			tag:             "",
+			expectedVersion: "",
+		},
+		{
+			name:            "version set, tag empty",
+			version:         "3.0.0",
+			tag:             "",
+			expectedVersion: "3.0.0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Simulate the resolution logic from runMCPServerPublish
+			version := tt.version
+			tag := tt.tag
+			if version == "" && tag != "" {
+				version = tag
+			}
+			if version != tt.expectedVersion {
+				t.Errorf("expected version %q but got %q", tt.expectedVersion, version)
+			}
+		})
+	}
+}
+
+func TestPublishCmdHasTagFlag(t *testing.T) {
+	flag := PublishCmd.Flags().Lookup("tag")
+	if flag == nil {
+		t.Fatal("expected --tag flag to be registered on PublishCmd")
+	}
+	if flag.DefValue != "" {
+		t.Errorf("expected --tag default to be empty but got %q", flag.DefValue)
+	}
+}
+
 func TestRegistryTypeRuntimeHints(t *testing.T) {
 	tests := []struct {
 		regType  string


### PR DESCRIPTION
# Description

**Motivation:** The `arctl skill publish` command has a `--tag` flag, but `arctl mcp publish` does not. This inconsistency means users who try `--tag` with `mcp publish` get a silent failure.

**What changed:** Added `--tag` flag to `arctl mcp publish` as an alias for `--version`. When `--version` is not set, `--tag` is used as the server version. `--version` takes precedence when both flags are provided.

**Related issues:** Fixes #148

/kind fix

# Changelog

```release-note
Add --tag flag to mcp publish command as alias for --version
```

# Additional Notes

- Follows the same precedence pattern as `arctl skill publish`
- New table-driven tests cover: version precedence, tag fallback, both empty, version-only