### PR TITLE
fix: handle transient network errors in PyPI validation test

### DIFF
--- a/internal/registry/validators/registries/pypi_test.go
+++ b/internal/registry/validators/registries/pypi_test.go
@@ -2,6 +2,7 @@ package registries_test
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/agentregistry-dev/agentregistry/internal/registry/validators/registries"
@@ -14,12 +15,14 @@ func TestValidatePyPI_RealPackages(t *testing.T) {
 	ctx := context.Background()
 
 	tests := []struct {
-		name         string
-		packageName  string
-		version      string
-		serverName   string
-		expectError  bool
-		errorMessage string
+		name          string
+		packageName   string
+		version       string
+		serverName    string
+		expectError   bool
+		errorMessage  string
+		networkBound  bool // true if test depends on PyPI being reachable
+		allowNetError bool // true if network errors are acceptable (e.g. non-existent package)
 	}{
 		{
 			name:         "empty package identifier should fail",
@@ -38,12 +41,14 @@ func TestValidatePyPI_RealPackages(t *testing.T) {
 			errorMessage: "package version is required for PyPI packages",
 		},
 		{
-			name:         "non-existent package should fail",
-			packageName:  generateRandomPackageName(),
-			version:      "1.0.0",
-			serverName:   "com.example/test",
-			expectError:  true,
-			errorMessage: "not found",
+			name:          "non-existent package should fail",
+			packageName:   generateRandomPackageName(),
+			version:       "1.0.0",
+			serverName:    "com.example/test",
+			expectError:   true,
+			errorMessage:  "not found",
+			networkBound:  true,
+			allowNetError: true,
 		},
 		{
 			name:         "real package without MCP server name should fail",
@@ -52,6 +57,7 @@ func TestValidatePyPI_RealPackages(t *testing.T) {
 			serverName:   "com.example/test",
 			expectError:  true,
 			errorMessage: "ownership validation failed",
+			networkBound: true,
 		},
 		{
 			name:         "real package with different server name should fail",
@@ -60,13 +66,15 @@ func TestValidatePyPI_RealPackages(t *testing.T) {
 			serverName:   "com.example/completely-different-name",
 			expectError:  true,
 			errorMessage: "ownership validation failed", // Will fail because numpy doesn't have this server name
+			networkBound: true,
 		},
 		{
-			name:        "real package with server name in README should pass",
-			packageName: "time-mcp-pypi",
-			version:     "1.0.6",
-			serverName:  "io.github.domdomegg/time-mcp-pypi",
-			expectError: false,
+			name:         "real package with server name in README should pass",
+			packageName:  "time-mcp-pypi",
+			version:      "1.0.6",
+			serverName:   "io.github.domdomegg/time-mcp-pypi",
+			expectError:  false,
+			networkBound: true,
 		},
 	}
 
@@ -82,10 +90,41 @@ func TestValidatePyPI_RealPackages(t *testing.T) {
 
 			if tt.expectError {
 				require.Error(t, err)
-				assert.Contains(t, err.Error(), tt.errorMessage)
+				errMsg := err.Error()
+				// For network-bound tests, a timeout or connection error is
+				// an acceptable alternative to the expected message since the
+				// test still proves the package cannot be validated.
+				if tt.allowNetError && isNetworkError(errMsg) {
+					return
+				}
+				if tt.networkBound && isNetworkError(errMsg) {
+					t.Skipf("skipping due to transient network error: %v", err)
+				}
+				assert.Contains(t, errMsg, tt.errorMessage)
 			} else {
+				if err != nil && tt.networkBound && isNetworkError(err.Error()) {
+					t.Skipf("skipping due to transient network error: %v", err)
+				}
 				require.NoError(t, err)
 			}
 		})
 	}
+}
+
+// isNetworkError returns true if the error message indicates a transient
+// network issue (timeout, DNS failure, connection refused, etc.).
+func isNetworkError(msg string) bool {
+	patterns := []string{
+		"context deadline exceeded",
+		"connection refused",
+		"no such host",
+		"i/o timeout",
+		"TLS handshake timeout",
+	}
+	for _, p := range patterns {
+		if strings.Contains(msg, p) {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
# Description

- **Motivation:** The PyPI validation tests fail intermittently in CI when PyPI is unreachable (timeout, DNS failure). Fixes #194.
- **What changed:**
  - Added `networkBound` and `allowNetError` flags to test cases that depend on PyPI being reachable
  - Non-existent package test accepts network errors as valid failures (both prove the package cannot be validated)
  - Other network-bound tests skip gracefully on transient errors instead of failing
  - Added `isNetworkError` helper that checks for common transient error patterns (timeout, DNS, connection refused, TLS handshake)

# Change Type

/kind flake

# Changelog

```release-note
Handle transient network errors in PyPI validation tests to reduce CI flakiness
```

# Additional Notes

- Only `internal/registry/validators/registries/pypi_test.go` is changed.