### PR TITLE
fix: clean up skill show command output

### DIFF
--- a/internal/cli/skill/show.go
+++ b/internal/cli/skill/show.go
@@ -51,11 +51,18 @@ func runShow(cmd *cobra.Command, args []string) error {
 	t := printer.NewTablePrinter(os.Stdout)
 	t.SetHeaders("Property", "Value")
 	t.AddRow("Name", skill.Skill.Name)
-	t.AddRow("Description", skill.Skill.Description)
+	t.AddRow("Title", printer.EmptyValueOrDefault(skill.Skill.Title, "<none>"))
+	t.AddRow("Description", printer.EmptyValueOrDefault(skill.Skill.Description, "<none>"))
 	t.AddRow("Version", skill.Skill.Version)
-	t.AddRow("Category", skill.Skill.Category)
-	t.AddRow("Status", skill.Meta.Official.Status)
-	t.AddRow("Website", skill.Skill.WebsiteURL)
+
+	typ, src := skillSource(skill)
+	t.AddRow("Type", printer.EmptyValueOrDefault(typ, "<none>"))
+	t.AddRow("Source", printer.EmptyValueOrDefault(src, "<none>"))
+
+	if skill.Meta.Official != nil {
+		t.AddRow("Status", printer.EmptyValueOrDefault(skill.Meta.Official.Status, "<none>"))
+	}
+
 	if err := t.Render(); err != nil {
 		return fmt.Errorf("failed to render table: %w", err)
 	}


### PR DESCRIPTION
# Description

Completes the cleanup started in #269 by applying the same improvements to the `skill show` command.

**Changes:**
- Remove empty/nonsensical **Category** and **Website** columns from `skill show` output
- Replace with useful **Type** and **Source** fields (reusing `skillSource()` from the list command)
- Add **Title** field for consistency with `skill list`
- Fix potential nil pointer dereference when `Meta.Official` is nil

Fixes #256

/kind cleanup

# Changelog

```release-note
Clean up skill show command to remove empty Category/Website fields and show Type/Source instead
```

# Additional Notes

PR #269 cleaned up the `skill list` command. This PR applies the same treatment to `skill show`, fully resolving issue #256.

🤖 Generated with [Claude Code](https://claude.com/claude-code)