### PR TITLE
Makefile: Self-document help targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+# https://www.gnu.org/software/make/manual/html_node/Special-Variables.html#Special-Variables
+.DEFAULT_GOAL := help
+
 # Load .env into make's variable scope if it exists
 ifneq (,$(wildcard .env))
   include .env
@@ -47,60 +50,23 @@ HELM_PLUGIN_UNITTEST_VERSION ?= v1.0.3
 # It is not entirely clear as to what is causing the issue exactly because the error message
 # is not completely clear is it the plugin that does not support the flag or is it helm or both?
 HELM_PLUGIN_INSTALL_FLAGS ?= --verify=false
-
-
-
-# Default target
+# Help
+# `make help` self-documents targets annotated with `##`.
 .PHONY: help
-help:
-	@echo "Available targets:"
-	@echo "  install-ui            - Install UI dependencies"
-	@echo "  build-ui              - Build the Next.js UI"
-	@echo "  clean-ui              - Clean UI build artifacts"
-	@echo "  build-cli             - Build the Go CLI"
-	@echo "  build                 - Build both UI and Go CLI"
-	@echo "  install               - Install the CLI to GOPATH/bin"
-	@echo "  run                   - Start local dev environment (docker-compose)"
-	@echo "  down                  - Stop local dev environment"
-	@echo "  dev-ui                - Run Next.js in development mode"
-	@echo "  test                  - Run Go unit tests"
-	@echo "  test-integration      - Run Go tests with integration tests"
-	@echo "  test-coverage         - Run Go tests with coverage"
-	@echo "  test-coverage-report  - Run Go tests with HTML coverage report"
-	@echo "  clean                 - Clean all build artifacts"
-	@echo "  all                   - Clean and build everything"
-	@echo "  lint                  - Run the linter (GOLANGCI_LINT_ARGS=--fix to auto-fix)"
-	@echo "  verify                - Verify generated code is up to date"
-	@echo "  release               - Build and release the CLI"
-	@echo ""
-	@echo "Helm / Chart targets (chart dir: $(HELM_CHART_DIR)):"
-	@echo "  charts-deps           - Build Helm chart dependencies"
-	@echo "  charts-lint           - Lint the Helm chart (helm lint --strict)"
-	@echo "  charts-render-test    - Render chart templates (smoke test with min required values)"
-	@echo "  charts-package        - Package chart → $(HELM_PACKAGE_DIR)/"
-	@echo "  charts-push           - Package + push chart to OCI registry (requires creds)"
-	@echo "  charts-test           - Run helm-unittest tests (installs plugin if absent)"
-	@echo "  charts-all            - charts-push then charts-test"
-	@echo ""
-	@echo "Kind / local K8s targets (cluster: $(KIND_CLUSTER_NAME)):"
-	@echo "  create-kind-cluster   - Create Kind cluster with MetalLB"
-	@echo "  use-kind-cluster      - Merge kubeconfig and set default namespace"
-	@echo "  delete-kind-cluster   - Delete the Kind cluster"
-	@echo "  prune-kind-cluster    - Prune dangling images from Kind control-plane"
-	@echo "  kind-debug            - Shell into Kind control-plane with btop"
-	@echo "  install-postgresql    - Deploy PostgreSQL/pgvector into Kind"
-	@echo "  install-agentregistry - Build images and Helm-install AgentRegistry into Kind"
-	@echo "  setup-kind-cluster    - Full local K8s dev setup (kind + postgres + agentregistry)"
+help: NAME_COLUMN_WIDTH=35
+help: LINE_COLUMN_WIDTH=5
+help: ## Output the self-documenting make targets
+	@grep -hnE '^[%a-zA-Z0-9_./-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk '{line=$$0; lineno=line; sub(/:.*/, "", lineno); sub(/^[^:]*:/, "", line); target=line; sub(/:.*/, "", target); desc=line; sub(/^.*##[[:space:]]*/, "", desc); printf "\033[36mL%-$(LINE_COLUMN_WIDTH)s%-$(NAME_COLUMN_WIDTH)s\033[0m %s\n", lineno, target, desc}'
 
 # Install UI dependencies
 .PHONY: install-ui
-install-ui:
+install-ui: ## Install UI dependencies
 	@echo "Installing UI dependencies..."
 	cd ui && npm install
 
 # Build the Next.js UI (outputs to internal/registry/api/ui/dist)
 .PHONY: build-ui
-build-ui: install-ui
+build-ui: install-ui ## Build the Next.js UI for embedding
 	@echo "Building Next.js UI for embedding..."
 	cd ui && npm run build:export
 	@echo "Copying built files to internal/registry/api/ui/dist..."
@@ -111,7 +77,7 @@ build-ui: install-ui
 
 # Clean UI build artifacts
 .PHONY: clean-ui
-clean-ui:
+clean-ui: ## Clean UI build artifacts
 	@echo "Cleaning UI build artifacts..."
 	git clean -xdf ./internal/registry/api/ui/dist/
 	git clean -xdf ./ui/out/
@@ -120,7 +86,7 @@ clean-ui:
 
 # Build the Go CLI
 .PHONY: build-cli
-build-cli: mod-download
+build-cli: mod-download ## Build the Go CLI
 	@echo "Building Go CLI..."
 	@echo "Downloading Go dependencies..."
 	@echo "Building binary..."
@@ -130,7 +96,7 @@ build-cli: mod-download
 
 # Build the Go server (with embedded UI)
 .PHONY: build-server
-build-server: mod-download
+build-server: mod-download ## Build the Go server binary
 	@echo "Building Go CLI..."
 	@echo "Downloading Go dependencies..."
 	@echo "Building binary..."
@@ -140,26 +106,26 @@ build-server: mod-download
 
 # Build everything (UI + Go)
 .PHONY: build
-build: build-ui build-cli
+build: build-ui build-cli ## Build the UI and Go CLI
 	@echo "Build complete!"
 	@echo "Run './bin/arctl --help' to get started"
 
 # Install the CLI to GOPATH/bin
 .PHONY: install
-install: build
+install: build ## Install the CLI to GOPATH/bin
 	@echo "Installing arctl to GOPATH/bin..."
 	go install
 	@echo "Installation complete! Run 'arctl --help' to get started"
 
 # Run Next.js in development mode
 .PHONY: dev-ui
-dev-ui:
+dev-ui: ## Run the Next.js UI in development mode
 	@echo "Starting Next.js development server..."
 	cd ui && npm run dev
 
 # Start local development environment (docker-compose)
 .PHONY: run
-run: docker-registry docker-compose-up build-cli
+run: docker-registry docker-compose-up build-cli ## Start the local development environment
 	@echo ""
 	@echo "agentregistry is running:"
 	@echo "  UI:  http://localhost:12121"
@@ -170,41 +136,41 @@ run: docker-registry docker-compose-up build-cli
 
 # Stop local development environment
 .PHONY: down
-down: docker-compose-down
+down: docker-compose-down ## Stop the local development environment
 	@echo "agentregistry stopped"
 
 # Run Go tests (unit tests only)
 .PHONY: test-unit
-test-unit:
+test-unit: ## Run Go unit tests
 	@echo "Running Go unit tests..."
 	go tool gotestsum --format testdox -- -tags=unit -timeout 5m ./...
 
 # Run Go tests with integration tests
 .PHONY: test
-test:
+test: ## Run Go integration tests
 	@echo "Running Go tests with integration..."
 	go tool gotestsum --format testdox -- -tags=integration -timeout 10m ./...
 
-e2e: build-cli
+e2e: build-cli ## Run end-to-end tests
 	go tool gotestsum --format testdox -- -tags=e2e -timeout 45m ./e2e/...
 
-gen-openapi:
+gen-openapi: ## Generate the OpenAPI specification
 	@echo "Generating OpenAPI spec..."
 	go run ./cmd/tools/gen-openapi -output openapi.yaml
 
-gen-client: gen-openapi install-ui
+gen-client: gen-openapi install-ui ## Generate the TypeScript client
 	@echo "Generating TypeScript client..."
 	cd ui && npm run generate
 
 # Run Go tests with coverage
 .PHONY: test-coverage
-test-coverage:
+test-coverage: ## Run Go tests with coverage
 	@echo "Running Go tests with coverage..."
 	go test -ldflags "$(LDFLAGS)" -cover ./...
 
 # Run Go tests with coverage report
 .PHONY: test-coverage-report
-test-coverage-report:
+test-coverage-report: ## Run Go tests with an HTML coverage report
 	@echo "Running Go tests with coverage report..."
 	go test -ldflags "$(LDFLAGS)" -coverprofile=coverage.out ./...
 	go tool cover -html=coverage.out -o coverage.html
@@ -212,7 +178,7 @@ test-coverage-report:
 
 # Clean all build artifacts
 .PHONY: clean
-clean: clean-ui
+clean: clean-ui ## Clean all build artifacts
 	@echo "Cleaning Go build artifacts..."
 	rm -rf bin/
 	go clean
@@ -220,12 +186,12 @@ clean: clean-ui
 
 # Clean and build everything
 .PHONY: all
-all: clean build
+all: clean build ## Clean and build everything
 	@echo "Clean build complete!"
 
 # Quick development build (skips cleaning)
 .PHONY: dev-build
-dev-build: build-ui
+dev-build: build-ui ## Build quickly for local development
 	@echo "Building Go CLI (development mode)..."
 	go build -o bin/arctl cmd/cli/main.go
 	@echo "Development build complete!"
@@ -233,19 +199,19 @@ dev-build: build-ui
 
 # Build custom agent gateway image with npx/uvx support
 .PHONY: docker-agentgateway
-docker-agentgateway:
+docker-agentgateway: ## Build the custom agent gateway image
 	@echo "Building custom age	nt gateway image..."
 	$(DOCKER_BUILDER) build $(DOCKER_BUILD_ARGS) -f docker/agentgateway.Dockerfile -t $(DOCKER_REGISTRY)/$(DOCKER_REPO)/arctl-agentgateway:$(VERSION) .
 	echo "✓ Agent gateway image built successfully";
 
 .PHONY: docker-server
-docker-server: .env
+docker-server: .env ## Build the server Docker image
 	@echo "Building server Docker image..."
 	$(DOCKER_BUILDER) build $(DOCKER_BUILD_ARGS) -f docker/server.Dockerfile -t $(DOCKER_REGISTRY)/$(DOCKER_REPO)/server:$(VERSION) --build-arg LDFLAGS="$(LDFLAGS)" .
 	@echo "✓ Docker image built successfully"
 
 .PHONY: docker-registry
-docker-registry:
+docker-registry: ## Ensure the local Docker registry is running
 	@echo "Building running local Docker registry..."
 	if docker inspect docker-registry >/dev/null 2>&1; then \
 		echo "Registry already running. Skipping build." ; \
@@ -255,10 +221,10 @@ docker-registry:
 	fi
 
 .PHONY: docker
-docker: docker-agentgateway docker-server
+docker: docker-agentgateway docker-server ## Build the project Docker images
 
 .PHONY: docker-tag-as-dev
-docker-tag-as-dev:
+docker-tag-as-dev: ## Tag and push Docker images as :dev
 	@echo "Pulling and tagging as dev..."
 	docker pull $(DOCKER_REGISTRY)/$(DOCKER_REPO)/server:$(VERSION)
 	docker tag $(DOCKER_REGISTRY)/$(DOCKER_REPO)/server:$(VERSION) $(DOCKER_REGISTRY)/$(DOCKER_REPO)/server:dev
@@ -269,16 +235,16 @@ docker-tag-as-dev:
 	@echo "✓ Docker image pulled successfully"
 
 .PHONY: docker-compose-up
-docker-compose-up: docker docker-tag-as-dev
+docker-compose-up: docker docker-tag-as-dev ## Start services with Docker Compose
 	@echo "Starting services with Docker Compose..."
 	VERSION=$(VERSION) DOCKER_REGISTRY=$(DOCKER_REGISTRY) docker compose -p agentregistry -f internal/daemon/docker-compose.yml up -d --wait --pull always
 
 .PHONY: docker-compose-down
-docker-compose-down:
+docker-compose-down: ## Stop services managed by Docker Compose
 	VERSION=$(VERSION) DOCKER_REGISTRY=$(DOCKER_REGISTRY) docker compose -p agentregistry -f internal/daemon/docker-compose.yml down
 
 .PHONY: docker-compose-rm
-docker-compose-rm:
+docker-compose-rm: ## Remove Docker Compose services and volumes
 	VERSION=$(VERSION) DOCKER_REGISTRY=$(DOCKER_REGISTRY) docker compose -p agentregistry -f internal/daemon/docker-compose.yml rm --volumes --force
 
 KIND_CLUSTER_NAME ?= agentregistry
@@ -369,7 +335,7 @@ endif
 
 ## Set up a full local K8s dev environment (Kind + PostgreSQL/pgvector + AgentRegistry)
 .PHONY: setup-kind-cluster
-setup-kind-cluster: create-kind-cluster install-postgresql install-agentregistry
+setup-kind-cluster: create-kind-cluster install-postgresql install-agentregistry ## Set up the full local Kind development environment
 
 bin/arctl-linux-amd64:
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "$(LDFLAGS)" -o bin/arctl-linux-amd64 cmd/cli/main.go
@@ -401,6 +367,7 @@ bin/arctl-windows-amd64.exe:
 bin/arctl-windows-amd64.exe.sha256: bin/arctl-windows-amd64.exe
 	sha256sum bin/arctl-windows-amd64.exe > bin/arctl-windows-amd64.exe.sha256
 
+release-cli: ## Build release CLI archives and checksums
 release-cli: bin/arctl-linux-amd64.sha256
 release-cli: bin/arctl-linux-arm64.sha256
 release-cli: bin/arctl-darwin-amd64.sha256
@@ -447,20 +414,20 @@ _helm-check:
 
 # Build chart dependencies (resolves Chart.yaml dependencies → charts/ subdir).
 .PHONY: charts-deps
-charts-deps: _helm-check
+charts-deps: _helm-check ## Build Helm chart dependencies
 	@echo "Building Helm chart dependencies for $(HELM_CHART_DIR)..."
 	$(HELM) dependency build $(HELM_CHART_DIR)
 
 # Lint chart with --strict so warnings are treated as errors.
 .PHONY: charts-lint
-charts-lint: charts-deps
+charts-lint: charts-deps ## Lint the Helm chart with --strict
 	@echo "Linting Helm chart $(HELM_CHART_DIR)..."
 	$(HELM) lint $(HELM_CHART_DIR) --strict
 
 # Render chart templates to stdout (smoke test — catches template errors).
 # Uses minimum required values to pass chart validation.
 .PHONY: charts-render-test
-charts-render-test: charts-deps
+charts-render-test: charts-deps ## Render chart templates as a smoke test
 	@echo "Rendering chart templates for $(HELM_CHART_DIR)..."
 	$(HELM) template test-release $(HELM_CHART_DIR) \
 	  --values $(HELM_CHART_DIR)/values.yaml \
@@ -470,7 +437,7 @@ charts-render-test: charts-deps
 
 # Package the chart into $(HELM_PACKAGE_DIR)/.
 .PHONY: charts-package
-charts-package: charts-lint
+charts-package: charts-lint ## Package the Helm chart into $(HELM_PACKAGE_DIR)
 	@mkdir -p $(HELM_PACKAGE_DIR)
 	@echo "Packaging chart $(HELM_CHART_DIR) → $(HELM_PACKAGE_DIR)/"
 	$(HELM) package $(HELM_CHART_DIR) -d $(HELM_PACKAGE_DIR)
@@ -483,7 +450,7 @@ charts-package: charts-lint
 #   HELM_REGISTRY_PASSWORD   – registry password / token (required)
 # Override registry/repo: make charts-push HELM_REGISTRY=ghcr.io HELM_REPO=org/repo
 .PHONY: charts-push
-charts-push: charts-package
+charts-push: charts-package ## Push packaged charts to the configured registry
 	@echo "Pushing chart(s) to $(HELM_REGISTRY)/$(HELM_REPO)/charts (mode: $(HELM_PUSH_MODE))"
 ifeq ($(HELM_PUSH_MODE),oci)
 	@if [ -z "$$HELM_REGISTRY_PASSWORD" ]; then \
@@ -510,12 +477,12 @@ endif
 #   2. checks for the helm-unittest plugin and installs it if missing
 #   3. runs the full test suite
 .PHONY: charts-test
-charts-test: _helm-check charts-deps helm-unittest-install
+charts-test: _helm-check charts-deps helm-unittest-install ## Run helm-unittest chart tests
 	@echo "Running helm-unittest on $(HELM_CHART_DIR)..."
 	$(HELM) unittest $(HELM_CHART_DIR) --file "tests/*_test.yaml"
 
 .PHONY: helm-unittest-install
-helm-unittest-install: _helm-check
+helm-unittest-install: _helm-check ## Install the helm-unittest plugin if needed
 	@echo "Checking for helm-unittest plugin..."
 	@if ! $(HELM) plugin list | awk '{print $$1}' | grep -q '^unittest$$'; then \
 	  echo "helm-unittest plugin not found — installing from $(HELM_PLUGIN_UNITTEST_URL)"; \
@@ -535,5 +502,5 @@ helm-unittest-install: _helm-check
 
 # Convenience: package → push → test.
 .PHONY: charts-all
-charts-all: charts-push charts-test
+charts-all: charts-push charts-test ## Package, push, and test the Helm chart
 	@echo "charts-all complete: packaged, pushed, and tested."


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don't apply.
-->

# Description

<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

Teach make help to discover documented targets from the Makefile instead of maintaining a separate echoed list.

This keeps the output close to the implementation and avoids help text drift over time.

Fixes #313 

# Change Type

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bump
/kind cleanup
/kind design
/kind deprecation
/kind documentation
/kind feature
/kind fix
/kind flake
/kind install
```
-->

/kind cleanup

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
NONE
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
