### PR TITLE
always set the KAGENT_NAMESPACE; add the agent URL to the deployed page

### DIFF
--- a/internal/cli/common/common.go
+++ b/internal/cli/common/common.go
@@ -13,6 +13,8 @@ import (
 
 const DefaultUserName = "user"
 
+const DefaultAgentGatewayPort = "21212"
+
 // BuildLocalImageName constructs a local Docker image name from a project name and version.
 // Returns format: "kebab-case-name:version"
 func BuildLocalImageName(name, version string) string {

--- a/internal/cli/configure/configure.go
+++ b/internal/cli/configure/configure.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/agentregistry-dev/agentregistry/internal/cli/common"
 	"github.com/spf13/cobra"
 )
 
@@ -80,8 +81,8 @@ var ConfigureCmd = &cobra.Command{
 }
 
 func init() {
-	ConfigureCmd.Flags().StringVar(&configureURL, "url", "", "Custom MCP server URL (default: http://localhost:21212/mcp")
-	ConfigureCmd.Flags().StringVar(&configurePort, "port", "21212", "Port for the MCP server")
+	ConfigureCmd.Flags().StringVar(&configureURL, "url", "", fmt.Sprintf("Custom MCP server URL (default: http://localhost:%s/mcp)", common.DefaultAgentGatewayPort))
+	ConfigureCmd.Flags().StringVar(&configurePort, "port", common.DefaultAgentGatewayPort, "Port for the MCP server")
 }
 
 func writeConfigFile(configPath string, config any) error {

--- a/internal/cli/mcp/deploy.go
+++ b/internal/cli/mcp/deploy.go
@@ -103,7 +103,7 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 	}
 	if deployProviderID == "local" {
 		fmt.Printf("\nServer deployment recorded. The registry will reconcile containers automatically.\n")
-		fmt.Printf("Agent Gateway endpoint: http://localhost:21212/mcp\n")
+		fmt.Printf("Agent Gateway endpoint: http://localhost:%s/mcp\n", common.DefaultAgentGatewayPort)
 	}
 
 	return nil

--- a/internal/registry/platforms/utils/deployment_adapter_utils.go
+++ b/internal/registry/platforms/utils/deployment_adapter_utils.go
@@ -88,12 +88,13 @@ func ResolveAgent(
 	}
 	envValues := copyStringMap(deployment.Env)
 	if envValues["KAGENT_NAMESPACE"] == "" {
-		envValues["KAGENT_NAMESPACE"] = namespace
-	}
-	// We always need a namespace when deploying to local/docker (kagent-adk requires it)
-	// so even if namespace isn't explicitly provided, we should set it to default.
-	if envValues["KAGENT_NAMESPACE"] == "" {
-		envValues["KAGENT_NAMESPACE"] = "default"
+		if namespace != "" {
+			envValues["KAGENT_NAMESPACE"] = namespace
+		} else {
+			// We always need a namespace when deploying to local/docker (kagent-adk requires it)
+			// so even if namespace isn't explicitly provided, we should set it to default.
+			envValues["KAGENT_NAMESPACE"] = "default"
+		}
 	}
 	envValues["KAGENT_URL"] = "http://localhost"
 	envValues["KAGENT_NAME"] = agentResp.Agent.Name

--- a/internal/registry/platforms/utils/deployment_adapter_utils_test.go
+++ b/internal/registry/platforms/utils/deployment_adapter_utils_test.go
@@ -195,3 +195,70 @@ func TestResolveAgentDefaultsLocalPort(t *testing.T) {
 		t.Fatalf("port = %d, want %d", resolved.Agent.Deployment.Port, DefaultLocalAgentPort)
 	}
 }
+
+func TestResolveAgentNamespaceDefaulting(t *testing.T) {
+	newRegistry := func() *servicetesting.FakeRegistry {
+		r := servicetesting.NewFakeRegistry()
+		r.Agents = []*models.AgentResponse{{
+			Agent: models.AgentJSON{
+				AgentManifest: models.AgentManifest{
+					Name:          "planner",
+					ModelProvider: "openai",
+					ModelName:     "gpt-4o",
+				},
+				Version: "1.0.0",
+			},
+		}}
+		return r
+	}
+
+	tests := []struct {
+		name          string
+		namespace     string
+		deploymentEnv map[string]string
+		wantNamespace string
+	}{
+		{
+			name:          "defaults to 'default' when namespace param is empty",
+			namespace:     "",
+			deploymentEnv: map[string]string{},
+			wantNamespace: "default",
+		},
+		{
+			name:          "uses explicit namespace param",
+			namespace:     "production",
+			deploymentEnv: map[string]string{},
+			wantNamespace: "production",
+		},
+		{
+			name:          "deployment env KAGENT_NAMESPACE takes priority over namespace param",
+			namespace:     "staging",
+			deploymentEnv: map[string]string{"KAGENT_NAMESPACE": "from-env"},
+			wantNamespace: "from-env",
+		},
+		{
+			name:          "deployment env KAGENT_NAMESPACE takes priority over default",
+			namespace:     "",
+			deploymentEnv: map[string]string{"KAGENT_NAMESPACE": "from-env"},
+			wantNamespace: "from-env",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resolved, err := ResolveAgent(context.Background(), newRegistry(), &models.Deployment{
+				ID:         "dep-123",
+				ServerName: "planner",
+				Version:    "1.0.0",
+				Env:        tt.deploymentEnv,
+			}, tt.namespace)
+			if err != nil {
+				t.Fatalf("ResolveAgent() unexpected error: %v", err)
+			}
+			got := resolved.Agent.Deployment.Env["KAGENT_NAMESPACE"]
+			if got != tt.wantNamespace {
+				t.Errorf("KAGENT_NAMESPACE = %q, want %q", got, tt.wantNamespace)
+			}
+		})
+	}
+}

--- a/ui/app/deployed/page.tsx
+++ b/ui/app/deployed/page.tsx
@@ -17,6 +17,8 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog"
 
+const GATEWAY_BASE_URL = process.env.NEXT_PUBLIC_GATEWAY_URL || "http://localhost:21212"
+
 function sanitizeName(value: string): string {
   return value.toLowerCase().replace(/[^a-z0-9-]/g, '-')
 }
@@ -24,7 +26,7 @@ function sanitizeName(value: string): string {
 function getAgentEndpointUrl(serverName: string, deploymentId: string): string {
   const name = sanitizeName(serverName)
   const id = sanitizeName(deploymentId)
-  return `http://localhost:21212/agents/${name}-${id}`
+  return `${GATEWAY_BASE_URL}/agents/${name}-${id}`
 }
 
 export default function DeployedPage() {
@@ -36,7 +38,7 @@ export default function DeployedPage() {
   const [copied, setCopied] = useState(false)
   const [copiedAgentId, setCopiedAgentId] = useState<string | null>(null)
 
-  const gatewayUrl = "http://localhost:21212/mcp"
+  const gatewayUrl = `${GATEWAY_BASE_URL}/mcp`
 
   const copyToClipboard = () => {
     navigator.clipboard.writeText(gatewayUrl)

--- a/ui/package.json
+++ b/ui/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "NEXT_PUBLIC_API_URL=http://localhost:12121 next dev",
+    "dev": "NEXT_PUBLIC_API_URL=http://localhost:12121 NEXT_PUBLIC_GATEWAY_URL=http://localhost:21212 next dev",
     "build": "next build",
     "build:export": "NEXT_BUILD_EXPORT=true next build",
     "start": "next start",


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don't apply.
-->

# Description

We must always set the KAGENT_NAMESPACE, even when deploying to docker. This PR also adds the agent URL to the /deployed page in the UI

<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

# Change Type

```
/kind fix
```

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
add agent URL to the UI and fix the local docker deployment
```

<img width="938" height="307" alt="Screenshot 2026-03-11 at 3 11 37 PM" src="https://github.com/user-attachments/assets/cdde6c3e-b952-4597-99e9-f120a37d2f1a" />


