### PR TITLE
cli: allow resolving MCP URL containing ${ENV_VAR}

### DIFF
--- a/internal/cli/agent/frameworks/adk/python/templates/agent/mcp_tools.py.tmpl
+++ b/internal/cli/agent/frameworks/adk/python/templates/agent/mcp_tools.py.tmpl
@@ -45,7 +45,7 @@ def _resolve_env_vars(value: str) -> str:
 
 def _get_terminate_on_close() -> bool:
     """Get the terminate_on_close setting from environment variable.
-    
+
     Defaults to True for backward compatibility.
     Set MCP_TERMINATE_ON_CLOSE=false for stateless MCP servers.
     """
@@ -56,12 +56,12 @@ def _load_runtime_mcp_servers() -> List[dict]:
     """Load MCP servers resolved at runtime (registry types) from config file."""
     # The agent-specific directory is mounted to /config, so the file is at /config/mcp-servers.json
     config_paths = [Path(__file__).parent / "mcp-servers.json", Path("/config/mcp-servers.json")]
-    
+
     # Allow override via environment variable for testing/debugging
     env_path = os.environ.get("MCP_SERVERS_CONFIG_PATH")
     if env_path:
         config_paths.insert(0, Path(env_path))
-    
+
     for config_path in config_paths:
         if not config_path.exists():
             continue
@@ -74,17 +74,17 @@ def _load_runtime_mcp_servers() -> List[dict]:
                     return data["servers"]
         except (json.JSONDecodeError, IOError):
             continue
-    
+
     return []
 
 
 def _get_all_mcp_servers() -> List[dict]:
     """Get all MCP servers, merging baked-in and runtime-resolved servers."""
     servers = list(_MCP_SERVERS)  # Only command/remote servers (registry filtered out at template time)
-    
+
     # Load runtime-resolved servers (registry types)
     runtime_servers = _load_runtime_mcp_servers()
-    
+
     # Append runtime servers, avoiding duplicates by name
     existing_names = {s.get("name") for s in servers}
     for runtime_server in runtime_servers:
@@ -92,7 +92,7 @@ def _get_all_mcp_servers() -> List[dict]:
         if server_name and server_name not in existing_names:
             servers.append(runtime_server)
             existing_names.add(server_name)
-    
+
     return servers
 
 def get_mcp_tools(
@@ -101,7 +101,7 @@ def get_mcp_tools(
     global_filter: Optional[Union[ToolPredicate, List[str]]] = None,
 ) -> List[MCPToolset]:
     """Return MCP toolsets for the configured servers.
-    
+
     Environment variables:
         MCP_TERMINATE_ON_CLOSE: Set to "false" for stateless MCP servers.
             Defaults to "true" for backward compatibility.
@@ -118,6 +118,7 @@ def get_mcp_tools(
     for server in servers:
         server_name = server["name"]
         url = f"http://{server_name}:3000/mcp" if server["type"] == "command" else server["url"]
+        url = _resolve_env_vars(url)
 
         headers = {}
         if "headers" in server and server["headers"]:

--- a/internal/cli/agent/frameworks/common/manifest_manager.go
+++ b/internal/cli/agent/frameworks/common/manifest_manager.go
@@ -3,11 +3,18 @@ package common
 import (
 	"fmt"
 	"net/url"
+	"regexp"
 	"time"
 
 	"github.com/agentregistry-dev/agentregistry/internal/cli/manifest"
 	"github.com/agentregistry-dev/agentregistry/pkg/models"
 )
+
+// envVarPortPattern matches ${VAR} when used as a port (after a colon).
+var envVarPortPattern = regexp.MustCompile(`:\$\{[^}]+\}`)
+
+// envVarPattern matches remaining ${VAR} placeholders in strings.
+var envVarPattern = regexp.MustCompile(`\$\{[^}]+\}`)
 
 const ManifestFileName = "agent.yaml"
 
@@ -84,7 +91,12 @@ func validateRemoteMcpServer(i int, srv models.McpServerType) error {
 	if srv.URL == "" {
 		return fmt.Errorf("mcpServers[%d]: url is required for type 'remote'", i)
 	}
-	parsed, err := url.Parse(srv.URL)
+	// Replace ${VAR} placeholders with dummy values so url.Parse can
+	// validate the structure. The actual env vars are resolved at runtime.
+	// Port placeholders (e.g. :${PORT}) need a numeric replacement.
+	sanitized := envVarPortPattern.ReplaceAllString(srv.URL, ":8080")
+	sanitized = envVarPattern.ReplaceAllString(sanitized, "placeholder")
+	parsed, err := url.Parse(sanitized)
 	if err != nil {
 		return fmt.Errorf("mcpServers[%d]: url is not a valid URL: %v", i, err)
 	}

--- a/internal/cli/agent/frameworks/common/manifest_manager_test.go
+++ b/internal/cli/agent/frameworks/common/manifest_manager_test.go
@@ -1,0 +1,89 @@
+package common
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/agentregistry-dev/agentregistry/pkg/models"
+)
+
+func TestValidateRemoteMcpServer(t *testing.T) {
+	tests := []struct {
+		name    string
+		srv     models.McpServerType
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name:    "valid http url",
+			srv:     models.McpServerType{Type: "remote", Name: "s", URL: "http://example.com/mcp"},
+			wantErr: false,
+		},
+		{
+			name:    "valid https url",
+			srv:     models.McpServerType{Type: "remote", Name: "s", URL: "https://example.com/mcp"},
+			wantErr: false,
+		},
+		{
+			name:    "url with env var in host",
+			srv:     models.McpServerType{Type: "remote", Name: "s", URL: "http://${GATEWAY_HOST}/mcp"},
+			wantErr: false,
+		},
+		{
+			name:    "url with env var in port",
+			srv:     models.McpServerType{Type: "remote", Name: "s", URL: "http://localhost:${PORT}/mcp"},
+			wantErr: false,
+		},
+		{
+			name:    "url with multiple env vars",
+			srv:     models.McpServerType{Type: "remote", Name: "s", URL: "https://${HOST}:${PORT}/${PATH}"},
+			wantErr: false,
+		},
+		{
+			name:    "url entirely from env var",
+			srv:     models.McpServerType{Type: "remote", Name: "s", URL: "${FULL_URL}"},
+			wantErr: true,
+			errMsg:  "url scheme must be http or https",
+		},
+		{
+			name:    "empty url",
+			srv:     models.McpServerType{Type: "remote", Name: "s", URL: ""},
+			wantErr: true,
+			errMsg:  "url is required",
+		},
+		{
+			name:    "missing scheme",
+			srv:     models.McpServerType{Type: "remote", Name: "s", URL: "example.com/mcp"},
+			wantErr: true,
+			errMsg:  "url scheme must be http or https",
+		},
+		{
+			name:    "ftp scheme",
+			srv:     models.McpServerType{Type: "remote", Name: "s", URL: "ftp://example.com/mcp"},
+			wantErr: true,
+			errMsg:  "url scheme must be http or https",
+		},
+		{
+			name:    "missing host",
+			srv:     models.McpServerType{Type: "remote", Name: "s", URL: "http:///path"},
+			wantErr: true,
+			errMsg:  "url is missing host",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateRemoteMcpServer(0, tt.srv)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.errMsg)
+				}
+				if tt.errMsg != "" && !strings.Contains(err.Error(), tt.errMsg) {
+					t.Errorf("error %q does not contain %q", err.Error(), tt.errMsg)
+				}
+			} else if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Description
Allows resolving MCP URLs containing ${ENV_VAR} using dynamic URL resolution from environment variables at runtime. This is extremely useful to not hardcode the MCP URL in the agent code and instead specify them during deployment using environment variables, decoupling code from runtime values that are dynamic.

E.g. `arctl agent add-mcp --remote http://\${ADDRESS}/mcp`

# Change Type

```
/kind new_feature
```

# Changelog

```release-note
Allows MCP URLs containing environment variables to be resolved
at runtime.
```