### PR TITLE
internal: Fix latest version display

### DIFF
--- a/internal/cli/common/common.go
+++ b/internal/cli/common/common.go
@@ -81,10 +81,12 @@ func ResolveVersion(flagVersion, manifestVersion string) string {
 	return "latest"
 }
 
-// FormatVersionForDisplay normalizes version display with a leading "v".
+// FormatVersionForDisplay adds a leading "v" only for valid semver values.
+// Non-semver labels are returned unchanged.
 func FormatVersionForDisplay(version string) string {
-	if !semver.IsValid(versionpkg.EnsureVPrefix(version)) {
+	versionWithV := versionpkg.EnsureVPrefix(version)
+	if !semver.IsValid(versionWithV) {
 		return version
 	}
-	return versionpkg.EnsureVPrefix(version)
+	return versionWithV
 }

--- a/internal/cli/common/common_test.go
+++ b/internal/cli/common/common_test.go
@@ -307,8 +307,8 @@ func TestFormatVersionForDisplay(t *testing.T) {
 		{name: "adds v prefix when missing", version: "1.0.0", want: "v1.0.0"},
 		{name: "keeps existing v prefix", version: "v1.0.0", want: "v1.0.0"},
 		{name: "keeps latest sentinel", version: "latest", want: "latest"},
-		{name: "keeps supported non semver labels", version: "snapshot", want: "snapshot"},
-		{name: "keeps date based versions", version: "2021.03.15", want: "2021.03.15"},
+		{name: "keeps supported non-semver labels", version: "snapshot", want: "snapshot"},
+		{name: "keeps date-based versions", version: "2021.03.15", want: "2021.03.15"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don't apply.
-->

# Description

<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

We keep non-semver version labels unchanged when formatting them for CLI output.

Previously, the display helper always added a leading v, which turned the latest sentinel into vlatest in publish and delete output.

Now, only semver values are normalized with a v prefix, while labels like latest are shown as-is.

Fixes #227.

# Change Type

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bump
/kind cleanup
/kind design
/kind deprecation
/kind documentation
/kind feature
/kind fix
/kind flake
/kind install
```
-->

/kind fix

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
NONE
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
