### PR TITLE
internal: Fix failed deployment cleanup

### DIFF
--- a/internal/cli/agent/list_test.go
+++ b/internal/cli/agent/list_test.go
@@ -5,14 +5,16 @@ import (
 
 	cliCommon "github.com/agentregistry-dev/agentregistry/internal/cli/common"
 	"github.com/agentregistry-dev/agentregistry/internal/client"
+	"github.com/agentregistry-dev/agentregistry/pkg/models"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestBuildDeploymentCounts_Agent(t *testing.T) {
 	deployments := []*client.DeploymentResponse{
-		{ServerName: "acme/planner", Version: "1.0.0", ResourceType: "agent"},
-		{ServerName: "acme/planner", Version: "1.0.0", ResourceType: "agent"},
-		{ServerName: "acme/planner", Version: "2.0.0", ResourceType: "agent"},
+		{ServerName: "acme/planner", Version: "1.0.0", ResourceType: "agent", Status: models.DeploymentStatusDeployed},
+		{ServerName: "acme/planner", Version: "1.0.0", ResourceType: "agent", Status: models.DeploymentStatusFailed},
+		{ServerName: "acme/planner", Version: "1.0.0", ResourceType: "agent", Status: models.DeploymentStatusDeployed},
+		{ServerName: "acme/planner", Version: "2.0.0", ResourceType: "agent", Status: models.DeploymentStatusDeployed},
 		{ServerName: "acme/weather", Version: "1.0.0", ResourceType: "mcp"},
 		nil,
 	}

--- a/internal/cli/common/deployments.go
+++ b/internal/cli/common/deployments.go
@@ -4,13 +4,18 @@ import (
 	"fmt"
 
 	"github.com/agentregistry-dev/agentregistry/internal/client"
+	"github.com/agentregistry-dev/agentregistry/pkg/models"
 )
 
 // BuildDeploymentCounts indexes deployment rows by resource name and version.
+// Skip non-deployed statuses and non-matching resource types.
 func BuildDeploymentCounts(deployments []*client.DeploymentResponse, resourceType string) map[string]map[string]int {
 	counts := make(map[string]map[string]int)
 	for _, deployment := range deployments {
 		if deployment == nil || deployment.ResourceType != resourceType {
+			continue
+		}
+		if deployment.Status != models.DeploymentStatusDeployed {
 			continue
 		}
 		if counts[deployment.ServerName] == nil {

--- a/internal/cli/mcp/list_test.go
+++ b/internal/cli/mcp/list_test.go
@@ -5,14 +5,16 @@ import (
 
 	cliCommon "github.com/agentregistry-dev/agentregistry/internal/cli/common"
 	"github.com/agentregistry-dev/agentregistry/internal/client"
+	"github.com/agentregistry-dev/agentregistry/pkg/models"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestBuildDeploymentCounts_MCP(t *testing.T) {
 	deployments := []*client.DeploymentResponse{
-		{ServerName: "acme/weather", Version: "1.0.0", ResourceType: "mcp"},
-		{ServerName: "acme/weather", Version: "1.0.0", ResourceType: "mcp"},
-		{ServerName: "acme/weather", Version: "2.0.0", ResourceType: "mcp"},
+		{ServerName: "acme/weather", Version: "1.0.0", ResourceType: "mcp", Status: models.DeploymentStatusDeployed},
+		{ServerName: "acme/weather", Version: "1.0.0", ResourceType: "mcp", Status: models.DeploymentStatusFailed},
+		{ServerName: "acme/weather", Version: "1.0.0", ResourceType: "mcp", Status: models.DeploymentStatusDeployed},
+		{ServerName: "acme/weather", Version: "2.0.0", ResourceType: "mcp", Status: models.DeploymentStatusDeployed},
 		{ServerName: "acme/planner", Version: "1.0.0", ResourceType: "agent"},
 		nil,
 	}

--- a/internal/registry/api/handlers/v0/deployment_meta_bridge.go
+++ b/internal/registry/api/handlers/v0/deployment_meta_bridge.go
@@ -25,6 +25,9 @@ func deploymentResourceIndex(ctx context.Context, registry service.RegistryServi
 		if deployment == nil {
 			continue
 		}
+		if deployment.Status != models.DeploymentStatusDeployed {
+			continue
+		}
 
 		resourceType := strings.ToLower(strings.TrimSpace(deployment.ResourceType))
 		resourceName := strings.TrimSpace(deployment.ServerName)

--- a/internal/registry/api/handlers/v0/deployment_meta_bridge_test.go
+++ b/internal/registry/api/handlers/v0/deployment_meta_bridge_test.go
@@ -12,15 +12,15 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestDeploymentResourceIndexIncludesAllStatuses(t *testing.T) {
+func TestDeploymentResourceIndexIncludesOnlyDeployedStatuses(t *testing.T) {
 	now := time.Now().UTC()
 	reg := &servicetest.FakeRegistry{
 		GetDeploymentsFn: func(_ context.Context, _ *models.DeploymentFilter) ([]*models.Deployment, error) {
 			return []*models.Deployment{
-				{ID: "dep-deploying", ServerName: "io.test/server", ResourceType: "mcp", Status: "deploying", UpdatedAt: now.Add(30 * time.Second)},
-				{ID: "dep-active", ServerName: "io.test/server", ResourceType: "mcp", Status: "deployed", UpdatedAt: now},
-				{ID: "dep-discovered", ServerName: "io.test/server", ResourceType: "mcp", Status: "discovered", UpdatedAt: now.Add(-30 * time.Second)},
-				{ID: "dep-cancelled", ServerName: "io.test/server", ResourceType: "mcp", Status: "cancelled", UpdatedAt: now.Add(-time.Minute)},
+				{ID: "dep-deploying", ServerName: "io.test/server", ResourceType: "mcp", Status: models.DeploymentStatusDeploying, UpdatedAt: now.Add(30 * time.Second)},
+				{ID: "dep-deployed", ServerName: "io.test/server", ResourceType: "mcp", Status: models.DeploymentStatusDeployed, UpdatedAt: now.Add(-15 * time.Second)},
+				{ID: "dep-discovered", ServerName: "io.test/server", ResourceType: "mcp", Status: models.DeploymentStatusDiscovered, UpdatedAt: now.Add(-30 * time.Second)},
+				{ID: "dep-cancelled", ServerName: "io.test/server", ResourceType: "mcp", Status: models.DeploymentStatusCancelled, UpdatedAt: now.Add(-time.Minute)},
 			}, nil
 		},
 	}
@@ -28,15 +28,9 @@ func TestDeploymentResourceIndexIncludesAllStatuses(t *testing.T) {
 	index := deploymentResourceIndex(context.Background(), reg)
 	key := deploymentResourceKey{resourceType: "mcp", resourceName: "io.test/server"}
 
-	require.Len(t, index[key], 4)
-	assert.Equal(t, "dep-deploying", index[key][0].ID)
-	assert.Equal(t, "deploying", index[key][0].Status)
-	assert.Equal(t, "dep-active", index[key][1].ID)
-	assert.Equal(t, "deployed", index[key][1].Status)
-	assert.Equal(t, "dep-discovered", index[key][2].ID)
-	assert.Equal(t, "discovered", index[key][2].Status)
-	assert.Equal(t, "dep-cancelled", index[key][3].ID)
-	assert.Equal(t, "cancelled", index[key][3].Status)
+	require.Len(t, index[key], 1)
+	assert.Equal(t, "dep-deployed", index[key][0].ID)
+	assert.Equal(t, models.DeploymentStatusDeployed, index[key][0].Status)
 }
 
 func TestAttachServerDeploymentMetaMatchesVersionAndLatest(t *testing.T) {
@@ -44,8 +38,8 @@ func TestAttachServerDeploymentMetaMatchesVersionAndLatest(t *testing.T) {
 	reg := &servicetest.FakeRegistry{
 		GetDeploymentsFn: func(_ context.Context, _ *models.DeploymentFilter) ([]*models.Deployment, error) {
 			return []*models.Deployment{
-				{ID: "dep-v1", ServerName: "io.test/server", ResourceType: "mcp", Version: "1.0.0", Status: "deployed", UpdatedAt: now},
-				{ID: "dep-latest", ServerName: "io.test/server", ResourceType: "mcp", Version: "latest", Status: "deployed", UpdatedAt: now.Add(-time.Minute)},
+				{ID: "dep-v1", ServerName: "io.test/server", ResourceType: "mcp", Version: "1.0.0", Status: models.DeploymentStatusDeployed, UpdatedAt: now},
+				{ID: "dep-latest", ServerName: "io.test/server", ResourceType: "mcp", Version: "latest", Status: models.DeploymentStatusDeployed, UpdatedAt: now.Add(-time.Minute)},
 			}, nil
 		},
 	}

--- a/internal/registry/platforms/kubernetes/deployment_adapter_kubernetes.go
+++ b/internal/registry/platforms/kubernetes/deployment_adapter_kubernetes.go
@@ -44,7 +44,7 @@ func (a *kubernetesDeploymentAdapter) Deploy(ctx context.Context, req *models.De
 	if err := kubernetesApplyPlatformConfig(ctx, provider, cfg, false); err != nil {
 		return nil, fmt.Errorf("apply kubernetes platform config: %w", err)
 	}
-	return &models.DeploymentActionResult{Status: "deployed"}, nil
+	return &models.DeploymentActionResult{Status: models.DeploymentStatusDeployed}, nil
 }
 
 func (a *kubernetesDeploymentAdapter) Undeploy(ctx context.Context, deployment *models.Deployment) error {

--- a/internal/registry/platforms/kubernetes/deployment_adapter_kubernetes_platform.go
+++ b/internal/registry/platforms/kubernetes/deployment_adapter_kubernetes_platform.go
@@ -830,7 +830,7 @@ func kubernetesDiscoverDeployments(ctx context.Context, provider *models.Provide
 			Version:          "unknown",
 			DeployedAt:       creation,
 			UpdatedAt:        creation,
-			Status:           "deployed",
+			Status:           models.DeploymentStatusDeployed,
 			Origin:           "discovered",
 			ProviderID:       providerID,
 			ResourceType:     resourceType,

--- a/internal/registry/platforms/local/deployment_adapter_local.go
+++ b/internal/registry/platforms/local/deployment_adapter_local.go
@@ -64,7 +64,7 @@ func (a *localDeploymentAdapter) Deploy(ctx context.Context, req *models.Deploym
 		}
 	}
 
-	return &models.DeploymentActionResult{Status: "deployed"}, nil
+	return &models.DeploymentActionResult{Status: models.DeploymentStatusDeployed}, nil
 }
 
 func (a *localDeploymentAdapter) Undeploy(ctx context.Context, deployment *models.Deployment) error {

--- a/internal/registry/service/registry_service.go
+++ b/internal/registry/service/registry_service.go
@@ -1165,7 +1165,7 @@ func (s *registryServiceImpl) createManagedDeploymentRecord(ctx context.Context,
 		ID:               req.ID,
 		ServerName:       strings.TrimSpace(req.ServerName),
 		Version:          strings.TrimSpace(req.Version),
-		Status:           "deploying",
+		Status:           models.DeploymentStatusDeploying,
 		Env:              req.Env,
 		ProviderConfig:   req.ProviderConfig,
 		ProviderMetadata: req.ProviderMetadata,
@@ -1218,7 +1218,7 @@ func (s *registryServiceImpl) createManagedDeploymentRecord(ctx context.Context,
 }
 
 func (s *registryServiceImpl) applyDeploymentActionResult(ctx context.Context, deploymentID string, result *models.DeploymentActionResult) error {
-	status := "deployed"
+	status := models.DeploymentStatusDeployed
 	if result != nil {
 		if trimmedStatus := strings.TrimSpace(result.Status); trimmedStatus != "" {
 			status = trimmedStatus
@@ -1252,7 +1252,7 @@ func (s *registryServiceImpl) applyFailedDeploymentAction(
 	deployErr error,
 	result *models.DeploymentActionResult,
 ) error {
-	status := "failed"
+	status := models.DeploymentStatusFailed
 	if result != nil {
 		if trimmedStatus := strings.TrimSpace(result.Status); trimmedStatus != "" {
 			status = trimmedStatus

--- a/internal/registry/service/registry_service_test.go
+++ b/internal/registry/service/registry_service_test.go
@@ -1321,6 +1321,54 @@ func TestUndeployDeployment_UsesAdapterForLocalPlatform(t *testing.T) {
 	assert.True(t, removeCalled)
 }
 
+func TestUndeployDeployment_FailedOrCancelledRunsAdapterCleanup(t *testing.T) {
+	tests := []struct {
+		name   string
+		status string
+	}{
+		{name: "failed", status: models.DeploymentStatusFailed},
+		{name: "cancelled", status: models.DeploymentStatusCancelled},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			undeployCalled := false
+			removeCalled := false
+			mockDB := &deploymentMockDB{
+				getProviderByIDFn: func(_ context.Context, _ pgx.Tx, providerID string) (*models.Provider, error) {
+					return &models.Provider{ID: providerID, Platform: "local"}, nil
+				},
+				removeDeploymentByIdFn: func(_ context.Context, _ pgx.Tx, id string) error {
+					removeCalled = id == "dep-failed-1"
+					return nil
+				},
+			}
+			adapter := &testDeploymentAdapter{
+				undeployFn: func(_ context.Context, _ *models.Deployment) error {
+					undeployCalled = true
+					return nil
+				},
+			}
+
+			svc := &registryServiceImpl{
+				db: mockDB,
+				deploymentAdapters: map[string]registrytypes.DeploymentPlatformAdapter{
+					"local": adapter,
+				},
+			}
+
+			err := svc.UndeployDeployment(context.Background(), &models.Deployment{
+				ID:         "dep-failed-1",
+				ProviderID: "local",
+				Status:     tt.status,
+			})
+			require.NoError(t, err)
+			assert.True(t, undeployCalled)
+			assert.True(t, removeCalled)
+		})
+	}
+}
+
 func TestCreateDeployment_RejectsUnsupportedResourceTypeForProvider(t *testing.T) {
 	mockDB := &deployCreateMockDB{
 		getProviderByIDFn: func(_ context.Context, _ pgx.Tx, providerID string) (*models.Provider, error) {

--- a/pkg/models/deployment.go
+++ b/pkg/models/deployment.go
@@ -5,6 +5,20 @@ import (
 	"time"
 )
 
+// Deployment status values used across registry workflows and API payloads.
+const (
+	// DeploymentStatusDeploying indicates the deployment is currently being applied.
+	DeploymentStatusDeploying = "deploying"
+	// DeploymentStatusDeployed indicates the deployment is successfully applied.
+	DeploymentStatusDeployed = "deployed"
+	// DeploymentStatusFailed indicates deployment failed and may need cleanup/retry.
+	DeploymentStatusFailed = "failed"
+	// DeploymentStatusCancelled indicates deployment was cancelled before completion.
+	DeploymentStatusCancelled = "cancelled"
+	// DeploymentStatusDiscovered indicates deployment was discovered from runtime state.
+	DeploymentStatusDiscovered = "discovered"
+)
+
 // Deployment represents a deployed resource with unified deployment metadata.
 type Deployment struct {
 	ID               string            `json:"id"`


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don't apply.
-->

# Description

<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

We stop treating failed or cancelled deployment rows as active deployments and allow those rows to be removed without invoking platform undeploy.

Previously, list and metadata surfaces counted any matching deployment row, including failed and cancelled records. Deleting a failed deployment also still tried to undeploy platform resources first, which could fail even when nothing had been created.

Now, only deployed rows contribute to deployment status displays, and failed or cancelled records are removed directly from the database during delete.

Fixes #326.

# Change Type

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bump
/kind cleanup
/kind design
/kind deprecation
/kind documentation
/kind feature
/kind fix
/kind flake
/kind install
```
-->

/kind fix

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
NONE
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
