### PR TITLE
WIP: Wait for Kubernetes readiness

### DIFF
--- a/internal/cli/common/wait.go
+++ b/internal/cli/common/wait.go
@@ -2,12 +2,13 @@ package common
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/agentregistry-dev/agentregistry/internal/client"
 )
 
-const (
+var (
 	defaultWaitTimeout  = 5 * time.Minute
 	defaultPollInterval = 2 * time.Second
 )
@@ -31,15 +32,27 @@ func WaitForDeploymentReady(c *client.Client, deploymentID string) error {
 		case "deployed":
 			return nil
 		case "failed":
-			return fmt.Errorf("deployment failed")
+			return fmt.Errorf("deployment failed%s", formatDeploymentWaitError(dep.Error))
 		case "cancelled":
-			return fmt.Errorf("deployment was cancelled")
+			return fmt.Errorf("deployment was cancelled%s", formatDeploymentWaitError(dep.Error))
 		}
 
 		if time.Now().After(deadline) {
-			return fmt.Errorf("timed out waiting for deployment to become ready (current status: %s)", dep.Status)
+			return fmt.Errorf(
+				"timed out waiting for deployment to become ready (current status: %s%s)",
+				dep.Status,
+				formatDeploymentWaitError(dep.Error),
+			)
 		}
 
 		time.Sleep(defaultPollInterval)
 	}
+}
+
+func formatDeploymentWaitError(errorText string) string {
+	trimmed := strings.TrimSpace(errorText)
+	if trimmed == "" {
+		return ""
+	}
+	return ": " + trimmed
 }

--- a/internal/cli/common/wait_test.go
+++ b/internal/cli/common/wait_test.go
@@ -1,0 +1,74 @@
+package common
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/agentregistry-dev/agentregistry/internal/client"
+	"github.com/agentregistry-dev/agentregistry/pkg/models"
+)
+
+func TestWaitForDeploymentReady_ReturnsFailureDetails(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v0/deployments/dep-1" {
+			http.NotFound(w, r)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(models.Deployment{
+			ID:     "dep-1",
+			Status: "failed",
+			Error:  "agent demo-agent: DeploymentNotReady",
+		})
+	}))
+	defer srv.Close()
+
+	err := WaitForDeploymentReady(client.NewClient(srv.URL, ""), "dep-1")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if got, want := err.Error(), "deployment failed: agent demo-agent: DeploymentNotReady"; got != want {
+		t.Fatalf("WaitForDeploymentReady() error = %q, want %q", got, want)
+	}
+}
+
+func TestWaitForDeploymentReady_PollsUntilDeployed(t *testing.T) {
+	originalTimeout := defaultWaitTimeout
+	originalInterval := defaultPollInterval
+	defaultWaitTimeout = 200 * time.Millisecond
+	defaultPollInterval = 10 * time.Millisecond
+	t.Cleanup(func() {
+		defaultWaitTimeout = originalTimeout
+		defaultPollInterval = originalInterval
+	})
+
+	requests := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v0/deployments/dep-2" {
+			http.NotFound(w, r)
+			return
+		}
+		requests++
+		status := "deploying"
+		errorText := "agent demo-agent: DeploymentNotReady"
+		if requests >= 2 {
+			status = "deployed"
+			errorText = ""
+		}
+		_ = json.NewEncoder(w).Encode(models.Deployment{
+			ID:     "dep-2",
+			Status: status,
+			Error:  errorText,
+		})
+	}))
+	defer srv.Close()
+
+	if err := WaitForDeploymentReady(client.NewClient(srv.URL, ""), "dep-2"); err != nil {
+		t.Fatalf("WaitForDeploymentReady() error = %v", err)
+	}
+	if requests < 2 {
+		t.Fatalf("expected at least 2 poll requests, got %d", requests)
+	}
+}

--- a/internal/registry/platforms/kubernetes/deployment_adapter_kubernetes.go
+++ b/internal/registry/platforms/kubernetes/deployment_adapter_kubernetes.go
@@ -44,7 +44,7 @@ func (a *kubernetesDeploymentAdapter) Deploy(ctx context.Context, req *models.De
 	if err := kubernetesApplyPlatformConfig(ctx, provider, cfg, false); err != nil {
 		return nil, fmt.Errorf("apply kubernetes platform config: %w", err)
 	}
-	return &models.DeploymentActionResult{Status: "deployed"}, nil
+	return &models.DeploymentActionResult{Status: "deploying"}, nil
 }
 
 func (a *kubernetesDeploymentAdapter) Undeploy(ctx context.Context, deployment *models.Deployment) error {
@@ -71,6 +71,20 @@ func (a *kubernetesDeploymentAdapter) CleanupStale(ctx context.Context, deployme
 		log.Printf("Warning: failed to clean up stale kubernetes deployment %s: %v", deployment.ID, err)
 	}
 	return nil
+}
+
+func (a *kubernetesDeploymentAdapter) RefreshDeploymentState(
+	ctx context.Context,
+	deployment *models.Deployment,
+) (*models.DeploymentStatePatch, error) {
+	if err := utils.ValidateDeploymentRequest(deployment, true); err != nil {
+		return nil, err
+	}
+	provider, err := a.registry.GetProviderByID(ctx, deployment.ProviderID)
+	if err != nil {
+		return nil, err
+	}
+	return kubernetesRefreshManagedDeploymentState(ctx, provider, deployment)
 }
 
 func (a *kubernetesDeploymentAdapter) GetLogs(_ context.Context, _ *models.Deployment) ([]string, error) {

--- a/internal/registry/platforms/kubernetes/deployment_adapter_kubernetes_platform.go
+++ b/internal/registry/platforms/kubernetes/deployment_adapter_kubernetes_platform.go
@@ -17,6 +17,7 @@ import (
 	kmcpv1alpha1 "github.com/kagent-dev/kmcp/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -204,6 +205,265 @@ func kubernetesDeleteResourcesByDeploymentID(ctx context.Context, provider *mode
 	}
 }
 
+func kubernetesRefreshManagedDeploymentState(
+	ctx context.Context,
+	provider *models.Provider,
+	deployment *models.Deployment,
+) (*models.DeploymentStatePatch, error) {
+	c, err := kubernetesGetClient(provider)
+	if err != nil {
+		return nil, err
+	}
+	return kubernetesRefreshManagedDeploymentStateWithClient(ctx, c, provider, deployment)
+}
+
+func kubernetesRefreshManagedDeploymentStateWithClient(
+	ctx context.Context,
+	c client.Client,
+	provider *models.Provider,
+	deployment *models.Deployment,
+) (*models.DeploymentStatePatch, error) {
+	if deployment == nil {
+		return nil, fmt.Errorf("deployment is required")
+	}
+	namespace := deploymentNamespace(deployment, provider)
+	status, message, err := kubernetesManagedDeploymentReadiness(ctx, c, deployment, namespace)
+	if err != nil {
+		return nil, err
+	}
+
+	patch := &models.DeploymentStatePatch{}
+	if status != "" {
+		patch.Status = &status
+	}
+	patch.Error = &message
+	return patch, nil
+}
+
+func kubernetesManagedDeploymentReadiness(
+	ctx context.Context,
+	c client.Client,
+	deployment *models.Deployment,
+	namespace string,
+) (string, string, error) {
+	if deployment == nil {
+		return "", "", fmt.Errorf("deployment is required")
+	}
+
+	type resourceState struct {
+		status  string
+		message string
+	}
+	var states []resourceState
+
+	switch strings.ToLower(strings.TrimSpace(deployment.ResourceType)) {
+	case "agent":
+		agents, err := kubernetesListAgentsByDeploymentID(ctx, c, deployment.ID, namespace)
+		if err != nil {
+			return "", "", err
+		}
+		if len(agents) == 0 {
+			return "deploying", "waiting for kubernetes agent resource to be created", nil
+		}
+		for _, agent := range agents {
+			states = append(states, kubernetesEvaluateAgentReadiness(agent))
+		}
+
+		remoteMCPs, err := kubernetesListRemoteMCPServersByDeploymentID(ctx, c, deployment.ID, namespace)
+		if err != nil {
+			return "", "", err
+		}
+		for _, remote := range remoteMCPs {
+			states = append(states, kubernetesEvaluateRemoteMCPServerReadiness(remote))
+		}
+
+		mcpServers, err := kubernetesListMCPServersByDeploymentID(ctx, c, deployment.ID, namespace)
+		if err != nil {
+			return "", "", err
+		}
+		for _, mcp := range mcpServers {
+			states = append(states, kubernetesEvaluateMCPServerReadiness(mcp))
+		}
+	case "mcp":
+		remoteMCPs, err := kubernetesListRemoteMCPServersByDeploymentID(ctx, c, deployment.ID, namespace)
+		if err != nil {
+			return "", "", err
+		}
+		mcpServers, err := kubernetesListMCPServersByDeploymentID(ctx, c, deployment.ID, namespace)
+		if err != nil {
+			return "", "", err
+		}
+		if len(remoteMCPs) == 0 && len(mcpServers) == 0 {
+			return "deploying", "waiting for kubernetes MCP resources to be created", nil
+		}
+		for _, remote := range remoteMCPs {
+			states = append(states, kubernetesEvaluateRemoteMCPServerReadiness(remote))
+		}
+		for _, mcp := range mcpServers {
+			states = append(states, kubernetesEvaluateMCPServerReadiness(mcp))
+		}
+	default:
+		return "", "", fmt.Errorf("unsupported kubernetes resource type %q", deployment.ResourceType)
+	}
+
+	allReady := len(states) > 0
+	progressMessage := ""
+	for _, state := range states {
+		switch state.status {
+		case "failed":
+			return "failed", state.message, nil
+		case "deploying":
+			allReady = false
+			if progressMessage == "" && state.message != "" {
+				progressMessage = state.message
+			}
+		case "deployed":
+		default:
+			allReady = false
+		}
+	}
+	if allReady {
+		return "deployed", "", nil
+	}
+	return "deploying", progressMessage, nil
+}
+
+func kubernetesEvaluateAgentReadiness(agent *v1alpha2.Agent) (result struct {
+	status  string
+	message string
+}) {
+	if agent == nil {
+		result.status = "deploying"
+		result.message = "waiting for kubernetes agent resource"
+		return result
+	}
+	if !kubernetesObservedLatestGeneration(agent.Generation, agent.Status.ObservedGeneration) {
+		result.status = "deploying"
+		result.message = fmt.Sprintf("waiting for agent %s status to observe generation %d", agent.Name, agent.Generation)
+		return result
+	}
+	if cond := meta.FindStatusCondition(agent.Status.Conditions, v1alpha2.AgentConditionTypeAccepted); cond != nil && cond.Status == metav1.ConditionFalse {
+		result.status = "failed"
+		result.message = kubernetesFormatConditionMessage("agent", agent.Name, *cond)
+		return result
+	}
+	if cond := meta.FindStatusCondition(agent.Status.Conditions, v1alpha2.AgentConditionTypeReady); cond != nil {
+		switch cond.Status {
+		case metav1.ConditionTrue:
+			result.status = "deployed"
+			return result
+		case metav1.ConditionFalse:
+			result.status = "deploying"
+			result.message = kubernetesFormatConditionMessage("agent", agent.Name, *cond)
+			return result
+		}
+	}
+	result.status = "deploying"
+	result.message = fmt.Sprintf("waiting for agent %s to report Ready condition", agent.Name)
+	return result
+}
+
+func kubernetesEvaluateMCPServerReadiness(server *kmcpv1alpha1.MCPServer) (result struct {
+	status  string
+	message string
+}) {
+	if server == nil {
+		result.status = "deploying"
+		result.message = "waiting for kubernetes MCP server resource"
+		return result
+	}
+	if !kubernetesObservedLatestGeneration(server.Generation, server.Status.ObservedGeneration) {
+		result.status = "deploying"
+		result.message = fmt.Sprintf("waiting for MCP server %s status to observe generation %d", server.Name, server.Generation)
+		return result
+	}
+
+	for _, conditionType := range []string{
+		string(kmcpv1alpha1.MCPServerConditionAccepted),
+		string(kmcpv1alpha1.MCPServerConditionResolvedRefs),
+		string(kmcpv1alpha1.MCPServerConditionProgrammed),
+	} {
+		if cond := meta.FindStatusCondition(server.Status.Conditions, conditionType); cond != nil && cond.Status == metav1.ConditionFalse {
+			result.status = "failed"
+			result.message = kubernetesFormatConditionMessage("mcp server", server.Name, *cond)
+			return result
+		}
+	}
+
+	if cond := meta.FindStatusCondition(server.Status.Conditions, string(kmcpv1alpha1.MCPServerConditionReady)); cond != nil {
+		switch cond.Status {
+		case metav1.ConditionTrue:
+			result.status = "deployed"
+			return result
+		case metav1.ConditionFalse:
+			result.status = "deploying"
+			result.message = kubernetesFormatConditionMessage("mcp server", server.Name, *cond)
+			return result
+		}
+	}
+
+	result.status = "deploying"
+	result.message = fmt.Sprintf("waiting for MCP server %s to report Ready condition", server.Name)
+	return result
+}
+
+func kubernetesEvaluateRemoteMCPServerReadiness(server *v1alpha2.RemoteMCPServer) (result struct {
+	status  string
+	message string
+}) {
+	if server == nil {
+		result.status = "deploying"
+		result.message = "waiting for kubernetes remote MCP server resource"
+		return result
+	}
+	if !kubernetesObservedLatestGeneration(server.Generation, server.Status.ObservedGeneration) {
+		result.status = "deploying"
+		result.message = fmt.Sprintf("waiting for remote MCP server %s status to observe generation %d", server.Name, server.Generation)
+		return result
+	}
+
+	if cond := meta.FindStatusCondition(server.Status.Conditions, "Accepted"); cond != nil && cond.Status == metav1.ConditionFalse {
+		result.status = "failed"
+		result.message = kubernetesFormatConditionMessage("remote MCP server", server.Name, *cond)
+		return result
+	}
+
+	if cond := meta.FindStatusCondition(server.Status.Conditions, "Ready"); cond != nil {
+		switch cond.Status {
+		case metav1.ConditionTrue:
+			result.status = "deployed"
+			return result
+		case metav1.ConditionFalse:
+			result.status = "deploying"
+			result.message = kubernetesFormatConditionMessage("remote MCP server", server.Name, *cond)
+			return result
+		}
+	}
+	if cond := meta.FindStatusCondition(server.Status.Conditions, "Accepted"); cond != nil && cond.Status == metav1.ConditionTrue {
+		result.status = "deployed"
+		return result
+	}
+
+	result.status = "deploying"
+	result.message = fmt.Sprintf("waiting for remote MCP server %s to report Accepted condition", server.Name)
+	return result
+}
+
+func kubernetesObservedLatestGeneration(generation, observedGeneration int64) bool {
+	return observedGeneration >= generation
+}
+
+func kubernetesFormatConditionMessage(kind, name string, condition metav1.Condition) string {
+	details := strings.TrimSpace(condition.Message)
+	if details == "" {
+		details = strings.TrimSpace(condition.Reason)
+	}
+	if details == "" {
+		details = fmt.Sprintf("%s=%s", condition.Type, condition.Status)
+	}
+	return fmt.Sprintf("%s %s: %s", kind, name, details)
+}
+
 func kubernetesListAgents(ctx context.Context, provider *models.Provider, namespace string) ([]*v1alpha2.Agent, error) {
 	c, err := kubernetesGetClient(provider)
 	if err != nil {
@@ -216,6 +476,18 @@ func kubernetesListAgents(ctx context.Context, provider *models.Provider, namesp
 	}
 	if err := c.List(ctx, agentList, listOpts...); err != nil {
 		return nil, fmt.Errorf("failed to list agents: %w", err)
+	}
+	agents := make([]*v1alpha2.Agent, 0, len(agentList.Items))
+	for i := range agentList.Items {
+		agents = append(agents, &agentList.Items[i])
+	}
+	return agents, nil
+}
+
+func kubernetesListAgentsByDeploymentID(ctx context.Context, c client.Client, deploymentID, namespace string) ([]*v1alpha2.Agent, error) {
+	agentList := &v1alpha2.AgentList{}
+	if err := c.List(ctx, agentList, kubernetesDeploymentSelectorOpts(deploymentID, namespace)...); err != nil {
+		return nil, fmt.Errorf("failed to list agents by deployment id %s: %w", deploymentID, err)
 	}
 	agents := make([]*v1alpha2.Agent, 0, len(agentList.Items))
 	for i := range agentList.Items {
@@ -244,6 +516,18 @@ func kubernetesListMCPServers(ctx context.Context, provider *models.Provider, na
 	return servers, nil
 }
 
+func kubernetesListMCPServersByDeploymentID(ctx context.Context, c client.Client, deploymentID, namespace string) ([]*kmcpv1alpha1.MCPServer, error) {
+	mcpList := &kmcpv1alpha1.MCPServerList{}
+	if err := c.List(ctx, mcpList, kubernetesDeploymentSelectorOpts(deploymentID, namespace)...); err != nil {
+		return nil, fmt.Errorf("failed to list mcp servers by deployment id %s: %w", deploymentID, err)
+	}
+	servers := make([]*kmcpv1alpha1.MCPServer, 0, len(mcpList.Items))
+	for i := range mcpList.Items {
+		servers = append(servers, &mcpList.Items[i])
+	}
+	return servers, nil
+}
+
 func kubernetesListRemoteMCPServers(ctx context.Context, provider *models.Provider, namespace string) ([]*v1alpha2.RemoteMCPServer, error) {
 	c, err := kubernetesGetClient(provider)
 	if err != nil {
@@ -256,6 +540,18 @@ func kubernetesListRemoteMCPServers(ctx context.Context, provider *models.Provid
 	}
 	if err := c.List(ctx, remoteMCPList, listOpts...); err != nil {
 		return nil, fmt.Errorf("failed to list remote MCP servers: %w", err)
+	}
+	servers := make([]*v1alpha2.RemoteMCPServer, 0, len(remoteMCPList.Items))
+	for i := range remoteMCPList.Items {
+		servers = append(servers, &remoteMCPList.Items[i])
+	}
+	return servers, nil
+}
+
+func kubernetesListRemoteMCPServersByDeploymentID(ctx context.Context, c client.Client, deploymentID, namespace string) ([]*v1alpha2.RemoteMCPServer, error) {
+	remoteMCPList := &v1alpha2.RemoteMCPServerList{}
+	if err := c.List(ctx, remoteMCPList, kubernetesDeploymentSelectorOpts(deploymentID, namespace)...); err != nil {
+		return nil, fmt.Errorf("failed to list remote mcp servers by deployment id %s: %w", deploymentID, err)
 	}
 	servers := make([]*v1alpha2.RemoteMCPServer, 0, len(remoteMCPList.Items))
 	for i := range remoteMCPList.Items {

--- a/internal/registry/platforms/kubernetes/deployment_adapter_kubernetes_platform_test.go
+++ b/internal/registry/platforms/kubernetes/deployment_adapter_kubernetes_platform_test.go
@@ -525,6 +525,170 @@ func TestKubernetesDiscoverDeployments_RecordsNamespaceInProviderMetadata(t *tes
 	}
 }
 
+func TestKubernetesRefreshManagedDeploymentStateWithClient_AgentReady(t *testing.T) {
+	const (
+		namespace    = "demo-ns"
+		deploymentID = "dep-agent-ready"
+	)
+
+	fakeClient := fake.NewClientBuilder().WithScheme(kubernetesScheme).WithObjects(
+		&v1alpha2.Agent{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "demo-agent",
+				Namespace:  namespace,
+				Generation: 3,
+				Labels:     map[string]string{kubernetesDeploymentIDLabelKey: deploymentID},
+			},
+			Status: v1alpha2.AgentStatus{
+				ObservedGeneration: 3,
+				Conditions: []metav1.Condition{
+					{Type: v1alpha2.AgentConditionTypeAccepted, Status: metav1.ConditionTrue},
+					{Type: v1alpha2.AgentConditionTypeReady, Status: metav1.ConditionTrue},
+				},
+			},
+		},
+	).Build()
+
+	statusPatch, err := kubernetesRefreshManagedDeploymentStateWithClient(
+		context.Background(),
+		fakeClient,
+		&models.Provider{ID: "kubernetes-default", Platform: "kubernetes"},
+		&models.Deployment{ID: deploymentID, ResourceType: "agent", Env: map[string]string{"KAGENT_NAMESPACE": namespace}},
+	)
+	if err != nil {
+		t.Fatalf("kubernetesRefreshManagedDeploymentStateWithClient() error = %v", err)
+	}
+	if statusPatch == nil || statusPatch.Status == nil || *statusPatch.Status != "deployed" {
+		t.Fatalf("expected deployed status patch, got %#v", statusPatch)
+	}
+	if statusPatch.Error == nil || *statusPatch.Error != "" {
+		t.Fatalf("expected cleared error, got %#v", statusPatch.Error)
+	}
+}
+
+func TestKubernetesRefreshManagedDeploymentStateWithClient_AgentNotReadyRemainsDeploying(t *testing.T) {
+	const (
+		namespace    = "demo-ns"
+		deploymentID = "dep-agent-progressing"
+	)
+
+	fakeClient := fake.NewClientBuilder().WithScheme(kubernetesScheme).WithObjects(
+		&v1alpha2.Agent{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "demo-agent",
+				Namespace:  namespace,
+				Generation: 2,
+				Labels:     map[string]string{kubernetesDeploymentIDLabelKey: deploymentID},
+			},
+			Status: v1alpha2.AgentStatus{
+				ObservedGeneration: 2,
+				Conditions: []metav1.Condition{
+					{Type: v1alpha2.AgentConditionTypeAccepted, Status: metav1.ConditionTrue},
+					{Type: v1alpha2.AgentConditionTypeReady, Status: metav1.ConditionFalse, Reason: "DeploymentNotReady", Message: "underlying Deployment has unavailable replicas"},
+				},
+			},
+		},
+	).Build()
+
+	statusPatch, err := kubernetesRefreshManagedDeploymentStateWithClient(
+		context.Background(),
+		fakeClient,
+		&models.Provider{ID: "kubernetes-default", Platform: "kubernetes"},
+		&models.Deployment{ID: deploymentID, ResourceType: "agent", Env: map[string]string{"KAGENT_NAMESPACE": namespace}},
+	)
+	if err != nil {
+		t.Fatalf("kubernetesRefreshManagedDeploymentStateWithClient() error = %v", err)
+	}
+	if statusPatch == nil || statusPatch.Status == nil || *statusPatch.Status != "deploying" {
+		t.Fatalf("expected deploying status patch, got %#v", statusPatch)
+	}
+	if statusPatch.Error == nil || !strings.Contains(*statusPatch.Error, "underlying Deployment has unavailable replicas") {
+		t.Fatalf("expected readiness message in error field, got %#v", statusPatch.Error)
+	}
+}
+
+func TestKubernetesRefreshManagedDeploymentStateWithClient_RemoteMCPNotReadyRemainsDeploying(t *testing.T) {
+	const (
+		namespace    = "demo-ns"
+		deploymentID = "dep-remote-mcp-progressing"
+	)
+
+	fakeClient := fake.NewClientBuilder().WithScheme(kubernetesScheme).WithObjects(
+		&v1alpha2.RemoteMCPServer{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "demo-remote-mcp",
+				Namespace:  namespace,
+				Generation: 2,
+				Labels:     map[string]string{kubernetesDeploymentIDLabelKey: deploymentID},
+			},
+			Status: v1alpha2.RemoteMCPServerStatus{
+				ObservedGeneration: 2,
+				Conditions: []metav1.Condition{
+					{Type: "Accepted", Status: metav1.ConditionTrue},
+					{Type: "Ready", Status: metav1.ConditionFalse, Reason: "Reconciling", Message: "remote endpoint validation still running"},
+				},
+			},
+		},
+	).Build()
+
+	statusPatch, err := kubernetesRefreshManagedDeploymentStateWithClient(
+		context.Background(),
+		fakeClient,
+		&models.Provider{ID: "kubernetes-default", Platform: "kubernetes"},
+		&models.Deployment{ID: deploymentID, ResourceType: "mcp", Env: map[string]string{"KAGENT_NAMESPACE": namespace}},
+	)
+	if err != nil {
+		t.Fatalf("kubernetesRefreshManagedDeploymentStateWithClient() error = %v", err)
+	}
+	if statusPatch == nil || statusPatch.Status == nil || *statusPatch.Status != "deploying" {
+		t.Fatalf("expected deploying status patch, got %#v", statusPatch)
+	}
+	if statusPatch.Error == nil || !strings.Contains(*statusPatch.Error, "remote endpoint validation still running") {
+		t.Fatalf("expected readiness message in error field, got %#v", statusPatch.Error)
+	}
+}
+
+func TestKubernetesRefreshManagedDeploymentStateWithClient_MCPConditionFailure(t *testing.T) {
+	const (
+		namespace    = "demo-ns"
+		deploymentID = "dep-mcp-failed"
+	)
+
+	fakeClient := fake.NewClientBuilder().WithScheme(kubernetesScheme).WithObjects(
+		&kmcpv1alpha1.MCPServer{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "demo-mcp",
+				Namespace:  namespace,
+				Generation: 1,
+				Labels:     map[string]string{kubernetesDeploymentIDLabelKey: deploymentID},
+			},
+			Status: kmcpv1alpha1.MCPServerStatus{
+				ObservedGeneration: 1,
+				Conditions: []metav1.Condition{
+					{Type: string(kmcpv1alpha1.MCPServerConditionAccepted), Status: metav1.ConditionTrue},
+					{Type: string(kmcpv1alpha1.MCPServerConditionResolvedRefs), Status: metav1.ConditionFalse, Reason: string(kmcpv1alpha1.MCPServerReasonImageNotFound), Message: "image not found"},
+				},
+			},
+		},
+	).Build()
+
+	statusPatch, err := kubernetesRefreshManagedDeploymentStateWithClient(
+		context.Background(),
+		fakeClient,
+		&models.Provider{ID: "kubernetes-default", Platform: "kubernetes"},
+		&models.Deployment{ID: deploymentID, ResourceType: "mcp", Env: map[string]string{"KAGENT_NAMESPACE": namespace}},
+	)
+	if err != nil {
+		t.Fatalf("kubernetesRefreshManagedDeploymentStateWithClient() error = %v", err)
+	}
+	if statusPatch == nil || statusPatch.Status == nil || *statusPatch.Status != "failed" {
+		t.Fatalf("expected failed status patch, got %#v", statusPatch)
+	}
+	if statusPatch.Error == nil || !strings.Contains(*statusPatch.Error, "image not found") {
+		t.Fatalf("expected failure message in error field, got %#v", statusPatch.Error)
+	}
+}
+
 func testKubernetesProviderKubeconfig(contextHosts map[string]string, currentContext string) string {
 	clusters := make([]string, 0, len(contextHosts))
 	contexts := make([]string, 0, len(contextHosts))

--- a/internal/registry/service/registry_service.go
+++ b/internal/registry/service/registry_service.go
@@ -71,6 +71,12 @@ type DeploymentPlatformStaleCleaner interface {
 	CleanupStale(ctx context.Context, deployment *models.Deployment) error
 }
 
+// DeploymentPlatformStateRefresher is an optional adapter hook for updating
+// managed deployment state from live platform resources.
+type DeploymentPlatformStateRefresher interface {
+	RefreshDeploymentState(ctx context.Context, deployment *models.Deployment) (*models.DeploymentStatePatch, error)
+}
+
 // NewRegistryService creates a new registry service with the provided database and configuration
 func NewRegistryService(
 	db database.Database,
@@ -885,12 +891,71 @@ func (s *registryServiceImpl) GetDeployments(ctx context.Context, filter *models
 func (s *registryServiceImpl) GetDeploymentByID(ctx context.Context, id string) (*models.Deployment, error) {
 	deployment, err := s.db.GetDeploymentByID(ctx, nil, id)
 	if err == nil {
+		refreshed, refreshErr := s.refreshManagedDeploymentState(ctx, deployment)
+		if refreshErr != nil {
+			return nil, refreshErr
+		}
+		if refreshed != nil {
+			return refreshed, nil
+		}
 		return deployment, nil
 	}
 	if !errors.Is(err, database.ErrNotFound) {
 		return nil, err
 	}
 	return s.getDiscoveredDeploymentByID(ctx, id)
+}
+
+func (s *registryServiceImpl) refreshManagedDeploymentState(ctx context.Context, deployment *models.Deployment) (*models.Deployment, error) {
+	if deployment == nil {
+		return nil, nil
+	}
+	if !strings.EqualFold(strings.TrimSpace(deployment.Origin), "managed") {
+		return nil, nil
+	}
+	if !strings.EqualFold(strings.TrimSpace(deployment.Status), "deploying") {
+		return nil, nil
+	}
+
+	adapter, err := s.resolveDeploymentAdapterByProviderID(ctx, deployment.ProviderID)
+	if err != nil {
+		return nil, err
+	}
+	refresher, ok := adapter.(DeploymentPlatformStateRefresher)
+	if !ok {
+		return nil, nil
+	}
+
+	patch, err := refresher.RefreshDeploymentState(ctx, deployment)
+	if err != nil {
+		return nil, err
+	}
+	if !deploymentStatePatchChangesDeployment(deployment, patch) {
+		return nil, nil
+	}
+	if err := s.db.UpdateDeploymentState(auth.WithSystemContext(ctx), nil, deployment.ID, patch); err != nil {
+		return nil, err
+	}
+	return s.db.GetDeploymentByID(ctx, nil, deployment.ID)
+}
+
+func deploymentStatePatchChangesDeployment(deployment *models.Deployment, patch *models.DeploymentStatePatch) bool {
+	if deployment == nil || patch == nil {
+		return false
+	}
+	if patch.Status != nil && strings.TrimSpace(*patch.Status) != strings.TrimSpace(deployment.Status) {
+		return true
+	}
+	if patch.Error != nil && strings.TrimSpace(*patch.Error) != strings.TrimSpace(deployment.Error) {
+		return true
+	}
+	if patch.ProviderConfig != nil {
+		return true
+	}
+	if patch.ProviderMetadata != nil {
+		return true
+	}
+	return false
 }
 
 func (s *registryServiceImpl) getDiscoveredDeploymentByID(ctx context.Context, id string) (*models.Deployment, error) {

--- a/internal/registry/service/registry_service_test.go
+++ b/internal/registry/service/registry_service_test.go
@@ -1058,6 +1058,25 @@ func TestApplyDeploymentActionResult_UsesSystemContext(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestApplyDeploymentActionResult_PreservesInFlightStatus(t *testing.T) {
+	ctx := context.Background()
+	mockDB := &deployCreateMockDB{
+		updateDeploymentStateFn: func(_ context.Context, _ pgx.Tx, id string, patch *models.DeploymentStatePatch) error {
+			require.Equal(t, "dep-1", id)
+			require.NotNil(t, patch)
+			require.NotNil(t, patch.Status)
+			require.Equal(t, "deploying", *patch.Status)
+			require.NotNil(t, patch.Error)
+			require.Empty(t, *patch.Error)
+			return nil
+		},
+	}
+
+	svc := &registryServiceImpl{db: mockDB}
+	err := svc.applyDeploymentActionResult(ctx, "dep-1", &models.DeploymentActionResult{Status: "deploying"})
+	require.NoError(t, err)
+}
+
 func TestApplyFailedDeploymentAction_UsesSystemContext(t *testing.T) {
 	ctx := context.Background()
 	mockDB := &deployCreateMockDB{
@@ -1095,12 +1114,13 @@ type deployCreateMockDB struct {
 // deploymentMockDB is a minimal mock for database.Database that only implements
 // the methods needed for testing deployment cleanup logic. All other methods panic.
 type deploymentMockDB struct {
-	database.Database      // embed interface so unimplemented methods panic
-	getDeploymentByIDFn    func(ctx context.Context, tx pgx.Tx, id string) (*models.Deployment, error)
-	getDeploymentsFn       func(ctx context.Context, tx pgx.Tx, filter *models.DeploymentFilter) ([]*models.Deployment, error)
-	listProvidersFn        func(ctx context.Context, tx pgx.Tx, platform *string) ([]*models.Provider, error)
-	getProviderByIDFn      func(ctx context.Context, tx pgx.Tx, providerID string) (*models.Provider, error)
-	removeDeploymentByIdFn func(ctx context.Context, tx pgx.Tx, id string) error
+	database.Database       // embed interface so unimplemented methods panic
+	getDeploymentByIDFn     func(ctx context.Context, tx pgx.Tx, id string) (*models.Deployment, error)
+	getDeploymentsFn        func(ctx context.Context, tx pgx.Tx, filter *models.DeploymentFilter) ([]*models.Deployment, error)
+	listProvidersFn         func(ctx context.Context, tx pgx.Tx, platform *string) ([]*models.Provider, error)
+	getProviderByIDFn       func(ctx context.Context, tx pgx.Tx, providerID string) (*models.Provider, error)
+	updateDeploymentStateFn func(ctx context.Context, tx pgx.Tx, id string, patch *models.DeploymentStatePatch) error
+	removeDeploymentByIdFn  func(ctx context.Context, tx pgx.Tx, id string) error
 }
 
 func (m *deployCreateMockDB) GetProviderByID(ctx context.Context, tx pgx.Tx, providerID string) (*models.Provider, error) {
@@ -1151,6 +1171,10 @@ func (m *deploymentMockDB) GetProviderByID(ctx context.Context, tx pgx.Tx, provi
 	return m.getProviderByIDFn(ctx, tx, providerID)
 }
 
+func (m *deploymentMockDB) UpdateDeploymentState(ctx context.Context, tx pgx.Tx, id string, patch *models.DeploymentStatePatch) error {
+	return m.updateDeploymentStateFn(ctx, tx, id, patch)
+}
+
 func (m *deploymentMockDB) RemoveDeploymentByID(ctx context.Context, tx pgx.Tx, id string) error {
 	return m.removeDeploymentByIdFn(ctx, tx, id)
 }
@@ -1189,6 +1213,7 @@ type testDeploymentAdapter struct {
 	cancelFn       func(ctx context.Context, deployment *models.Deployment) error
 	discoverFn     func(ctx context.Context, providerID string) ([]*models.Deployment, error)
 	cleanupStaleFn func(ctx context.Context, deployment *models.Deployment) error
+	refreshStateFn func(ctx context.Context, deployment *models.Deployment) (*models.DeploymentStatePatch, error)
 	supportedTypes []string
 }
 
@@ -1241,6 +1266,13 @@ func (a *testDeploymentAdapter) CleanupStale(ctx context.Context, deployment *mo
 		return nil
 	}
 	return a.cleanupStaleFn(ctx, deployment)
+}
+
+func (a *testDeploymentAdapter) RefreshDeploymentState(ctx context.Context, deployment *models.Deployment) (*models.DeploymentStatePatch, error) {
+	if a.refreshStateFn == nil {
+		return nil, nil
+	}
+	return a.refreshStateFn(ctx, deployment)
 }
 
 func TestCleanupExistingDeployment_UsesAdapterStaleCleanerWhenAvailable(t *testing.T) {
@@ -1652,6 +1684,127 @@ func TestGetDeployments_ManagedOriginSkipsDiscovery(t *testing.T) {
 	require.Len(t, got, 1)
 	assert.False(t, discoverCalled)
 	assert.Equal(t, "dep-managed-only", got[0].ID)
+}
+
+func TestGetDeploymentByID_RefreshesManagedDeployingState(t *testing.T) {
+	current := &models.Deployment{
+		ID:         "dep-k8s-1",
+		ProviderID: "kubernetes-default",
+		Origin:     "managed",
+		Status:     "deploying",
+		Error:      "",
+	}
+	updated := *current
+	updated.Status = "deployed"
+
+	refreshCalled := false
+	mockDB := &deploymentMockDB{
+		getDeploymentByIDFn: func(_ context.Context, _ pgx.Tx, id string) (*models.Deployment, error) {
+			require.Equal(t, "dep-k8s-1", id)
+			if refreshCalled {
+				cloned := updated
+				return &cloned, nil
+			}
+			cloned := *current
+			return &cloned, nil
+		},
+		getProviderByIDFn: func(_ context.Context, _ pgx.Tx, providerID string) (*models.Provider, error) {
+			require.Equal(t, "kubernetes-default", providerID)
+			return &models.Provider{ID: providerID, Platform: "kubernetes"}, nil
+		},
+		updateDeploymentStateFn: func(_ context.Context, _ pgx.Tx, id string, patch *models.DeploymentStatePatch) error {
+			require.Equal(t, "dep-k8s-1", id)
+			require.NotNil(t, patch)
+			require.NotNil(t, patch.Status)
+			require.Equal(t, "deployed", *patch.Status)
+			require.NotNil(t, patch.Error)
+			require.Empty(t, *patch.Error)
+			refreshCalled = true
+			return nil
+		},
+	}
+	adapter := &testDeploymentAdapter{
+		refreshStateFn: func(_ context.Context, deployment *models.Deployment) (*models.DeploymentStatePatch, error) {
+			require.Equal(t, "dep-k8s-1", deployment.ID)
+			status := "deployed"
+			errorText := ""
+			return &models.DeploymentStatePatch{Status: &status, Error: &errorText}, nil
+		},
+	}
+
+	svc := &registryServiceImpl{
+		db: mockDB,
+		deploymentAdapters: map[string]registrytypes.DeploymentPlatformAdapter{
+			"kubernetes": adapter,
+		},
+	}
+
+	got, err := svc.GetDeploymentByID(context.Background(), "dep-k8s-1")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.True(t, refreshCalled)
+	assert.Equal(t, "deployed", got.Status)
+}
+
+func TestGetDeploymentByID_RefreshesManagedDeployingFailureState(t *testing.T) {
+	current := &models.Deployment{
+		ID:         "dep-k8s-2",
+		ProviderID: "kubernetes-default",
+		Origin:     "managed",
+		Status:     "deploying",
+	}
+	updated := *current
+	updated.Status = "failed"
+	updated.Error = "agent demo-agent: DeploymentNotReady"
+
+	refreshCalled := false
+	mockDB := &deploymentMockDB{
+		getDeploymentByIDFn: func(_ context.Context, _ pgx.Tx, id string) (*models.Deployment, error) {
+			require.Equal(t, "dep-k8s-2", id)
+			if refreshCalled {
+				cloned := updated
+				return &cloned, nil
+			}
+			cloned := *current
+			return &cloned, nil
+		},
+		getProviderByIDFn: func(_ context.Context, _ pgx.Tx, providerID string) (*models.Provider, error) {
+			require.Equal(t, "kubernetes-default", providerID)
+			return &models.Provider{ID: providerID, Platform: "kubernetes"}, nil
+		},
+		updateDeploymentStateFn: func(_ context.Context, _ pgx.Tx, id string, patch *models.DeploymentStatePatch) error {
+			require.Equal(t, "dep-k8s-2", id)
+			require.NotNil(t, patch)
+			require.NotNil(t, patch.Status)
+			require.Equal(t, "failed", *patch.Status)
+			require.NotNil(t, patch.Error)
+			require.Equal(t, "agent demo-agent: DeploymentNotReady", *patch.Error)
+			refreshCalled = true
+			return nil
+		},
+	}
+	adapter := &testDeploymentAdapter{
+		refreshStateFn: func(_ context.Context, deployment *models.Deployment) (*models.DeploymentStatePatch, error) {
+			require.Equal(t, "dep-k8s-2", deployment.ID)
+			status := "failed"
+			errorText := "agent demo-agent: DeploymentNotReady"
+			return &models.DeploymentStatePatch{Status: &status, Error: &errorText}, nil
+		},
+	}
+
+	svc := &registryServiceImpl{
+		db: mockDB,
+		deploymentAdapters: map[string]registrytypes.DeploymentPlatformAdapter{
+			"kubernetes": adapter,
+		},
+	}
+
+	got, err := svc.GetDeploymentByID(context.Background(), "dep-k8s-2")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.True(t, refreshCalled)
+	assert.Equal(t, "failed", got.Status)
+	assert.Equal(t, "agent demo-agent: DeploymentNotReady", got.Error)
 }
 
 func TestGetDeploymentByID_FallsBackToDiscoveredDeployments(t *testing.T) {


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don't apply.
-->

# Description

<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

We now keep Kubernetes deployments in an in-flight state until the live platform resources report readiness, and the CLI wait path surfaces current condition details instead of treating apply as success.

Previously, the Kubernetes adapter returned deployed immediately after apply, so --wait could exit successfully while the underlying Agent or MCP resources were still not ready. Follow-up to #296 which introduced the initial scaffolding, but didn't actually work.

Now, Kubernetes deploys stay in deploying until GetDeploymentByID refreshes their state from live CR conditions, and wait failures include the current deployment error text.

Fixes #230.

# Change Type

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bump
/kind cleanup
/kind design
/kind deprecation
/kind documentation
/kind feature
/kind fix
/kind flake
/kind install
```
-->

/kind fix

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
NONE
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
