### PR TITLE
ci: Fix PR limiter association exemptions

### DIFF
--- a/.github/workflows/pr-limit.yaml
+++ b/.github/workflows/pr-limit.yaml
@@ -15,10 +15,7 @@ jobs:
     - uses: Homebrew/actions/limit-pull-requests@50b8c2ab4a835c38897ed2c56c293b07167c0b59
       with:
         # https://docs.github.com/en/graphql/reference/enums#commentauthorassociation
-        except-author-associations: |
-          MEMBER
-          OWNER
-          COLLABORATOR
+        except-author-associations: MEMBER,OWNER,COLLABORATOR
         comment-limit: 3
         comment: >
           You already have 3 pull requests open. Please consider working on getting


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don't apply.
-->

# Description

<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

This updates the PR limiter workflow to pass exempt author associations in the format the pinned action parses.

Previously, we passed a newline-separated YAML block. The action splits this input on commas, so maintainers were still limited.

Now, we pass a comma-separated list.
MEMBER, OWNER, and COLLABORATOR are correctly exempted.

Fixes #387.

# Change Type

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bump
/kind cleanup
/kind design
/kind deprecation
/kind documentation
/kind feature
/kind fix
/kind flake
/kind install
```
-->

/kind cleanup

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
NONE
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
