### PR TITLE
logging: add a generic structured logger with dynamic levels

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -158,17 +158,23 @@ var (
 
 ## Logging
 
-Use Go's standard library structured logging:
+Use the `github.com/agentregistry-dev/agentregistry/pkg/logging` package for structured logging. Loggers should be package scoped in most cases, but the global logger can be directly used via the `slog` package if necessary. `logging.New` keeps track of `slog.LevelVar` to allow log levels to be changed at runtime via the `/logging` HTTP endpoint, so calling `logging.New*` within a re-entrant function will leak memory and should be avoided. If `logging.New*` is invoked within a re-entrant function, the tracked leveler should be explicitly deleted by a call to `logging.DeleteLeveler("component-name")` before the function returns.
 
 ```go
-import "log/slog"
+import (
+    "log/slog"
+    "github.com/agentregistry-dev/agentregistry/pkg/logging"
+)
 
-// Use structured logging with context
-slog.Info("agent created",
+var logger = logging.New("my-component")
+
+// package scoped logger
+logger.Info("agent created",
     "agent_id", agent.ID,
     "name", agent.Name,
 )
 
+// global logger
 slog.Error("failed to create agent",
     "error", err,
     "agent_name", name,

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -9,12 +9,6 @@ import (
 )
 
 func main() {
-	handler := slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
-		Level: slog.LevelInfo,
-	})
-	logger := slog.New(handler)
-	slog.SetDefault(logger)
-
 	ctx := context.Background()
 	if err := registry.App(ctx); err != nil {
 		slog.Error("failed to start registry", "error", err)

--- a/go.mod
+++ b/go.mod
@@ -39,6 +39,7 @@ require (
 	k8s.io/api v0.35.0
 	k8s.io/apimachinery v0.35.0
 	k8s.io/client-go v0.35.0
+	k8s.io/utils v0.0.0-20260108192941-914a6e750570
 	sigs.k8s.io/controller-runtime v0.23.0
 	trpc.group/trpc-go/trpc-a2a-go v0.2.5
 )
@@ -243,7 +244,6 @@ require (
 	gotest.tools/gotestsum v1.13.0 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20251125145642-4e65d59e963e // indirect
-	k8s.io/utils v0.0.0-20260108192941-914a6e750570 // indirect
 	mvdan.cc/sh/v3 v3.7.0 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/kind v0.31.0 // indirect

--- a/internal/registry/api/router/router.go
+++ b/internal/registry/api/router/router.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	apitypes "github.com/agentregistry-dev/agentregistry/internal/registry/api/apitypes"
+	"github.com/agentregistry-dev/agentregistry/pkg/logging"
 	"github.com/agentregistry-dev/agentregistry/pkg/registry/auth"
 	"github.com/danielgtaylor/huma/v2"
 	"github.com/danielgtaylor/huma/v2/adapters/humago"
@@ -191,7 +192,7 @@ func NewHumaAPI(cfg *config.Config, registry service.RegistryService, mux *http.
 
 	// Add metrics middleware with options
 	api.UseMiddleware(MetricTelemetryMiddleware(metrics,
-		WithSkipPaths("/health", "/metrics", "/ping", "/docs"),
+		WithSkipPaths("/health", "/metrics", "/ping", "/docs", "/logging"),
 	))
 
 	// Set the mux on routeOpts for SSE handlers that need direct mux access
@@ -204,6 +205,8 @@ func NewHumaAPI(cfg *config.Config, registry service.RegistryService, mux *http.
 
 	// Add /metrics for Prometheus metrics using promhttp
 	mux.Handle("/metrics", metrics.PrometheusHandler())
+	// Add /logging to control component loggers
+	mux.HandleFunc("/logging", logging.HTTPLevelHandler)
 
 	// Serve UI from root path or handle 404 for non-API routes
 	if uiHandler != nil {
@@ -215,6 +218,7 @@ func NewHumaAPI(cfg *config.Config, registry service.RegistryService, mux *http.
 				r.URL.Path == "/health" ||
 				r.URL.Path == "/ping" ||
 				r.URL.Path == "/metrics" ||
+				r.URL.Path == "/logging" ||
 				strings.HasPrefix(r.URL.Path, "/docs") {
 				handle404(w, r)
 				return

--- a/internal/registry/config/config.go
+++ b/internal/registry/config/config.go
@@ -25,6 +25,7 @@ type Config struct {
 	JWTPrivateKey            string `env:"JWT_PRIVATE_KEY" envDefault:""`
 	EnableAnonymousAuth      bool   `env:"ENABLE_ANONYMOUS_AUTH" envDefault:"false"`
 	EnableRegistryValidation bool   `env:"ENABLE_REGISTRY_VALIDATION" envDefault:"true"`
+	LogLevel                 string `env:"LOG_LEVEL" envDefault:"info"`
 
 	// OIDC Configuration
 	OIDCEnabled      bool   `env:"OIDC_ENABLED" envDefault:"false"`

--- a/internal/registry/registry_app.go
+++ b/internal/registry/registry_app.go
@@ -13,8 +13,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/agentregistry-dev/agentregistry/internal/registry/platforms/kubernetes"
-	"github.com/agentregistry-dev/agentregistry/internal/registry/platforms/local"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
 	mcpregistry "github.com/agentregistry-dev/agentregistry/internal/mcp/registryserver"
@@ -27,10 +25,13 @@ import (
 	"github.com/agentregistry-dev/agentregistry/internal/registry/embeddings"
 	"github.com/agentregistry-dev/agentregistry/internal/registry/importer"
 	"github.com/agentregistry-dev/agentregistry/internal/registry/jobs"
+	"github.com/agentregistry-dev/agentregistry/internal/registry/platforms/kubernetes"
+	"github.com/agentregistry-dev/agentregistry/internal/registry/platforms/local"
 	"github.com/agentregistry-dev/agentregistry/internal/registry/seed"
 	"github.com/agentregistry-dev/agentregistry/internal/registry/service"
 	"github.com/agentregistry-dev/agentregistry/internal/registry/telemetry"
 	"github.com/agentregistry-dev/agentregistry/internal/version"
+	"github.com/agentregistry-dev/agentregistry/pkg/logging"
 	"github.com/agentregistry-dev/agentregistry/pkg/registry/auth"
 	"github.com/agentregistry-dev/agentregistry/pkg/registry/database"
 
@@ -50,6 +51,8 @@ func App(_ context.Context, opts ...types.AppOptions) error {
 	// Create a context with timeout for PostgreSQL connection
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
+
+	setupLogging(cfg.LogLevel)
 
 	// Build auth providers from options (before database creation)
 	// Only create jwtManager if JWT is configured
@@ -308,4 +311,18 @@ func mcpAuthnMiddleware(authn auth.AuthnProvider) func(http.Handler) http.Handle
 			next.ServeHTTP(w, r)
 		})
 	}
+}
+
+// SetupLogging configures the global slog logger
+func setupLogging(levelStr string) {
+	if levelStr == "" {
+		levelStr = "info"
+	}
+	level, err := logging.ParseLevel(levelStr)
+	if err != nil {
+		slog.Error("failed to parse log level, defaulting to info", "error", err)
+		level = slog.LevelInfo
+	}
+	// set all loggers to the specified level
+	logging.Reset(level)
 }

--- a/pkg/logging/level.go
+++ b/pkg/logging/level.go
@@ -1,0 +1,232 @@
+/*
+Portions of this file are derived from the slog-leveler project
+(https://github.com/shashankram/slog-leveler)
+which is licensed under the MIT License.
+
+# MIT License
+
+# Copyright (c) 2025 Shashank Ram
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+package logging
+
+import (
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strings"
+)
+
+// Extra slog log levels
+const (
+	LevelTrace = slog.Level(-5) // 1 lower than slog.LevelDebug
+)
+
+const (
+	levelQuery = "level"
+)
+
+// Level strings
+const (
+	errorLevel = "error"
+	warnLevel  = "warn"
+	infoLevel  = "info"
+	debugLevel = "debug"
+	traceLevel = "trace"
+)
+
+var (
+	// GlobalLevel is the slog.LevelVar for the default logger
+	GlobalLevel = &slog.LevelVar{} // default is INFO
+
+	levelNames = map[slog.Leveler]string{
+		LevelTrace: traceLevel,
+	}
+)
+
+// GetLevel returns the current log level for the component
+func GetLevel(component string) (slog.Level, error) {
+	if component == "" {
+		component = DefaultComponent
+	}
+	lvl, ok := componentLeveler.Load(component)
+	if !ok {
+		return slog.Level(0), fmt.Errorf("logger not found for component: %s", component)
+	}
+	levelr := lvl.(*slog.LevelVar)
+	return levelr.Level(), nil
+}
+
+// MustGetLevel returns the current log level for the component or panics if the component is not found
+func MustGetLevel(component string) slog.Level {
+	level, err := GetLevel(component)
+	if err != nil {
+		panic(err)
+	}
+	return level
+}
+
+// SetLevel sets the log level for the component
+func SetLevel(component string, level slog.Level) error {
+	if component == "" {
+		component = DefaultComponent
+	}
+	lvl, ok := componentLeveler.Load(component)
+	if !ok {
+		return fmt.Errorf("logger not found for component: %s", component)
+	}
+	levelr := lvl.(*slog.LevelVar)
+	levelr.Set(level)
+	return nil
+}
+
+// MustSetLevel sets the log level for the component or panics if the component is not found
+func MustSetLevel(component string, level slog.Level) {
+	if err := SetLevel(component, level); err != nil {
+		panic(err)
+	}
+}
+
+// Reset resets the log level for all components to the given level
+func Reset(level slog.Level) {
+	componentLeveler.Range(func(key any, value any) bool {
+		MustSetLevel(key.(string), level)
+		return true
+	})
+}
+
+// HTTPLevelHandler handles HTTP requests to the log level of the default or
+// component specific loggers
+// It accepts POST and PUT requests with the following query parameters:
+// - level=<level>: updates log level across all component loggers
+// - <component>=<level>&<component=<level2>...: updates log level for specific components
+//
+// If no query parameters are provided, it returns the current log levels of all components
+func HTTPLevelHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost && r.Method != http.MethodPut {
+		http.Error(w, "method must be one of POST|PUT", http.StatusMethodNotAllowed)
+		return
+	}
+
+	componentValues := r.URL.Query()
+	if lvl := componentValues.Get(levelQuery); lvl != "" {
+		level, err := ParseLevel(lvl)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		Reset(level)
+		w.Write(fmt.Appendf(nil, "all logger levels updated to level: %s\n", lvl)) //nolint: errcheck
+		return
+	}
+
+	levels := make(map[string]slog.Level)
+	// Parse ?level= or ?c1=level1&c2=level2,...
+	for component := range componentValues {
+		l := componentValues.Get(component)
+		if l == "" {
+			http.Error(w, fmt.Sprintf("component %s: empty value", component), http.StatusBadRequest)
+			return
+		}
+
+		level, err := ParseLevel(l)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("component %s: %v", component, err), http.StatusBadRequest)
+			return
+		}
+		levels[component] = level
+	}
+
+	// Update component specific log levels
+	for component, level := range levels {
+		err := SetLevel(component, level)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		w.Write(fmt.Appendf(nil, "component %s log level set to: %s\n", component, strings.ToLower(levelName(level)))) //nolint: errcheck
+	}
+
+	// If no levels were set, write the current log levels
+	if len(levels) == 0 {
+		// Print current component log levels
+		w.Write([]byte("current log levels:\n---\n")) //nolint: errcheck
+		componentLeveler.Range(func(key any, value any) bool {
+			w.Write(fmt.Appendf(nil, "%s: %s\n", key, LevelToString(value.(*slog.LevelVar).Level()))) //nolint: errcheck
+			return true
+		})
+	}
+}
+
+// slogLevelReplacer replaces the slog.Level with a string representation
+func slogLevelReplacer(groups []string, attr slog.Attr) slog.Attr {
+	if attr.Key == slog.LevelKey {
+		level := attr.Value.Any().(slog.Level)
+		levelname := levelName(level)
+		attr.Value = slog.StringValue(levelname)
+	}
+	return attr
+}
+
+// levelName returns the string representation of slog.Level
+func levelName(level slog.Level) string {
+	levelname, ok := levelNames[level]
+	if !ok {
+		levelname = strings.ToLower(level.String())
+	}
+	return levelname
+}
+
+// ParseLevel parses the given level string to slog.Level,
+// and returns an error if the level is unknown
+func ParseLevel(level string) (slog.Level, error) {
+	switch strings.ToLower(level) {
+	case traceLevel:
+		return LevelTrace, nil
+	case debugLevel:
+		return slog.LevelDebug, nil
+	case infoLevel:
+		return slog.LevelInfo, nil
+	case warnLevel:
+		return slog.LevelWarn, nil
+	case errorLevel:
+		return slog.LevelError, nil
+	default:
+		return slog.LevelInfo, fmt.Errorf("unknown log level %s; should be one of error|warn|info|debug|trace", level)
+	}
+}
+
+// LevelToString returns the string representation of slog.Level
+func LevelToString(level slog.Level) string {
+	switch level {
+	case LevelTrace:
+		return traceLevel
+	case slog.LevelDebug:
+		return debugLevel
+	case slog.LevelInfo:
+		return infoLevel
+	case slog.LevelWarn:
+		return warnLevel
+	case slog.LevelError:
+		return errorLevel
+	default:
+		return level.String()
+	}
+}

--- a/pkg/logging/level_test.go
+++ b/pkg/logging/level_test.go
@@ -1,0 +1,189 @@
+/*
+Portions of this file are derived from the slog-leveler project
+(https://github.com/shashankram/slog-leveler)
+which is licensed under the MIT License.
+
+# MIT License
+
+# Copyright (c) 2025 Shashank Ram
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+package logging
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/utils/ptr"
+)
+
+func TestLogging(t *testing.T) {
+	tests := []struct {
+		name           string
+		components     []string
+		query          string
+		setLevel       map[string]slog.Level
+		wantStatusCode int
+		wantBody       string
+		wantLevels     map[string]slog.Level
+	}{
+		{
+			name:           "only default logger",
+			wantStatusCode: http.StatusOK,
+			wantLevels: map[string]slog.Level{
+				DefaultComponent: GlobalLevel.Level(),
+			},
+		},
+		{
+			name:           "update default level to debug",
+			query:          "level=debug",
+			wantStatusCode: http.StatusOK,
+			wantLevels: map[string]slog.Level{
+				DefaultComponent: slog.LevelDebug,
+			},
+		},
+		{
+			name:           "update all loggers to debug level",
+			components:     []string{"c1", "c2", "c3"},
+			query:          "level=debug",
+			wantStatusCode: http.StatusOK,
+			wantLevels: map[string]slog.Level{
+				DefaultComponent: slog.LevelDebug,
+				"c1":             slog.LevelDebug,
+				"c2":             slog.LevelDebug,
+				"c3":             slog.LevelDebug,
+			},
+		},
+		{
+			name:           "ignore component levels when updating specific logger levels",
+			components:     []string{"c1", "c2", "c3"},
+			query:          "level=debug&c1=error&c2=warn&c3=trace",
+			wantStatusCode: http.StatusOK,
+			wantLevels: map[string]slog.Level{
+				DefaultComponent: slog.LevelDebug,
+				"c1":             slog.LevelDebug,
+				"c2":             slog.LevelDebug,
+				"c3":             slog.LevelDebug,
+			},
+		},
+		{
+			name:           "update default and component levels",
+			components:     []string{"c1", "c2", "c3"},
+			query:          "default=debug&c1=error&c2=warn&c3=trace",
+			wantStatusCode: http.StatusOK,
+			wantLevels: map[string]slog.Level{
+				DefaultComponent: slog.LevelDebug,
+				"c1":             slog.LevelError,
+				"c2":             slog.LevelWarn,
+				"c3":             LevelTrace,
+			},
+		},
+		{
+			name:           "incorrect global log level should error and preserve current level",
+			query:          "level=foo",
+			wantStatusCode: http.StatusBadRequest,
+			wantBody:       "unknown log level foo",
+			wantLevels: map[string]slog.Level{
+				DefaultComponent: slog.LevelInfo,
+			},
+		},
+		{
+			name:           "incorrect component log level should error and preserve current level",
+			components:     []string{"c1"},
+			query:          "c1=foo",
+			wantStatusCode: http.StatusBadRequest,
+			wantBody:       "component c1: unknown log level foo",
+			wantLevels: map[string]slog.Level{
+				"c1": slog.LevelInfo,
+			},
+		},
+		{
+			name:           "update default and component levels using SetLevel",
+			components:     []string{"c1", "c2", "c3"},
+			setLevel:       map[string]slog.Level{"default": slog.LevelDebug, "c1": slog.LevelError, "c2": slog.LevelWarn, "c3": LevelTrace},
+			wantStatusCode: http.StatusOK,
+			wantLevels: map[string]slog.Level{
+				DefaultComponent: slog.LevelDebug,
+				"c1":             slog.LevelError,
+				"c2":             slog.LevelWarn,
+				"c3":             LevelTrace,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			a := require.New(t)
+
+			// Reset component levels to default level
+			Reset(slog.LevelInfo)
+
+			loggers := map[string]*slog.Logger{DefaultComponent: slog.Default()}
+			for _, component := range tc.components {
+				logger := New(component)
+				a.NotNil(logger)
+				loggers[component] = logger
+			}
+
+			// Test HTTP handler
+			path := "/logging"
+			if tc.query != "" {
+				path += "?" + tc.query
+			}
+			req := httptest.NewRequest(http.MethodPost, path, nil)
+			w := httptest.NewRecorder()
+			HTTPLevelHandler(w, req)
+			resp := w.Result()
+			a.Equal(tc.wantStatusCode, resp.StatusCode)
+			data, err := io.ReadAll(resp.Body)
+			a.NoError(err)
+			a.NotEmpty(data)
+			a.Contains(string(data), tc.wantBody)
+
+			// Test SetLevel
+			for component, level := range tc.setLevel {
+				err := SetLevel(component, level)
+				a.NoError(err)
+			}
+
+			for component, level := range tc.wantLevels {
+				a.Equal(level, MustGetLevel(component), component)
+				a.True(loggers[component].Enabled(context.TODO(), level), component)
+			}
+		})
+	}
+}
+
+func TestGetComponentLevels(t *testing.T) {
+	a := assert.New(t)
+
+	_ = NewWithOptions("TestGetComponentLevels1", Options{Level: ptr.To(slog.LevelDebug)})
+	_ = NewWithOptions("TestGetComponentLevels2", Options{Level: ptr.To(slog.LevelError)})
+
+	got := GetComponentLevels()
+	a.Equal(slog.LevelDebug, got["TestGetComponentLevels1"], "TestGetComponentLevels1")
+	a.Equal(slog.LevelError, got["TestGetComponentLevels2"], "TestGetComponentLevels2")
+}

--- a/pkg/logging/logger.go
+++ b/pkg/logging/logger.go
@@ -1,0 +1,119 @@
+/*
+Portions of this file are derived from the slog-leveler project
+(https://github.com/shashankram/slog-leveler)
+which is licensed under the MIT License.
+
+# MIT License
+
+# Copyright (c) 2025 Shashank Ram
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+package logging
+
+import (
+	"fmt"
+	"log/slog"
+	"sync"
+)
+
+const (
+	DefaultComponent = "default"
+)
+
+// componentLeveler maps component names to their respective slog.LevelVar instance
+var componentLeveler sync.Map
+
+func init() {
+	defaultLogger := New(DefaultComponent)
+	slog.SetDefault(defaultLogger)
+}
+
+// New returns a new slog.Logger instance for the given component with default Options.
+// If the component is empty, it returns the default logger.
+// NOTE: the logger's leveler is tracked in memory, so this should be used to create long lived loggers
+// whose log levels are required to be configurable at runtime.
+// Short lived loggers should be instantiated using logger.With() or call DeleteLeveler if instantiated
+// with New, to avoid leaking memory.
+func New(component string) *slog.Logger {
+	return NewWithOptions(component, Options{})
+}
+
+// NewWithOptions returns a new slog.Logger instance for the given component with the provided Options
+// If the component is empty, it returns the default logger.
+// NOTE: the logger's leveler is tracked in memory, so this should be used to create long lived loggers
+// whose log levels are required to be configurable at runtime.
+// Short lived loggers should be instantiated using logger.With() or call DeleteLeveler if instantiated
+// with NewWithOptions, to avoid leaking memory.
+func NewWithOptions(component string, opts Options) *slog.Logger {
+	if component == "" {
+		return slog.Default()
+	}
+
+	opts.Default()
+
+	level := &slog.LevelVar{}
+	if opts.Level != nil {
+		level.Set(*opts.Level)
+	} else {
+		defaultLvl, ok := componentLeveler.Load(DefaultComponent)
+		if ok {
+			level.Set(defaultLvl.(*slog.LevelVar).Level())
+		}
+	}
+	handlerOpts := &slog.HandlerOptions{
+		AddSource:   opts.AddSource || level.Level() <= slog.LevelDebug,
+		Level:       level,
+		ReplaceAttr: slogLevelReplacer,
+	}
+
+	attrs := []slog.Attr{{Key: "component", Value: slog.StringValue(component)}}
+
+	componentLeveler.Store(component, level)
+	var slogHandler slog.Handler
+	switch opts.Format {
+	case TextFormat:
+		slogHandler = slog.NewTextHandler(opts.Writer, handlerOpts).WithAttrs(attrs)
+	case JSONFormat:
+		slogHandler = slog.NewJSONHandler(opts.Writer, handlerOpts).WithAttrs(attrs)
+	default:
+		slogHandler = slog.NewTextHandler(opts.Writer, handlerOpts).WithAttrs(attrs)
+	}
+
+	return slog.New(slogHandler)
+}
+
+// DeleteLeveler deletes the leveler instance for the given component
+func DeleteLeveler(component string) error {
+	if component == "" {
+		return fmt.Errorf("component unspecified")
+	}
+	componentLeveler.Delete(component)
+	return nil
+}
+
+// GetComponentLevels returns a map of component names to their respective slog.Level
+func GetComponentLevels() map[string]slog.Level {
+	levels := make(map[string]slog.Level)
+	componentLeveler.Range(func(key any, value any) bool {
+		levels[key.(string)] = value.(*slog.LevelVar).Level()
+		return true
+	})
+	return levels
+}

--- a/pkg/logging/logger_test.go
+++ b/pkg/logging/logger_test.go
@@ -1,0 +1,75 @@
+/*
+Portions of this file are derived from the slog-leveler project
+(https://github.com/shashankram/slog-leveler)
+which is licensed under the MIT License.
+
+# MIT License
+
+# Copyright (c) 2025 Shashank Ram
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+package logging
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/utils/ptr"
+)
+
+func TestDeleteLeveler(t *testing.T) {
+	r := require.New(t)
+	l := New("delete")
+	err := SetLevel("delete", slog.LevelInfo)
+	r.NoError(err)
+	r.True(l.Enabled(context.TODO(), slog.LevelInfo))
+	r.False(l.Enabled(context.TODO(), slog.LevelDebug))
+	err = SetLevel("delete", slog.LevelDebug)
+	r.NoError(err)
+	r.True(l.Enabled(context.TODO(), slog.LevelDebug))
+	err = DeleteLeveler("delete")
+	r.NoError(err)
+	r.True(l.Enabled(context.TODO(), slog.LevelDebug))
+	err = SetLevel("delete", slog.LevelDebug)
+	r.ErrorContains(err, "logger not found")
+}
+
+func TestDefaultLevelInheritance(t *testing.T) {
+	r := require.New(t)
+
+	l1 := New("l1")
+	l2 := NewWithOptions("l2", Options{Level: ptr.To(slog.LevelDebug)})
+
+	r.True(slog.Default().Enabled(context.TODO(), slog.LevelInfo))
+	r.True(l1.Enabled(context.TODO(), slog.LevelInfo))
+	r.True(l2.Enabled(context.TODO(), slog.LevelDebug))
+
+	Reset(slog.LevelError)
+	r.True(slog.Default().Enabled(context.TODO(), slog.LevelError))
+	r.True(l1.Enabled(context.TODO(), slog.LevelError))
+	r.True(l2.Enabled(context.TODO(), slog.LevelError))
+
+	l3 := NewWithOptions("l3", Options{Level: ptr.To(slog.LevelDebug)})
+	r.True(l3.Enabled(context.TODO(), slog.LevelDebug))
+	l4 := New("l4")
+	r.True(l4.Enabled(context.TODO(), slog.LevelError))
+}

--- a/pkg/logging/options.go
+++ b/pkg/logging/options.go
@@ -1,0 +1,71 @@
+/*
+Portions of this file are derived from the slog-leveler project
+(https://github.com/shashankram/slog-leveler)
+which is licensed under the MIT License.
+
+# MIT License
+
+# Copyright (c) 2025 Shashank Ram
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+package logging
+
+import (
+	"io"
+	"log/slog"
+	"os"
+)
+
+// Options to configure the logger
+type Options struct {
+	// Logger level
+	Level *slog.Level
+
+	// Log format: text or json
+	Format LogFormat
+
+	// Writer to write logs to
+	Writer io.Writer
+
+	// AddSource adds the source code position of the log statement to the output
+	AddSource bool
+}
+
+// LogFormat represents the format of the log output
+type LogFormat string
+
+const (
+	// TextFormat represents plain text format
+	TextFormat LogFormat = "text"
+
+	// JSONFormat represents JSON format
+	JSONFormat LogFormat = "json"
+)
+
+// Default sets default values on Options
+func (o *Options) Default() {
+	// Level implicitly defaults to INFO
+	if o.Format == "" {
+		o.Format = JSONFormat
+	}
+	if o.Writer == nil {
+		o.Writer = os.Stderr
+	}
+}

--- a/pkg/logging/options_test.go
+++ b/pkg/logging/options_test.go
@@ -1,0 +1,77 @@
+/*
+Portions of this file are derived from the slog-leveler project
+(https://github.com/shashankram/slog-leveler)
+which is licensed under the MIT License.
+
+# MIT License
+
+# Copyright (c) 2025 Shashank Ram
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+package logging
+
+import (
+	"log/slog"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/utils/ptr"
+)
+
+func TestOptions(t *testing.T) {
+	tests := []struct {
+		name string
+		opts Options
+		want Options
+	}{
+		{
+			name: "default options",
+			opts: Options{},
+			want: Options{
+				Format: JSONFormat,
+				Writer: os.Stderr,
+			},
+		},
+		{
+			name: "custom options",
+			opts: Options{
+				Level:     ptr.To(slog.LevelDebug),
+				Format:    TextFormat,
+				Writer:    nil,
+				AddSource: true,
+			},
+			want: Options{
+				Level:     ptr.To(slog.LevelDebug),
+				Format:    TextFormat,
+				Writer:    os.Stderr,
+				AddSource: true,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := assert.New(t)
+			tt.opts.Default()
+			a.Equal(tt.want, tt.opts)
+		})
+	}
+}


### PR DESCRIPTION
# Description

Adds `logging` pkg that implements an slog based logger with dynamic level control via the `/logging` HTTP endpoint.

Update the log level of all loggers:
```
curl -X POST 'localhost:12121/logging?level=<level>'
```

Update the log level of a single component logger:
```
curl -X POST 'localhost:12121/logging?foo=debug'
```

Update the log level of a multiple component loggers:
```
curl -X POST 'localhost:12121/logging?foo=debug&bar=trace'
```

Display the current log level of all loggers:
```console
$ curl -X POST 'localhost:15000/logging'
current log levels:
---
bar: trace
default: info
foo: info
```

# Change Type

```
/kind new_feature
```

# Changelog

```release-note
Logging: add structured logging utility.
```
