### PR TITLE
logger: add enhancements and correctness fixes

### DIFF
--- a/internal/registry/api/router/router.go
+++ b/internal/registry/api/router/router.go
@@ -205,8 +205,8 @@ func NewHumaAPI(cfg *config.Config, registry service.RegistryService, mux *http.
 
 	// Add /metrics for Prometheus metrics using promhttp
 	mux.Handle("/metrics", metrics.PrometheusHandler())
-	// Add /logging to control component loggers
-	mux.HandleFunc("/logging", logging.HTTPLevelHandler)
+	// Add /logging to control component loggers (localhost only)
+	mux.HandleFunc("/logging", logging.LocalhostOnly(logging.HTTPLevelHandler))
 
 	// Serve UI from root path or handle 404 for non-API routes
 	if uiHandler != nil {

--- a/internal/registry/registry_app.go
+++ b/internal/registry/registry_app.go
@@ -313,8 +313,10 @@ func mcpAuthnMiddleware(authn auth.AuthnProvider) func(http.Handler) http.Handle
 	}
 }
 
-// SetupLogging configures the global slog logger
+// setupLogging configures the global slog logger
 func setupLogging(levelStr string) {
+	logging.SetupDefault()
+
 	if levelStr == "" {
 		levelStr = "info"
 	}

--- a/pkg/logging/level.go
+++ b/pkg/logging/level.go
@@ -30,6 +30,7 @@ package logging
 import (
 	"fmt"
 	"log/slog"
+	"net"
 	"net/http"
 	"strings"
 )
@@ -53,12 +54,8 @@ const (
 )
 
 var (
-	// GlobalLevel is the slog.LevelVar for the default logger
-	GlobalLevel = &slog.LevelVar{} // default is INFO
-
-	levelNames = map[slog.Leveler]string{
-		LevelTrace: traceLevel,
-	}
+	// globalLevel is the slog.LevelVar for the default logger
+	globalLevel = &slog.LevelVar{} // default is INFO
 )
 
 // GetLevel returns the current log level for the component
@@ -113,19 +110,33 @@ func Reset(level slog.Level) {
 }
 
 // HTTPLevelHandler handles HTTP requests to the log level of the default or
-// component specific loggers
-// It accepts POST and PUT requests with the following query parameters:
-// - level=<level>: updates log level across all component loggers
-// - <component>=<level>&<component=<level2>...: updates log level for specific components
+// component specific loggers.
 //
-// If no query parameters are provided, it returns the current log levels of all components
+// GET returns the current log levels of all components.
+//
+// POST/PUT with query parameters updates log levels:
+//   - level=<level>: updates log level across all component loggers
+//   - <component>=<level>&<component>=<level2>...: updates log level for specific components
+//
+// POST/PUT without query parameters returns 400.
 func HTTPLevelHandler(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodPost && r.Method != http.MethodPut {
-		http.Error(w, "method must be one of POST|PUT", http.StatusMethodNotAllowed)
+	switch r.Method {
+	case http.MethodGet:
+		writeCurrentLevels(w)
+		return
+	case http.MethodPost, http.MethodPut:
+		// handled below
+	default:
+		http.Error(w, "method must be one of GET|POST|PUT", http.StatusMethodNotAllowed)
 		return
 	}
 
 	componentValues := r.URL.Query()
+	if len(componentValues) == 0 {
+		http.Error(w, "query parameters required", http.StatusBadRequest)
+		return
+	}
+
 	if lvl := componentValues.Get(levelQuery); lvl != "" {
 		level, err := ParseLevel(lvl)
 		if err != nil {
@@ -138,7 +149,7 @@ func HTTPLevelHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	levels := make(map[string]slog.Level)
-	// Parse ?level= or ?c1=level1&c2=level2,...
+	// Parse ?c1=level1&c2=level2,...
 	for component := range componentValues {
 		l := componentValues.Get(component)
 		if l == "" {
@@ -154,24 +165,43 @@ func HTTPLevelHandler(w http.ResponseWriter, r *http.Request) {
 		levels[component] = level
 	}
 
-	// Update component specific log levels
-	for component, level := range levels {
-		err := SetLevel(component, level)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
+	// Validate all components exist before applying any changes
+	for component := range levels {
+		if _, ok := componentLeveler.Load(component); !ok {
+			http.Error(w, fmt.Sprintf("unknown component: %s", component), http.StatusBadRequest)
 			return
 		}
-		w.Write(fmt.Appendf(nil, "component %s log level set to: %s\n", component, strings.ToLower(levelName(level)))) //nolint: errcheck
 	}
 
-	// If no levels were set, write the current log levels
-	if len(levels) == 0 {
-		// Print current component log levels
-		w.Write([]byte("current log levels:\n---\n")) //nolint: errcheck
-		componentLeveler.Range(func(key any, value any) bool {
-			w.Write(fmt.Appendf(nil, "%s: %s\n", key, LevelToString(value.(*slog.LevelVar).Level()))) //nolint: errcheck
-			return true
-		})
+	// Apply all changes (guaranteed to succeed)
+	for component, level := range levels {
+		MustSetLevel(component, level)
+		w.Write(fmt.Appendf(nil, "component %s log level set to: %s\n", component, LevelToString(level))) //nolint: errcheck
+	}
+}
+
+// writeCurrentLevels writes the current log levels of all components to the response
+func writeCurrentLevels(w http.ResponseWriter) {
+	w.Write([]byte("current log levels:\n---\n")) //nolint: errcheck
+	componentLeveler.Range(func(key any, value any) bool {
+		w.Write(fmt.Appendf(nil, "%s: %s\n", key, LevelToString(value.(*slog.LevelVar).Level()))) //nolint: errcheck
+		return true
+	})
+}
+
+// LocalhostOnly wraps an http.HandlerFunc to only allow requests from localhost
+func LocalhostOnly(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		host, _, err := net.SplitHostPort(r.RemoteAddr)
+		if err != nil {
+			http.Error(w, "forbidden: localhost access only", http.StatusForbidden)
+			return
+		}
+		if host != "127.0.0.1" && host != "::1" {
+			http.Error(w, "forbidden: localhost access only", http.StatusForbidden)
+			return
+		}
+		next(w, r)
 	}
 }
 
@@ -179,19 +209,9 @@ func HTTPLevelHandler(w http.ResponseWriter, r *http.Request) {
 func slogLevelReplacer(groups []string, attr slog.Attr) slog.Attr {
 	if attr.Key == slog.LevelKey {
 		level := attr.Value.Any().(slog.Level)
-		levelname := levelName(level)
-		attr.Value = slog.StringValue(levelname)
+		attr.Value = slog.StringValue(LevelToString(level))
 	}
 	return attr
-}
-
-// levelName returns the string representation of slog.Level
-func levelName(level slog.Level) string {
-	levelname, ok := levelNames[level]
-	if !ok {
-		levelname = strings.ToLower(level.String())
-	}
-	return levelname
 }
 
 // ParseLevel parses the given level string to slog.Level,

--- a/pkg/logging/level_test.go
+++ b/pkg/logging/level_test.go
@@ -43,6 +43,7 @@ import (
 func TestLogging(t *testing.T) {
 	tests := []struct {
 		name           string
+		method         string
 		components     []string
 		query          string
 		setLevel       map[string]slog.Level
@@ -51,10 +52,21 @@ func TestLogging(t *testing.T) {
 		wantLevels     map[string]slog.Level
 	}{
 		{
-			name:           "only default logger",
+			name:           "GET returns current levels",
+			method:         http.MethodGet,
 			wantStatusCode: http.StatusOK,
+			wantBody:       "current log levels:",
 			wantLevels: map[string]slog.Level{
-				DefaultComponent: GlobalLevel.Level(),
+				DefaultComponent: globalLevel.Level(),
+			},
+		},
+		{
+			name:           "POST with no params returns 400",
+			method:         http.MethodPost,
+			wantStatusCode: http.StatusBadRequest,
+			wantBody:       "query parameters required",
+			wantLevels: map[string]slog.Level{
+				DefaultComponent: slog.LevelInfo,
 			},
 		},
 		{
@@ -121,7 +133,18 @@ func TestLogging(t *testing.T) {
 			},
 		},
 		{
+			name:           "unknown component returns 400 without partial update",
+			components:     []string{"c1"},
+			query:          "c1=debug&unknown=error",
+			wantStatusCode: http.StatusBadRequest,
+			wantBody:       "unknown component: unknown",
+			wantLevels: map[string]slog.Level{
+				"c1": slog.LevelInfo, // must not have been updated
+			},
+		},
+		{
 			name:           "update default and component levels using SetLevel",
+			method:         http.MethodGet,
 			components:     []string{"c1", "c2", "c3"},
 			setLevel:       map[string]slog.Level{"default": slog.LevelDebug, "c1": slog.LevelError, "c2": slog.LevelWarn, "c3": LevelTrace},
 			wantStatusCode: http.StatusOK,
@@ -144,16 +167,21 @@ func TestLogging(t *testing.T) {
 			loggers := map[string]*slog.Logger{DefaultComponent: slog.Default()}
 			for _, component := range tc.components {
 				logger := New(component)
+				t.Cleanup(func() { DeleteLeveler(component) }) //nolint: errcheck
 				a.NotNil(logger)
 				loggers[component] = logger
 			}
 
 			// Test HTTP handler
+			method := tc.method
+			if method == "" {
+				method = http.MethodPost
+			}
 			path := "/logging"
 			if tc.query != "" {
 				path += "?" + tc.query
 			}
-			req := httptest.NewRequest(http.MethodPost, path, nil)
+			req := httptest.NewRequest(method, path, nil)
 			w := httptest.NewRecorder()
 			HTTPLevelHandler(w, req)
 			resp := w.Result()
@@ -181,9 +209,55 @@ func TestGetComponentLevels(t *testing.T) {
 	a := assert.New(t)
 
 	_ = NewWithOptions("TestGetComponentLevels1", Options{Level: ptr.To(slog.LevelDebug)})
+	t.Cleanup(func() { DeleteLeveler("TestGetComponentLevels1") }) //nolint: errcheck
 	_ = NewWithOptions("TestGetComponentLevels2", Options{Level: ptr.To(slog.LevelError)})
+	t.Cleanup(func() { DeleteLeveler("TestGetComponentLevels2") }) //nolint: errcheck
 
 	got := GetComponentLevels()
 	a.Equal(slog.LevelDebug, got["TestGetComponentLevels1"], "TestGetComponentLevels1")
 	a.Equal(slog.LevelError, got["TestGetComponentLevels2"], "TestGetComponentLevels2")
+}
+
+func TestLocalhostOnly(t *testing.T) {
+	handler := LocalhostOnly(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("ok")) //nolint: errcheck
+	})
+
+	tests := []struct {
+		name       string
+		remoteAddr string
+		wantStatus int
+	}{
+		{
+			name:       "IPv4 localhost allowed",
+			remoteAddr: "127.0.0.1:12345",
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "IPv6 localhost allowed",
+			remoteAddr: "[::1]:12345",
+			wantStatus: http.StatusOK,
+		},
+		{
+			name:       "remote address rejected",
+			remoteAddr: "192.168.1.100:12345",
+			wantStatus: http.StatusForbidden,
+		},
+		{
+			name:       "public IP rejected",
+			remoteAddr: "8.8.8.8:443",
+			wantStatus: http.StatusForbidden,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/logging", nil)
+			req.RemoteAddr = tc.remoteAddr
+			w := httptest.NewRecorder()
+			handler(w, req)
+			assert.Equal(t, tc.wantStatus, w.Result().StatusCode)
+		})
+	}
 }

--- a/pkg/logging/logger.go
+++ b/pkg/logging/logger.go
@@ -40,7 +40,9 @@ const (
 // componentLeveler maps component names to their respective slog.LevelVar instance
 var componentLeveler sync.Map
 
-func init() {
+// SetupDefault creates and sets the default slog logger for the DefaultComponent.
+// This must be called early in application startup (e.g. in main or server init).
+func SetupDefault() {
 	defaultLogger := New(DefaultComponent)
 	slog.SetDefault(defaultLogger)
 }

--- a/pkg/logging/logger_test.go
+++ b/pkg/logging/logger_test.go
@@ -30,15 +30,22 @@ package logging
 import (
 	"context"
 	"log/slog"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"k8s.io/utils/ptr"
 )
 
+func TestMain(m *testing.M) {
+	SetupDefault()
+	os.Exit(m.Run())
+}
+
 func TestDeleteLeveler(t *testing.T) {
 	r := require.New(t)
 	l := New("delete")
+	t.Cleanup(func() { DeleteLeveler("delete") }) //nolint: errcheck
 	err := SetLevel("delete", slog.LevelInfo)
 	r.NoError(err)
 	r.True(l.Enabled(context.TODO(), slog.LevelInfo))
@@ -57,7 +64,9 @@ func TestDefaultLevelInheritance(t *testing.T) {
 	r := require.New(t)
 
 	l1 := New("l1")
+	t.Cleanup(func() { DeleteLeveler("l1") }) //nolint: errcheck
 	l2 := NewWithOptions("l2", Options{Level: ptr.To(slog.LevelDebug)})
+	t.Cleanup(func() { DeleteLeveler("l2") }) //nolint: errcheck
 
 	r.True(slog.Default().Enabled(context.TODO(), slog.LevelInfo))
 	r.True(l1.Enabled(context.TODO(), slog.LevelInfo))
@@ -69,7 +78,9 @@ func TestDefaultLevelInheritance(t *testing.T) {
 	r.True(l2.Enabled(context.TODO(), slog.LevelError))
 
 	l3 := NewWithOptions("l3", Options{Level: ptr.To(slog.LevelDebug)})
+	t.Cleanup(func() { DeleteLeveler("l3") }) //nolint: errcheck
 	r.True(l3.Enabled(context.TODO(), slog.LevelDebug))
 	l4 := New("l4")
+	t.Cleanup(func() { DeleteLeveler("l4") }) //nolint: errcheck
 	r.True(l4.Enabled(context.TODO(), slog.LevelError))
 }


### PR DESCRIPTION
# Description

- Conslidates level parsing via LevelToString.
- Un-exports GlobalLevel.
- Explict SetupDefault function to update the default slog logger.
- Use GET to read the log levels
- Validate components in level handler.
- Restrict /logging to localhost for security reasons.
- Adds t.Cleanup to test to prevent test pollution.
- `make lint` fixes to formatting

# Change Type

```
/kind cleanup
```

# Changelog

```release-note
NONE
```