### PR TITLE
fix: validate --page-size to prevent panic on negative values

### DIFF
--- a/internal/cli/skill/list.go
+++ b/internal/cli/skill/list.go
@@ -31,6 +31,10 @@ func init() {
 }
 
 func runList(cmd *cobra.Command, args []string) error {
+	if listPageSize <= 0 {
+		return fmt.Errorf("--page-size must be a positive integer, got %d", listPageSize)
+	}
+
 	if apiClient == nil {
 		return fmt.Errorf("API client not initialized")
 	}


### PR DESCRIPTION
Fixes #368

# Description

`arctl skill list --page-size -1` panics because the negative page size produces a negative end index in `displayPaginatedSkills`.

This change rejects non-positive `--page-size` values at the start of `runList` and returns a clear error instead of panicking.

# Testing

- `arctl skill list --page-size -1` now returns an error instead of panicking
- `arctl skill list --page-size 0` now returns an error
- `arctl skill list --page-size 5` still works normally
- `arctl skill list` with the default page size still works normally

```release-note
NONE
```
