### PR TITLE
fix: update lint Makefile target to use system golangci-lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -474,11 +474,12 @@ release-cli: bin/arctl-darwin-amd64.sha256
 release-cli: bin/arctl-darwin-arm64.sha256
 release-cli: bin/arctl-windows-amd64.exe.sha256
 
-GOLANGCI_LINT ?= go tool golangci-lint
+GOLANGCI_LINT ?= $(shell which golangci-lint 2>/dev/null || echo "golangci-lint")
 GOLANGCI_LINT_ARGS ?= --fix
 
 .PHONY: lint
 lint: ## Run golangci-lint linter
+	@command -v $(GOLANGCI_LINT) >/dev/null 2>&1 || { echo "Error: golangci-lint not found. Install: https://golangci-lint.run/welcome/install/"; exit 1; }
 	$(GOLANGCI_LINT) run $(GOLANGCI_LINT_ARGS)
 
 .PHONY: lint-ui


### PR DESCRIPTION
Fixes #377

# Description

After PR #253 removed `golangci-lint` from Go tools, `make lint` fails with `go: no such tool "golangci-lint"`.

This change updates `GOLANGCI_LINT` to use the system-installed `golangci-lint` binary instead of `go tool golangci-lint`, and adds a pre-flight check that prints an install link when the binary is missing.

# Testing

- `make lint` works when `golangci-lint` is installed on the system
- `make lint` prints a helpful install message when `golangci-lint` is not installed

```release-note
NONE
```
