### PR TITLE
[Proposal] Use annotation-based daemon skip for cobra commands

### DIFF
--- a/internal/cli/agent/build.go
+++ b/internal/cli/agent/build.go
@@ -6,9 +6,9 @@ import (
 	"path/filepath"
 
 	"github.com/agentregistry-dev/agentregistry/internal/cli/agent/project"
-	"github.com/agentregistry-dev/agentregistry/pkg/cli/annotations"
 	"github.com/agentregistry-dev/agentregistry/internal/cli/common"
 	"github.com/agentregistry-dev/agentregistry/internal/cli/common/docker"
+	"github.com/agentregistry-dev/agentregistry/pkg/cli/annotations"
 	"github.com/agentregistry-dev/agentregistry/pkg/models"
 	"github.com/spf13/cobra"
 )

--- a/internal/cli/agent/build.go
+++ b/internal/cli/agent/build.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 
 	"github.com/agentregistry-dev/agentregistry/internal/cli/agent/project"
+	"github.com/agentregistry-dev/agentregistry/pkg/cli/annotations"
 	"github.com/agentregistry-dev/agentregistry/internal/cli/common"
 	"github.com/agentregistry-dev/agentregistry/internal/cli/common/docker"
 	"github.com/agentregistry-dev/agentregistry/pkg/models"
@@ -13,8 +14,9 @@ import (
 )
 
 var BuildCmd = &cobra.Command{
-	Use:   "build [project-directory]",
-	Short: "Build Docker images for an agent project",
+	Use:         "build [project-directory]",
+	Annotations: map[string]string{annotations.SkipDaemonAnnotation: "true"},
+	Short:       "Build Docker images for an agent project",
 	Long: `Build Docker images for an agent project created with the init command.
 
 This command looks for agent.yaml in the specified directory, regenerates template artifacts,

--- a/internal/cli/agent/init.go
+++ b/internal/cli/agent/init.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/agentregistry-dev/agentregistry/internal/cli/agent/frameworks"
 	"github.com/agentregistry-dev/agentregistry/internal/cli/agent/frameworks/common"
-	"github.com/agentregistry-dev/agentregistry/pkg/cli/annotations"
 	"github.com/agentregistry-dev/agentregistry/internal/version"
+	"github.com/agentregistry-dev/agentregistry/pkg/cli/annotations"
 	"github.com/agentregistry-dev/agentregistry/pkg/validators"
 	"github.com/spf13/cobra"
 )

--- a/internal/cli/agent/init.go
+++ b/internal/cli/agent/init.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/agentregistry-dev/agentregistry/internal/cli/agent/frameworks"
 	"github.com/agentregistry-dev/agentregistry/internal/cli/agent/frameworks/common"
+	"github.com/agentregistry-dev/agentregistry/pkg/cli/annotations"
 	"github.com/agentregistry-dev/agentregistry/internal/version"
 	"github.com/agentregistry-dev/agentregistry/pkg/validators"
 	"github.com/spf13/cobra"
@@ -22,8 +23,9 @@ const (
 )
 
 var InitCmd = &cobra.Command{
-	Use:   "init [framework] [language] [agent-name]",
-	Short: "Initialize a new agent project",
+	Use:         "init [framework] [language] [agent-name]",
+	Annotations: map[string]string{annotations.SkipDaemonAnnotation: "true"},
+	Short:       "Initialize a new agent project",
 	Long: `Initialize a new agent project using the specified framework and language.
 
 Supported frameworks and languages:

--- a/internal/cli/configure/configure.go
+++ b/internal/cli/configure/configure.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 
 	"github.com/agentregistry-dev/agentregistry/internal/cli/common"
+	"github.com/agentregistry-dev/agentregistry/pkg/cli/annotations"
 	"github.com/spf13/cobra"
 )
 
@@ -25,8 +26,9 @@ var clientConfigurers = map[string]ClientConfigurer{
 
 // NewConfigureCmd creates the configure command
 var ConfigureCmd = &cobra.Command{
-	Use:   "configure [client-name]",
-	Short: "Configure a client",
+	Use:         "configure [client-name]",
+	Annotations: map[string]string{annotations.SkipDaemonAnnotation: "true"},
+	Short:       "Configure a client",
 	Long:  `Creates the .json configuration for each client, so it can connect to arctl.`,
 	Args:  cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {

--- a/internal/cli/configure/configure.go
+++ b/internal/cli/configure/configure.go
@@ -29,8 +29,8 @@ var ConfigureCmd = &cobra.Command{
 	Use:         "configure [client-name]",
 	Annotations: map[string]string{annotations.SkipDaemonAnnotation: "true"},
 	Short:       "Configure a client",
-	Long:  `Creates the .json configuration for each client, so it can connect to arctl.`,
-	Args:  cobra.MaximumNArgs(1),
+	Long:        `Creates the .json configuration for each client, so it can connect to arctl.`,
+	Args:        cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		// Show supported clients if no argument provided
 		if len(args) == 0 {

--- a/internal/cli/mcp/add_tool.go
+++ b/internal/cli/mcp/add_tool.go
@@ -8,9 +8,9 @@ import (
 	"strings"
 
 	"github.com/agentregistry-dev/agentregistry/internal/cli/mcp/frameworks"
-	"github.com/agentregistry-dev/agentregistry/pkg/cli/annotations"
 	"github.com/agentregistry-dev/agentregistry/internal/cli/mcp/manifest"
 	"github.com/agentregistry-dev/agentregistry/internal/cli/mcp/templates"
+	"github.com/agentregistry-dev/agentregistry/pkg/cli/annotations"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/cli/mcp/add_tool.go
+++ b/internal/cli/mcp/add_tool.go
@@ -8,14 +8,16 @@ import (
 	"strings"
 
 	"github.com/agentregistry-dev/agentregistry/internal/cli/mcp/frameworks"
+	"github.com/agentregistry-dev/agentregistry/pkg/cli/annotations"
 	"github.com/agentregistry-dev/agentregistry/internal/cli/mcp/manifest"
 	"github.com/agentregistry-dev/agentregistry/internal/cli/mcp/templates"
 	"github.com/spf13/cobra"
 )
 
 var AddToolCmd = &cobra.Command{
-	Use:   "add-tool [tool-name]",
-	Short: "Add a new MCP tool to your project",
+	Use:         "add-tool [tool-name]",
+	Annotations: map[string]string{annotations.SkipDaemonAnnotation: "true"},
+	Short:       "Add a new MCP tool to your project",
 	Long: `Generate a new MCP tool that will be automatically loaded by the server.
 
 This command creates a new tool file in src/tools/ with a generic template.

--- a/internal/cli/mcp/build.go
+++ b/internal/cli/mcp/build.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/agentregistry-dev/agentregistry/internal/cli/common"
+	"github.com/agentregistry-dev/agentregistry/pkg/cli/annotations"
 	"github.com/agentregistry-dev/agentregistry/internal/cli/common/docker"
 	"github.com/agentregistry-dev/agentregistry/internal/cli/mcp/build"
 	"github.com/agentregistry-dev/agentregistry/internal/cli/mcp/manifest"
@@ -13,8 +14,9 @@ import (
 )
 
 var BuildCmd = &cobra.Command{
-	Use:   "build",
-	Short: "Build MCP server as a Docker image",
+	Use:         "build",
+	Annotations: map[string]string{annotations.SkipDaemonAnnotation: "true"},
+	Short:       "Build MCP server as a Docker image",
 	Long: `Build an MCP server from the current project.
 	
 This command will detect the project type and build the appropriate

--- a/internal/cli/mcp/build.go
+++ b/internal/cli/mcp/build.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 
 	"github.com/agentregistry-dev/agentregistry/internal/cli/common"
-	"github.com/agentregistry-dev/agentregistry/pkg/cli/annotations"
 	"github.com/agentregistry-dev/agentregistry/internal/cli/common/docker"
 	"github.com/agentregistry-dev/agentregistry/internal/cli/mcp/build"
 	"github.com/agentregistry-dev/agentregistry/internal/cli/mcp/manifest"
+	"github.com/agentregistry-dev/agentregistry/pkg/cli/annotations"
 	"github.com/agentregistry-dev/agentregistry/pkg/printer"
 
 	"github.com/spf13/cobra"

--- a/internal/cli/mcp/init.go
+++ b/internal/cli/mcp/init.go
@@ -9,9 +9,9 @@ import (
 	"strings"
 
 	"github.com/agentregistry-dev/agentregistry/internal/cli/mcp/frameworks"
-	"github.com/agentregistry-dev/agentregistry/pkg/cli/annotations"
 	"github.com/agentregistry-dev/agentregistry/internal/cli/mcp/manifest"
 	"github.com/agentregistry-dev/agentregistry/internal/cli/mcp/templates"
+	"github.com/agentregistry-dev/agentregistry/pkg/cli/annotations"
 	"github.com/agentregistry-dev/agentregistry/pkg/validators"
 
 	"github.com/spf13/cobra"

--- a/internal/cli/mcp/init.go
+++ b/internal/cli/mcp/init.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/agentregistry-dev/agentregistry/internal/cli/mcp/frameworks"
+	"github.com/agentregistry-dev/agentregistry/pkg/cli/annotations"
 	"github.com/agentregistry-dev/agentregistry/internal/cli/mcp/manifest"
 	"github.com/agentregistry-dev/agentregistry/internal/cli/mcp/templates"
 	"github.com/agentregistry-dev/agentregistry/pkg/validators"
@@ -17,8 +18,9 @@ import (
 )
 
 var InitCmd = &cobra.Command{
-	Use:   "init [project-type] [project-name]",
-	Short: "Initialize a new MCP server project",
+	Use:         "init [project-type] [project-name]",
+	Annotations: map[string]string{annotations.SkipDaemonAnnotation: "true"},
+	Short:       "Initialize a new MCP server project",
 	Long: `Initialize a new MCP server project with dynamic tool loading.
 
 This command provides subcommands to initialize a new MCP server project

--- a/internal/cli/skill/build.go
+++ b/internal/cli/skill/build.go
@@ -6,8 +6,8 @@ import (
 	"path/filepath"
 
 	"github.com/agentregistry-dev/agentregistry/internal/cli/common"
-	"github.com/agentregistry-dev/agentregistry/pkg/cli/annotations"
 	"github.com/agentregistry-dev/agentregistry/internal/cli/common/docker"
+	"github.com/agentregistry-dev/agentregistry/pkg/cli/annotations"
 	"github.com/agentregistry-dev/agentregistry/pkg/printer"
 	"github.com/spf13/cobra"
 )

--- a/internal/cli/skill/build.go
+++ b/internal/cli/skill/build.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 
 	"github.com/agentregistry-dev/agentregistry/internal/cli/common"
+	"github.com/agentregistry-dev/agentregistry/pkg/cli/annotations"
 	"github.com/agentregistry-dev/agentregistry/internal/cli/common/docker"
 	"github.com/agentregistry-dev/agentregistry/pkg/printer"
 	"github.com/spf13/cobra"
@@ -15,8 +16,9 @@ import (
 const skillDockerfile = "FROM scratch\nCOPY . .\n"
 
 var BuildCmd = &cobra.Command{
-	Use:   "build <skill-folder-path>",
-	Short: "Build a skill as a Docker image",
+	Use:         "build <skill-folder-path>",
+	Annotations: map[string]string{annotations.SkipDaemonAnnotation: "true"},
+	Short:       "Build a skill as a Docker image",
 	Long: `Build a skill from a local folder containing SKILL.md.
 
 This command reads the SKILL.md frontmatter to determine the skill name,

--- a/internal/cli/skill/init.go
+++ b/internal/cli/skill/init.go
@@ -15,8 +15,8 @@ var InitCmd = &cobra.Command{
 	Use:         "init [skill-name]",
 	Annotations: map[string]string{annotations.SkipDaemonAnnotation: "true"},
 	Short:       "Initialize a new agentic skill project",
-	Long:  `Initialize a new agentic skill project.`,
-	RunE:  runInit,
+	Long:        `Initialize a new agentic skill project.`,
+	RunE:        runInit,
 }
 
 var (

--- a/internal/cli/skill/init.go
+++ b/internal/cli/skill/init.go
@@ -5,14 +5,16 @@ import (
 	"path/filepath"
 
 	"github.com/agentregistry-dev/agentregistry/internal/cli/skill/templates"
+	"github.com/agentregistry-dev/agentregistry/pkg/cli/annotations"
 	"github.com/agentregistry-dev/agentregistry/pkg/validators"
 
 	"github.com/spf13/cobra"
 )
 
 var InitCmd = &cobra.Command{
-	Use:   "init [skill-name]",
-	Short: "Initialize a new agentic skill project",
+	Use:         "init [skill-name]",
+	Annotations: map[string]string{annotations.SkipDaemonAnnotation: "true"},
+	Short:       "Initialize a new agentic skill project",
 	Long:  `Initialize a new agentic skill project.`,
 	RunE:  runInit,
 }

--- a/internal/cli/version.go
+++ b/internal/cli/version.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/agentregistry-dev/agentregistry/internal/client"
 	"github.com/agentregistry-dev/agentregistry/internal/version"
+	"github.com/agentregistry-dev/agentregistry/pkg/cli/annotations"
 )
 
 var apiClient *client.Client
@@ -31,9 +32,10 @@ type versionOutput struct {
 var jsonOutput bool
 
 var VersionCmd = &cobra.Command{
-	Use:   "version",
-	Short: "Show version information",
-	Long:  `Displays the version of arctl.`,
+	Use:         "version",
+	Short:       "Show version information",
+	Long:        `Displays the version of arctl.`,
+	Annotations: map[string]string{annotations.SkipDaemonAnnotation: "true"},
 	Run: func(cmd *cobra.Command, args []string) {
 		output := versionOutput{
 			ArctlVersion: version.Version,

--- a/pkg/cli/annotations/annotations.go
+++ b/pkg/cli/annotations/annotations.go
@@ -1,0 +1,8 @@
+package annotations
+
+// SkipDaemonAnnotation is the cobra.Command annotation key that opts a command
+// out of PersistentPreRunE setup (daemon connection, API client creation, etc.).
+// Add it to any command's Annotations map with the value "true" to skip.
+//
+//	Annotations: map[string]string{annotations.SkipDaemonAnnotation: "true"}
+const SkipDaemonAnnotation = "skipDaemon"

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/agentregistry-dev/agentregistry/internal/cli"
 	"github.com/agentregistry-dev/agentregistry/internal/cli/agent"
-	"github.com/agentregistry-dev/agentregistry/pkg/cli/annotations"
 	agentutils "github.com/agentregistry-dev/agentregistry/internal/cli/agent/utils"
 	"github.com/agentregistry-dev/agentregistry/internal/cli/configure"
 	clidaemon "github.com/agentregistry-dev/agentregistry/internal/cli/daemon"
@@ -18,6 +17,7 @@ import (
 	"github.com/agentregistry-dev/agentregistry/internal/cli/prompt"
 	"github.com/agentregistry-dev/agentregistry/internal/cli/skill"
 	"github.com/agentregistry-dev/agentregistry/internal/client"
+	"github.com/agentregistry-dev/agentregistry/pkg/cli/annotations"
 	"github.com/agentregistry-dev/agentregistry/pkg/daemon/dockercompose"
 	"github.com/agentregistry-dev/agentregistry/pkg/types"
 	"github.com/spf13/cobra"

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/agentregistry-dev/agentregistry/internal/cli"
 	"github.com/agentregistry-dev/agentregistry/internal/cli/agent"
+	"github.com/agentregistry-dev/agentregistry/pkg/cli/annotations"
 	agentutils "github.com/agentregistry-dev/agentregistry/internal/cli/agent/utils"
 	"github.com/agentregistry-dev/agentregistry/internal/cli/configure"
 	clidaemon "github.com/agentregistry-dev/agentregistry/internal/cli/daemon"
@@ -149,40 +150,20 @@ func normalizeBaseURL(raw string) string {
 	return "http://" + trimmed
 }
 
-// preRunSkipCommands defines which commands skip pre-run setup (no API client needed).
-// Key: parent name; value: set of subcommand names that skip setup.
-var preRunSkipCommands = map[string]map[string]bool{
-	"arctl": {
-		"completion": true,
-		"configure":  true,
-		"version":    true,
-	},
-	"agent": {
-		"build": true,
-		"init":  true,
-	},
-	"mcp": {
-		"add-tool": true,
-		"build":    true,
-		"init":     true,
-	},
-	"skill": {
-		"build": true,
-		"init":  true,
-	},
-}
-
-// preRunBehavior returns whether to skip pre-run setup (e.g. agent/mcp/skill init).
+// preRunBehavior returns whether to skip pre-run setup by walking the command
+// hierarchy for the annotations.SkipDaemonAnnotation. Any ancestor having the annotation
+// causes all descendants to skip as well. Cobra's auto-generated "completion"
+// command cannot be annotated, so it is handled as a special case.
 func preRunBehavior(cmd *cobra.Command) (skipSetup bool) {
 	if cmd == nil {
 		return false
 	}
 	for c := cmd; c != nil; c = c.Parent() {
-		parent := c.Parent()
-		if parent == nil {
-			break
+		if c.Annotations[annotations.SkipDaemonAnnotation] == "true" {
+			return true
 		}
-		if subcommands, ok := preRunSkipCommands[parent.Name()]; ok && subcommands[c.Name()] {
+		// Cobra's auto-generated completion command cannot be annotated.
+		if c.Name() == "completion" && c.Parent() != nil && c.Parent().Name() == "arctl" {
 			return true
 		}
 	}

--- a/pkg/cli/root_test.go
+++ b/pkg/cli/root_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/agentregistry-dev/agentregistry/internal/client"
+	"github.com/agentregistry-dev/agentregistry/pkg/cli/annotations"
 	"github.com/agentregistry-dev/agentregistry/pkg/types"
 	"github.com/spf13/cobra"
 )
@@ -35,39 +36,41 @@ func TestNormalizeBaseURL(t *testing.T) {
 }
 
 func TestPreRunBehavior(t *testing.T) {
+	skipAnnotation := map[string]string{annotations.SkipDaemonAnnotation: "true"}
+
 	root := &cobra.Command{Use: "arctl"}
 
 	agentCmd := &cobra.Command{Use: "agent"}
-	initCmd := &cobra.Command{Use: "init"}
-	buildCmd := &cobra.Command{Use: "build"}
+	initCmd := &cobra.Command{Use: "init", Annotations: skipAnnotation}
+	buildCmd := &cobra.Command{Use: "build", Annotations: skipAnnotation}
 	listCmd := &cobra.Command{Use: "list"}
 	agentCmd.AddCommand(initCmd)
 	agentCmd.AddCommand(buildCmd)
 	agentCmd.AddCommand(listCmd)
 
 	mcpCmd := &cobra.Command{Use: "mcp"}
-	mcpInitCmd := &cobra.Command{Use: "init"}
-	mcpBuildCmd := &cobra.Command{Use: "build"}
-	mcpAddToolCmd := &cobra.Command{Use: "add-tool"}
+	mcpInitCmd := &cobra.Command{Use: "init", Annotations: skipAnnotation}
+	mcpBuildCmd := &cobra.Command{Use: "build", Annotations: skipAnnotation}
+	mcpAddToolCmd := &cobra.Command{Use: "add-tool", Annotations: skipAnnotation}
 	mcpCmd.AddCommand(mcpInitCmd)
 	mcpCmd.AddCommand(mcpBuildCmd)
 	mcpCmd.AddCommand(mcpAddToolCmd)
 
 	skillCmd := &cobra.Command{Use: "skill"}
-	skillInitCmd := &cobra.Command{Use: "init"}
-	skillBuildCmd := &cobra.Command{Use: "build"}
+	skillInitCmd := &cobra.Command{Use: "init", Annotations: skipAnnotation}
+	skillBuildCmd := &cobra.Command{Use: "build", Annotations: skipAnnotation}
 	skillCmd.AddCommand(skillInitCmd)
 	skillCmd.AddCommand(skillBuildCmd)
 
-	// Subcommand under "mcp init" (e.g. arctl mcp init python mymcp)
+	// Subcommand under "mcp init" — inherits skip from annotated ancestor
 	initPythonCmd := &cobra.Command{Use: "python"}
 	mcpInitCmd.AddCommand(initPythonCmd)
 
-	configureCmd := &cobra.Command{Use: "configure"}
+	configureCmd := &cobra.Command{Use: "configure", Annotations: skipAnnotation}
 	completionCmd := &cobra.Command{Use: "completion"}
 	zshCompletionCmd := &cobra.Command{Use: "zsh"}
 	completionCmd.AddCommand(zshCompletionCmd)
-	versionCmd := &cobra.Command{Use: "version"}
+	versionCmd := &cobra.Command{Use: "version", Annotations: skipAnnotation}
 	root.AddCommand(agentCmd, mcpCmd, skillCmd, configureCmd, completionCmd, versionCmd)
 
 	tests := []struct {


### PR DESCRIPTION
This is a proposal, can be removed if not as helpful as I think it is 👍🏼

# Description

- Remove daemon skip map
- Use special annotation to skip daemon on commands

Currently we define the set of skipped commands in an un-exported field. If anyone extends this library they won't be able to easily set up commands that don't require a daemon running. We can create extension points (exported functionality or cli option one can plug in commands), but this would be _another_ extension point which adds complexity to the codebase.

Proposal is to move from the map-based skips to an annotation-based one. Commands would be able to define if they don't need the daemon directly in its definition through the annotation field.

> Annotations are key/value pairs that can be used by applications to identify or group commands or set special options.

# Change Type

```
/kind cleanup
```

# Changelog

```release-note
NONE
```

# Additional Notes

An edge case would be if commands define their own `PersistentPreRun`, then the one we use now is overriden and so setting `skipDaemon: true` on those commands won't have any effect. This is a pre-existing edge case, but worth noting.

The root `completion` command is from cobra, so it is the exception where we can't directly define the annotation for.