### PR TITLE
Nit: Use `/ping` for daemon ready check instead of `/version`

### DIFF
--- a/pkg/daemon/health.go
+++ b/pkg/daemon/health.go
@@ -14,11 +14,11 @@ type HealthChecker struct {
 // IsResponding checks if the server is responding
 func (h *HealthChecker) IsResponding() bool {
 	httpClient := &http.Client{Timeout: 2 * time.Second}
-	versionURL := strings.TrimRight(h.BaseURL, "/") + "/version"
+	pingURL := strings.TrimRight(h.BaseURL, "/") + "/ping"
 
 	const maxRetries = 3
 	for i := range maxRetries {
-		resp, err := httpClient.Get(versionURL)
+		resp, err := httpClient.Get(pingURL)
 		if err == nil {
 			defer resp.Body.Close()
 			if resp.StatusCode == http.StatusOK {
@@ -42,7 +42,7 @@ func (h *HealthChecker) WaitForReady(timeout time.Duration) error {
 		resp, err := httpClient.Get(pingURL)
 		if err == nil {
 			resp.Body.Close()
-			if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+			if resp.StatusCode == http.StatusOK {
 				return nil
 			}
 		}


### PR DESCRIPTION
# Description

When using CLI, i noticed random calls to `/version` when using it which was confusing (i'd only expect it to be called if I'm trying to see the version). Since `/version` is not a "public path" (not in our list of paths to avoid doing AuthN checks), there are also 3 lines of "unauthenticated -> /v0/version" fails each CLI call.

We could add `/version` as a public path if we don't believe having build/run info public is an issue, but at the core level if we're checking for a response, we should be hitting between `/ping` or `/health`. I chose `/ping` since this is doing a response check not actual health checks per daemon-call.

**Changes**
- Use `/ping` for response checks
- Check for HTTP `200` specifically for OK-ness. Huma defaults to a 200 code on responses with a body (which the /ping endpoint provides.)

# Change Type

```
/kind cleanup
```

# Changelog

```release-note
NONE
```

# Additional Notes
