### PR TITLE
feat: add declarative CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,5 @@ Thumbs.db
 # Generated Helm chart manifest
 charts/agentregistry/Chart.yaml
 
+_output/
+

--- a/Makefile
+++ b/Makefile
@@ -8,10 +8,18 @@ ifneq (,$(wildcard .env))
 endif
 
 # Image configuration
-DOCKER_REGISTRY ?= localhost:5001
+REGISTRY_PORT ?= 5001
+DOCKER_REGISTRY ?= localhost:$(REGISTRY_PORT)
 BASE_IMAGE_REGISTRY ?= ghcr.io
 DOCKER_REPO ?= agentregistry-dev/agentregistry
 DOCKER_BUILDER ?= docker buildx
+BUILDX_BUILDER_NAME ?= agentregistry-builder
+BUILDX_BUILDER_NETWORK ?= buildnet
+OUTDIR ?= _output
+# The buildx builder runs inside a container on buildnet and cannot reach
+# localhost:5001 for pushes. Push directly to kind-registry:5000 on buildnet instead.
+# DOCKER_REGISTRY (localhost:5001) is kept for helm chart image references.
+DOCKER_BUILD_REGISTRY ?= kind-registry:5000
 DOCKER_BUILD_ARGS ?= --push --platform linux/$(LOCALARCH)
 BUILD_DATE ?= $(shell date -u '+%Y-%m-%d')
 GIT_COMMIT ?= $(shell git rev-parse --short HEAD || echo "unknown")
@@ -256,27 +264,56 @@ dev-build: build-ui ## Build quickly for local development
 
 # Build custom agent gateway image with npx/uvx support
 .PHONY: docker-agentgateway
-docker-agentgateway: ## Build the custom agent gateway image
+docker-agentgateway: buildx-create ## Build the custom agent gateway image
 	@echo "Building custom agent gateway image..."
-	$(DOCKER_BUILDER) build $(DOCKER_BUILD_ARGS) -f docker/agentgateway.Dockerfile -t $(DOCKER_REGISTRY)/$(DOCKER_REPO)/arctl-agentgateway:$(VERSION) .
+	$(DOCKER_BUILDER) build --builder $(BUILDX_BUILDER_NAME) $(DOCKER_BUILD_ARGS) -f docker/agentgateway.Dockerfile -t $(DOCKER_BUILD_REGISTRY)/$(DOCKER_REPO)/arctl-agentgateway:$(VERSION) .
 	echo "✓ Agent gateway image built successfully";
 
 .PHONY: docker-server
-docker-server: .env ## Build the server Docker image
+docker-server: .env buildx-create ## Build the server Docker image
 	@echo "Building server Docker image..."
-	$(DOCKER_BUILDER) build $(DOCKER_BUILD_ARGS) -f docker/server.Dockerfile -t $(DOCKER_REGISTRY)/$(DOCKER_REPO)/server:$(VERSION) --build-arg LDFLAGS="$(LDFLAGS)" .
+	$(DOCKER_BUILDER) build --builder $(BUILDX_BUILDER_NAME) $(DOCKER_BUILD_ARGS) -f docker/server.Dockerfile -t $(DOCKER_BUILD_REGISTRY)/$(DOCKER_REPO)/server:$(VERSION) --build-arg LDFLAGS="$(LDFLAGS)" .
 	@echo "✓ Docker image built successfully"
 
+.PHONY: builder-network
+builder-network:
+	@if ! docker network ls | grep -q "$(BUILDX_BUILDER_NETWORK)"; then \
+		docker network create $(BUILDX_BUILDER_NETWORK); \
+	fi
+
+.PHONY: buildx-rm
+buildx-rm: ## Remove the buildx builder
+	@if docker buildx inspect "$(BUILDX_BUILDER_NAME)" >/dev/null 2>&1; then \
+		docker buildx rm "$(BUILDX_BUILDER_NAME)" || true; \
+	fi
+
 .PHONY: local-registry
-local-registry: ## Ensure the local registry (kind-registry) is running on port 5001
-	@echo "Ensuring local registry is running on port 5001..."
+local-registry: builder-network ## Ensure the local registry (kind-registry) is running on port $(REGISTRY_PORT)
+	@echo "Ensuring local registry is running on port $(REGISTRY_PORT)..."
 	@if [ "$$(docker inspect -f '{{.State.Running}}' kind-registry 2>/dev/null || true)" = "true" ]; then \
 		echo "kind-registry already running. Skipping." ; \
 	elif docker inspect kind-registry >/dev/null 2>&1; then \
 		docker start kind-registry ; \
 	else \
 		docker run \
-		-d --restart=always -p "127.0.0.1:5001:5000" --network bridge --name kind-registry "docker.io/library/registry:2" ; \
+		-d --restart=always -p "127.0.0.1:$(REGISTRY_PORT):5000" \
+		--network $(BUILDX_BUILDER_NETWORK) --name kind-registry "docker.io/library/registry:2" ; \
+	fi
+	@docker network connect $(BUILDX_BUILDER_NETWORK) kind-registry 2>/dev/null || true
+	@docker network connect kind kind-registry 2>/dev/null || true
+
+.PHONY: buildx-create
+buildx-create: local-registry ## Create the buildx builder on buildnet (run once per machine)
+	@if docker buildx inspect "$(BUILDX_BUILDER_NAME)" >/dev/null 2>&1; then \
+		echo "Buildx builder $(BUILDX_BUILDER_NAME) already exists"; \
+		docker buildx use "$(BUILDX_BUILDER_NAME)" 2>/dev/null || true; \
+	else \
+		mkdir -p $(OUTDIR)/buildkit; \
+		REGISTRY_PORT=$(REGISTRY_PORT) envsubst < docker/buildkit.tpl > $(OUTDIR)/buildkit/buildkit.toml; \
+		docker buildx create --use --bootstrap \
+			--name $(BUILDX_BUILDER_NAME) \
+			--driver-opt network=$(BUILDX_BUILDER_NETWORK) \
+			--config $(OUTDIR)/buildkit/buildkit.toml; \
 	fi
 
 .PHONY: docker

--- a/docker/buildkit.tpl
+++ b/docker/buildkit.tpl
@@ -1,0 +1,8 @@
+[registry."localhost:${REGISTRY_PORT}"]
+  mirrors = ["http://kind-registry:5000"]
+  http = true
+  insecure = true
+
+[registry."kind-registry:5000"]
+  http = true
+  insecure = true

--- a/docs/declarative-cli.md
+++ b/docs/declarative-cli.md
@@ -5,7 +5,7 @@ Define agents, MCP servers, skills, and prompts as YAML files and manage them wi
 ## Quick Start
 
 ```bash
-arctl init agent adk python summarizer --model-provider Gemini --model-name gemini-2.0-flash
+arctl init agent adk python summarizer --model-provider gemini --model-name gemini-2.0-flash
 arctl build summarizer/ --push    # optional: build and push Docker image
 arctl apply -f summarizer/agent.yaml
 ```
@@ -22,7 +22,7 @@ arctl apply -f summarizer/agent.yaml
 ## Agents
 
 ```bash
-arctl init agent adk python summarizer --model-provider Gemini --model-name gemini-2.0-flash
+arctl init agent adk python summarizer --model-provider gemini --model-name gemini-2.0-flash
 arctl build summarizer/ --push    # optional: build and push Docker image
 arctl apply -f summarizer/agent.yaml
 arctl get agent summarizer

--- a/docs/declarative-cli.md
+++ b/docs/declarative-cli.md
@@ -1,0 +1,67 @@
+# Declarative CLI
+
+Define agents, MCP servers, skills, and prompts as YAML files and manage them with `arctl apply`, `arctl get`, and `arctl delete`.
+
+## Quick Start
+
+```bash
+arctl init agent adk python summarizer --model-provider Gemini --model-name gemini-2.0-flash
+arctl build summarizer/ --push    # optional: build and push Docker image
+arctl apply -f summarizer/agent.yaml
+```
+
+## Resource Types
+
+| Kind | get | delete |
+|------|-----|--------|
+| `Agent` | `arctl get agents` | `arctl delete agent NAME --version VERSION` |
+| `MCPServer` | `arctl get mcps` | `arctl delete mcp NAME --version VERSION` |
+| `Skill` | `arctl get skills` | `arctl delete skill NAME --version VERSION` |
+| `Prompt` | `arctl get prompts` | `arctl delete prompt NAME --version VERSION` |
+
+## Agents
+
+```bash
+arctl init agent adk python summarizer --model-provider Gemini --model-name gemini-2.0-flash
+arctl build summarizer/ --push    # optional: build and push Docker image
+arctl apply -f summarizer/agent.yaml
+arctl get agent summarizer
+arctl delete agent summarizer --version 0.1.0
+```
+
+## MCP Servers
+
+```bash
+arctl init mcp fastmcp-python acme/my-server
+arctl build my-server/ --push    # optional: build and push Docker image
+arctl apply -f my-server/mcp.yaml
+arctl get mcps
+arctl delete mcp acme/my-server --version 0.1.0
+```
+
+## Skills & Prompts
+
+```bash
+arctl init skill summarize --category nlp
+arctl apply -f summarize/skill.yaml
+arctl get skills
+arctl delete skill summarize --version 0.1.0
+
+arctl init prompt summarizer-system-prompt
+arctl apply -f summarizer-system-prompt.yaml
+arctl get prompts
+arctl delete prompt summarizer-system-prompt --version 0.1.0
+```
+
+## Tips
+
+```bash
+# Apply multiple resources from one file (separated by ---)
+# Resources are applied in document order — define dependencies before the agent
+arctl apply -f full-stack.yaml
+
+# List all resource types at once
+arctl get all
+```
+
+See [`examples/declarative/`](../examples/declarative/) for ready-to-use YAML files, including [`full-stack.yaml`](../examples/declarative/full-stack.yaml) which defines an agent and all its dependencies in a single file.

--- a/e2e/declarative_test.go
+++ b/e2e/declarative_test.go
@@ -96,7 +96,7 @@ spec:
   description: "E2E declarative apply test agent"
   language: python
   framework: adk
-  modelProvider: google
+  modelProvider: gemini
   modelName: gemini-2.0-flash
 `, agentName, version)
 
@@ -224,7 +224,7 @@ spec:
   description: "Multi-doc test agent"
   language: python
   framework: adk
-  modelProvider: google
+  modelProvider: gemini
   modelName: gemini-2.0-flash
 `, serverName, version, agentName, version)
 
@@ -258,7 +258,7 @@ spec:
   description: "Dry-run test agent"
   language: python
   framework: adk
-  modelProvider: google
+  modelProvider: gemini
   modelName: gemini-2.0-flash
 `, agentName, version)
 

--- a/e2e/declarative_test.go
+++ b/e2e/declarative_test.go
@@ -1,0 +1,580 @@
+//go:build e2e
+
+// Tests for declarative CLI commands: apply, get, delete, and init.
+// These tests verify end-to-end behavior using the real arctl binary against
+// a live registry.
+
+package e2e
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+// writeDeclarativeYAML writes YAML content to a temp file and returns the path.
+func writeDeclarativeYAML(t *testing.T, dir, filename, content string) string {
+	t.Helper()
+	path := filepath.Join(dir, filename)
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("Failed to write YAML file %s: %v", path, err)
+	}
+	return path
+}
+
+// verifyAgentExists checks that the agent exists in the registry via HTTP GET.
+func verifyAgentExists(t *testing.T, regURL, name, version string) {
+	t.Helper()
+	encoded := strings.ReplaceAll(name, "/", "%2F")
+	url := fmt.Sprintf("%s/agents/%s/versions/%s", regURL, encoded, version)
+	resp := RegistryGet(t, url)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("Expected agent %s@%s to exist (HTTP 200) but got %d", name, version, resp.StatusCode)
+	}
+}
+
+// verifyAgentNotFound checks that the agent no longer exists in the registry.
+func verifyAgentNotFound(t *testing.T, regURL, name, version string) {
+	t.Helper()
+	encoded := strings.ReplaceAll(name, "/", "%2F")
+	url := fmt.Sprintf("%s/agents/%s/versions/%s", regURL, encoded, version)
+	client := &http.Client{}
+	resp, err := client.Get(url)
+	if err != nil {
+		t.Fatalf("Failed to GET %s: %v", url, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("Expected agent %s@%s to be deleted (HTTP 404) but got %d", name, version, resp.StatusCode)
+	}
+}
+
+// verifyServerExists checks that the MCP server exists in the registry via HTTP GET.
+func verifyServerExists(t *testing.T, regURL, name, version string) {
+	t.Helper()
+	encoded := strings.ReplaceAll(name, "/", "%2F")
+	url := fmt.Sprintf("%s/servers/%s/versions/%s", regURL, encoded, version)
+	resp := RegistryGet(t, url)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("Expected server %s@%s to exist (HTTP 200) but got %d", name, version, resp.StatusCode)
+	}
+}
+
+// TestDeclarativeApply_AgentLifecycle tests the full apply → get → delete lifecycle
+// for an Agent resource using the declarative CLI.
+func TestDeclarativeApply_AgentLifecycle(t *testing.T) {
+	regURL := RegistryURL(t)
+	tmpDir := t.TempDir()
+
+	agentName := UniqueAgentName("declagent")
+	version := "0.0.1-e2e"
+
+	// Clean up any stale entry from a previous interrupted run.
+	RunArctl(t, tmpDir, "delete", "agent", agentName, "--version", version, "--registry-url", regURL)
+	t.Cleanup(func() {
+		RunArctl(t, tmpDir, "delete", "agent", agentName, "--version", version, "--registry-url", regURL)
+	})
+
+	agentYAML := fmt.Sprintf(`
+apiVersion: ar.dev/v1alpha1
+kind: Agent
+metadata:
+  name: %s
+  version: "%s"
+spec:
+  image: ghcr.io/e2e-test/decl-agent:latest
+  description: "E2E declarative apply test agent"
+  language: python
+  framework: adk
+  modelProvider: google
+  modelName: gemini-2.0-flash
+`, agentName, version)
+
+	yamlPath := writeDeclarativeYAML(t, tmpDir, "agent.yaml", agentYAML)
+
+	// Step 1: Apply the agent.
+	t.Run("apply", func(t *testing.T) {
+		result := RunArctl(t, tmpDir, "apply", "-f", yamlPath, "--registry-url", regURL)
+		RequireSuccess(t, result)
+		RequireOutputContains(t, result, "agent/"+agentName+" applied")
+	})
+
+	// Step 2: Verify it exists in the registry.
+	t.Run("verify_exists", func(t *testing.T) {
+		verifyAgentExists(t, regURL, agentName, version)
+	})
+
+	// Step 3: Get it via the declarative get command (table output).
+	t.Run("get_table", func(t *testing.T) {
+		result := RunArctl(t, tmpDir, "get", "agents", "--registry-url", regURL)
+		RequireSuccess(t, result)
+		RequireOutputContains(t, result, agentName)
+	})
+
+	// Step 4: Get individual agent as YAML.
+	t.Run("get_yaml", func(t *testing.T) {
+		result := RunArctl(t, tmpDir, "get", "agent", agentName, "-o", "yaml", "--registry-url", regURL)
+		RequireSuccess(t, result)
+		RequireOutputContains(t, result, "apiVersion: ar.dev/v1alpha1")
+		RequireOutputContains(t, result, "kind: Agent")
+		RequireOutputContains(t, result, agentName)
+	})
+
+	// Step 5: Get individual agent as JSON.
+	t.Run("get_json", func(t *testing.T) {
+		result := RunArctl(t, tmpDir, "get", "agent", agentName, "-o", "json", "--registry-url", regURL)
+		RequireSuccess(t, result)
+		var parsed map[string]any
+		if err := json.Unmarshal([]byte(result.Stdout), &parsed); err != nil {
+			t.Fatalf("Expected valid JSON output, got: %s", result.Stdout)
+		}
+	})
+
+	// Step 6: Delete it.
+	t.Run("delete", func(t *testing.T) {
+		result := RunArctl(t, tmpDir, "delete", "agent", agentName, "--version", version, "--registry-url", regURL)
+		RequireSuccess(t, result)
+	})
+
+	// Step 7: Verify it is gone.
+	t.Run("verify_deleted", func(t *testing.T) {
+		verifyAgentNotFound(t, regURL, agentName, version)
+	})
+}
+
+// TestDeclarativeApply_MCPServer tests applying an MCPServer resource using the
+// declarative CLI.
+func TestDeclarativeApply_MCPServer(t *testing.T) {
+	regURL := RegistryURL(t)
+	tmpDir := t.TempDir()
+
+	serverName := "e2e-test/" + UniqueNameWithPrefix("decl-mcp")
+	version := "0.0.1-e2e"
+
+	// Clean up any stale entry.
+	RunArctl(t, tmpDir, "mcp", "delete", serverName, "--version", version, "--registry-url", regURL)
+	t.Cleanup(func() {
+		RunArctl(t, tmpDir, "mcp", "delete", serverName, "--version", version, "--registry-url", regURL)
+	})
+
+	serverYAML := fmt.Sprintf(`
+apiVersion: ar.dev/v1alpha1
+kind: MCPServer
+metadata:
+  name: %s
+  version: "%s"
+spec:
+  description: "E2E declarative apply test MCP server"
+`, serverName, version)
+
+	yamlPath := writeDeclarativeYAML(t, tmpDir, "server.yaml", serverYAML)
+
+	// Apply the MCP server.
+	result := RunArctl(t, tmpDir, "apply", "-f", yamlPath, "--registry-url", regURL)
+	RequireSuccess(t, result)
+	RequireOutputContains(t, result, "mcpserver/"+serverName+" applied")
+
+	// Verify it exists.
+	verifyServerExists(t, regURL, serverName, version)
+}
+
+// TestDeclarativeApply_MultiDoc tests applying a multi-document YAML file.
+func TestDeclarativeApply_MultiDoc(t *testing.T) {
+	regURL := RegistryURL(t)
+	tmpDir := t.TempDir()
+
+	serverName := "e2e-test/" + UniqueNameWithPrefix("decl-multi-mcp")
+	agentName := UniqueAgentName("declmultiagent")
+	version := "0.0.1-e2e"
+
+	// Clean up.
+	RunArctl(t, tmpDir, "mcp", "delete", serverName, "--version", version, "--registry-url", regURL)
+	RunArctl(t, tmpDir, "delete", "agent", agentName, "--version", version, "--registry-url", regURL)
+	t.Cleanup(func() {
+		RunArctl(t, tmpDir, "mcp", "delete", serverName, "--version", version, "--registry-url", regURL)
+		RunArctl(t, tmpDir, "delete", "agent", agentName, "--version", version, "--registry-url", regURL)
+	})
+
+	multiDocYAML := fmt.Sprintf(`
+apiVersion: ar.dev/v1alpha1
+kind: MCPServer
+metadata:
+  name: %s
+  version: "%s"
+spec:
+  description: "Multi-doc test MCP server"
+---
+apiVersion: ar.dev/v1alpha1
+kind: Agent
+metadata:
+  name: %s
+  version: "%s"
+spec:
+  image: ghcr.io/e2e-test/multi-agent:latest
+  description: "Multi-doc test agent"
+  language: python
+  framework: adk
+  modelProvider: google
+  modelName: gemini-2.0-flash
+`, serverName, version, agentName, version)
+
+	yamlPath := writeDeclarativeYAML(t, tmpDir, "stack.yaml", multiDocYAML)
+
+	result := RunArctl(t, tmpDir, "apply", "-f", yamlPath, "--registry-url", regURL)
+	RequireSuccess(t, result)
+	RequireOutputContains(t, result, "mcpserver/"+serverName+" applied")
+	RequireOutputContains(t, result, "agent/"+agentName+" applied")
+
+	verifyServerExists(t, regURL, serverName, version)
+	verifyAgentExists(t, regURL, agentName, version)
+}
+
+// TestDeclarativeApply_DryRun verifies dry-run mode does not create resources.
+func TestDeclarativeApply_DryRun(t *testing.T) {
+	regURL := RegistryURL(t)
+	tmpDir := t.TempDir()
+
+	agentName := UniqueAgentName("decldryrun")
+	version := "0.0.1-e2e"
+
+	agentYAML := fmt.Sprintf(`
+apiVersion: ar.dev/v1alpha1
+kind: Agent
+metadata:
+  name: %s
+  version: "%s"
+spec:
+  image: ghcr.io/e2e-test/dryrun:latest
+  description: "Dry-run test agent"
+  language: python
+  framework: adk
+  modelProvider: google
+  modelName: gemini-2.0-flash
+`, agentName, version)
+
+	yamlPath := writeDeclarativeYAML(t, tmpDir, "dryrun.yaml", agentYAML)
+
+	result := RunArctl(t, tmpDir, "apply", "-f", yamlPath, "--dry-run", "--registry-url", regURL)
+	RequireSuccess(t, result)
+	RequireOutputContains(t, result, "[dry-run]")
+
+	// Resource must NOT exist.
+	verifyAgentNotFound(t, regURL, agentName, version)
+}
+
+// --- init tests ---
+
+// parseDeclarativeYAML reads a YAML file and returns it as a map.
+func parseDeclarativeYAML(t *testing.T, path string) map[string]any {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("Failed to read YAML file %s: %v", path, err)
+	}
+	var m map[string]any
+	if err := yaml.Unmarshal(data, &m); err != nil {
+		t.Fatalf("Failed to parse YAML file %s: %v", path, err)
+	}
+	return m
+}
+
+// TestDeclarativeInit_Agent verifies arctl init agent generates the correct
+// declarative agent.yaml and that the result can be applied to the registry.
+func TestDeclarativeInit_Agent(t *testing.T) {
+	regURL := RegistryURL(t)
+	tmpDir := t.TempDir()
+
+	name := UniqueAgentName("initagent")
+	version := "0.1.0"
+
+	t.Cleanup(func() {
+		RunArctl(t, tmpDir, "delete", "agent", name, "--version", version, "--registry-url", regURL)
+	})
+
+	// Step 1: init generates project directory and declarative agent.yaml (offline).
+	result := RunArctl(t, tmpDir, "init", "agent", "adk", "python", name)
+	RequireSuccess(t, result)
+	RequireOutputContains(t, result, "Successfully created agent:")
+
+	agentYAMLPath := filepath.Join(tmpDir, name, "agent.yaml")
+	RequireFileExists(t, agentYAMLPath)
+
+	// Step 2: verify the generated YAML has the right declarative structure.
+	m := parseDeclarativeYAML(t, agentYAMLPath)
+	if m["apiVersion"] != "ar.dev/v1alpha1" {
+		t.Errorf("expected apiVersion ar.dev/v1alpha1, got %v", m["apiVersion"])
+	}
+	if m["kind"] != "Agent" {
+		t.Errorf("expected kind Agent, got %v", m["kind"])
+	}
+	metadata, _ := m["metadata"].(map[string]any)
+	if metadata["name"] != name {
+		t.Errorf("expected metadata.name %q, got %v", name, metadata["name"])
+	}
+
+	// Step 3: apply the generated YAML directly (no edits needed for a simple name).
+	applyResult := RunArctl(t, tmpDir, "apply", "-f", agentYAMLPath, "--registry-url", regURL)
+	RequireSuccess(t, applyResult)
+	RequireOutputContains(t, applyResult, "agent/"+name+" applied")
+
+	// Step 4: verify it exists in the registry.
+	verifyAgentExists(t, regURL, name, version)
+}
+
+// TestDeclarativeInit_MCP verifies arctl init mcp generates the correct
+// declarative mcp.yaml (offline, no registry required for generation).
+func TestDeclarativeInit_MCP(t *testing.T) {
+	tmpDir := t.TempDir()
+	// MCP names must be namespace/name format.
+	dirName := UniqueNameWithPrefix("initmcp")
+	fullName := "e2e-test/" + dirName
+
+	// init is offline — no registry-url needed.
+	result := RunArctl(t, tmpDir, "init", "mcp", "fastmcp-python", fullName)
+	RequireSuccess(t, result)
+	RequireOutputContains(t, result, "Successfully created MCP server:")
+
+	// Directory uses just the name part after "/".
+	mcpYAMLPath := filepath.Join(tmpDir, dirName, "mcp.yaml")
+	RequireFileExists(t, mcpYAMLPath)
+
+	m := parseDeclarativeYAML(t, mcpYAMLPath)
+	if m["apiVersion"] != "ar.dev/v1alpha1" {
+		t.Errorf("expected apiVersion ar.dev/v1alpha1, got %v", m["apiVersion"])
+	}
+	if m["kind"] != "MCPServer" {
+		t.Errorf("expected kind MCPServer, got %v", m["kind"])
+	}
+	metadata, _ := m["metadata"].(map[string]any)
+	if metadata["name"] != fullName {
+		t.Errorf("expected metadata.name %q, got %v", fullName, metadata["name"])
+	}
+	spec, _ := m["spec"].(map[string]any)
+	pkgs, ok := spec["packages"].([]any)
+	if !ok || len(pkgs) == 0 {
+		t.Error("expected spec.packages to be a non-empty list")
+	}
+}
+
+// TestDeclarativeInit_Skill verifies arctl init skill generates the correct
+// declarative skill.yaml and that it can be applied to the registry.
+func TestDeclarativeInit_Skill(t *testing.T) {
+	regURL := RegistryURL(t)
+	tmpDir := t.TempDir()
+
+	name := UniqueNameWithPrefix("initskill")
+	version := "0.1.0"
+
+	t.Cleanup(func() {
+		RunArctl(t, tmpDir, "delete", "skill", name, "--version", version, "--registry-url", regURL)
+	})
+
+	// Step 1: init generates project directory and declarative skill.yaml (offline).
+	result := RunArctl(t, tmpDir, "init", "skill", name)
+	RequireSuccess(t, result)
+	RequireOutputContains(t, result, "Successfully created skill:")
+
+	skillYAMLPath := filepath.Join(tmpDir, name, "skill.yaml")
+	RequireFileExists(t, skillYAMLPath)
+
+	// Step 2: verify generated YAML structure.
+	m := parseDeclarativeYAML(t, skillYAMLPath)
+	if m["apiVersion"] != "ar.dev/v1alpha1" {
+		t.Errorf("expected apiVersion ar.dev/v1alpha1, got %v", m["apiVersion"])
+	}
+	if m["kind"] != "Skill" {
+		t.Errorf("expected kind Skill, got %v", m["kind"])
+	}
+
+	// Step 3: apply to the registry.
+	applyResult := RunArctl(t, tmpDir, "apply", "-f", skillYAMLPath, "--registry-url", regURL)
+	RequireSuccess(t, applyResult)
+	RequireOutputContains(t, applyResult, "skill/"+name+" applied")
+}
+
+// TestDeclarativeInit_Prompt verifies arctl init prompt generates the correct
+// declarative prompt YAML and that it can be applied to the registry.
+func TestDeclarativeInit_Prompt(t *testing.T) {
+	regURL := RegistryURL(t)
+	tmpDir := t.TempDir()
+
+	name := UniqueNameWithPrefix("initprompt")
+	version := "0.1.0"
+
+	t.Cleanup(func() {
+		RunArctl(t, tmpDir, "delete", "prompt", name, "--version", version, "--registry-url", regURL)
+	})
+
+	// Step 1: init writes NAME.yaml in cwd (no project directory).
+	result := RunArctl(t, tmpDir, "init", "prompt", name)
+	RequireSuccess(t, result)
+	RequireOutputContains(t, result, "Successfully created prompt:")
+
+	promptYAMLPath := filepath.Join(tmpDir, name+".yaml")
+	RequireFileExists(t, promptYAMLPath)
+
+	// Step 2: verify generated YAML structure.
+	m := parseDeclarativeYAML(t, promptYAMLPath)
+	if m["apiVersion"] != "ar.dev/v1alpha1" {
+		t.Errorf("expected apiVersion ar.dev/v1alpha1, got %v", m["apiVersion"])
+	}
+	if m["kind"] != "Prompt" {
+		t.Errorf("expected kind Prompt, got %v", m["kind"])
+	}
+	spec, _ := m["spec"].(map[string]any)
+	if spec["content"] == "" {
+		t.Error("expected spec.content to be non-empty")
+	}
+
+	// Step 3: apply to the registry.
+	applyResult := RunArctl(t, tmpDir, "apply", "-f", promptYAMLPath, "--registry-url", regURL)
+	RequireSuccess(t, applyResult)
+	RequireOutputContains(t, applyResult, "prompt/"+name+" applied")
+}
+
+// --- build tests ---
+
+// skipIfNoDocker skips the test if Docker is not available in the environment.
+func skipIfNoDocker(t *testing.T) {
+	t.Helper()
+	out, err := exec.Command("docker", "version", "--format", "{{.Server.Version}}").Output()
+	if err != nil || len(out) == 0 {
+		t.Skip("Skipping: Docker daemon not available")
+	}
+}
+
+// TestDeclarativeBuild_Agent verifies the full declarative agent workflow:
+// init → build → verify image exists.
+func TestDeclarativeBuild_Agent(t *testing.T) {
+	skipIfNoDocker(t)
+	tmpDir := t.TempDir()
+
+	name := UniqueAgentName("bldagent")
+	image := "localhost:5001/" + name + ":latest"
+	CleanupDockerImage(t, image)
+
+	// Step 1: init the project.
+	result := RunArctl(t, tmpDir, "init", "agent", "adk", "python", name)
+	RequireSuccess(t, result)
+
+	projectDir := filepath.Join(tmpDir, name)
+	RequireDirExists(t, projectDir)
+
+	// Step 2: build the Docker image.
+	result = RunArctl(t, tmpDir, "build", projectDir)
+	RequireSuccess(t, result)
+	RequireOutputContains(t, result, "Building agent image:")
+
+	// Step 3: verify the image was built locally.
+	if !DockerImageExists(t, image) {
+		t.Errorf("Expected Docker image %s to exist after build", image)
+	}
+}
+
+// TestDeclarativeBuild_MCP verifies the declarative MCP build workflow:
+// init → build → verify image exists.
+func TestDeclarativeBuild_MCP(t *testing.T) {
+	skipIfNoDocker(t)
+	tmpDir := t.TempDir()
+
+	// MCP names must be namespace/name format; directory uses just the name part.
+	dirName := UniqueNameWithPrefix("bldmcp")
+	fullName := "e2e-test/" + dirName
+	image := "localhost:5001/" + dirName + ":latest"
+	CleanupDockerImage(t, image)
+
+	// Step 1: init the project.
+	result := RunArctl(t, tmpDir, "init", "mcp", "fastmcp-python", fullName)
+	RequireSuccess(t, result)
+
+	projectDir := filepath.Join(tmpDir, dirName)
+	RequireDirExists(t, projectDir)
+
+	// Step 2: build the Docker image.
+	result = RunArctl(t, tmpDir, "build", projectDir)
+	RequireSuccess(t, result)
+	RequireOutputContains(t, result, "Building MCP server image:")
+
+	// Step 3: verify the image was built locally.
+	if !DockerImageExists(t, image) {
+		t.Errorf("Expected Docker image %s to exist after build", image)
+	}
+}
+
+// TestDeclarativeBuild_NoYAML verifies a clear error when no declarative YAML is present.
+func TestDeclarativeBuild_NoYAML(t *testing.T) {
+	tmpDir := t.TempDir()
+	result := RunArctl(t, tmpDir, "build", tmpDir)
+	RequireFailure(t, result)
+	combined := result.Stdout + result.Stderr
+	if !strings.Contains(combined, "no declarative YAML found") {
+		t.Errorf("expected 'no declarative YAML found' in output, got:\n%s", combined)
+	}
+}
+
+// TestDeclarativeBuild_PromptError verifies build refuses to run for Prompt kind.
+func TestDeclarativeBuild_PromptError(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// init prompt writes a file in cwd, not a subdir, so run from tmpDir.
+	result := RunArctl(t, tmpDir, "init", "prompt", "myprompt")
+	RequireSuccess(t, result)
+
+	// Move the file into a subdir so we can pass a directory to build.
+	subDir := filepath.Join(tmpDir, "prompt-project")
+	require.NoError(t, os.MkdirAll(subDir, 0o755))
+	require.NoError(t, os.Rename(
+		filepath.Join(tmpDir, "myprompt.yaml"),
+		filepath.Join(subDir, "prompt.yaml"),
+	))
+
+	result = RunArctl(t, tmpDir, "build", subDir)
+	RequireFailure(t, result)
+	combined := result.Stdout + result.Stderr
+	if !strings.Contains(combined, "prompts have no build step") {
+		t.Errorf("expected 'prompts have no build step' in output, got:\n%s", combined)
+	}
+}
+
+// TestDeclarativeInit_InvalidArgs verifies error handling for bad init arguments.
+func TestDeclarativeInit_InvalidArgs(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	tests := []struct {
+		name        string
+		args        []string
+		errContains string
+	}{
+		{
+			name:        "agent unsupported framework",
+			args:        []string{"init", "agent", "langchain", "python", "myagent"},
+			errContains: "unsupported framework",
+		},
+		{
+			name:        "mcp unsupported framework",
+			args:        []string{"init", "mcp", "typescript", "myserver"},
+			errContains: "unsupported framework",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := RunArctl(t, tmpDir, tc.args...)
+			RequireFailure(t, result)
+			combined := result.Stdout + result.Stderr
+			if !strings.Contains(combined, tc.errContains) {
+				t.Errorf("expected output to contain %q, got:\n%s", tc.errContains, combined)
+			}
+		})
+	}
+}

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -12,6 +12,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -100,7 +101,12 @@ func resolveRegistryURL() (string, func()) {
 // can reach it when the MetalLB IP is not routable from the host (macOS + Docker Desktop).
 // Returns the localhost URL once the forward is ready, and a stop function.
 func startPortForward(servicePort int) (string, func()) {
-	const localPort = 18121 // arbitrary local port; must not conflict with other services
+	localPort := 18121 // default; override with E2E_LOCAL_PORT env var
+	if v := os.Getenv("E2E_LOCAL_PORT"); v != "" {
+		if p, err := strconv.Atoi(v); err == nil {
+			localPort = p
+		}
+	}
 	const pollInterval = 500 * time.Millisecond
 	const readyTimeout = 30 * time.Second
 

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -5,11 +5,13 @@ package e2e
 import (
 	"context"
 	"fmt"
+	"io"
 	"log"
 	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -30,9 +32,13 @@ func TestMain(m *testing.M) {
 
 	checkPrerequisites()
 
+	var cleanupFns []func()
+
 	registryURL = os.Getenv("ARCTL_API_BASE_URL")
 	if IsK8sBackend() {
-		registryURL = discoverRegistryURL()
+		var cleanup func()
+		registryURL, cleanup = resolveRegistryURL()
+		cleanupFns = append(cleanupFns, cleanup)
 	}
 	if registryURL == "" {
 		log.Fatal("ARCTL_API_BASE_URL not set — run tests via `make test-e2e-docker` or `make test-e2e-k8s`")
@@ -46,14 +52,20 @@ func TestMain(m *testing.M) {
 		log.Printf("  Cluster:            %s (context: %s)", e2eClusterName, e2eKubeContext)
 	}
 
-	os.Exit(m.Run())
+	code := m.Run()
+	for i := len(cleanupFns) - 1; i >= 0; i-- {
+		cleanupFns[i]()
+	}
+	os.Exit(code)
 }
 
-// discoverRegistryURL resolves the registry URL from the LoadBalancer IP
-// assigned to the agentregistry service in the Kind cluster.
-func discoverRegistryURL() string {
+// resolveRegistryURL waits for the agentregistry LoadBalancer service to get an IP,
+// then returns the registry URL and a cleanup function. On macOS, MetalLB IPs are
+// not routable from the Docker Desktop host, so it falls back to a kubectl port-forward.
+func resolveRegistryURL() (string, func()) {
 	const timeout = 2 * time.Minute
 	const pollInterval = 3 * time.Second
+	const servicePort = 12121
 
 	var ip string
 	var lastErr error
@@ -66,7 +78,6 @@ func discoverRegistryURL() string {
 			lastErr = pollErr
 			return false, nil
 		}
-
 		ip = strings.TrimSpace(string(out))
 		return ip != "", nil
 	})
@@ -78,7 +89,62 @@ func discoverRegistryURL() string {
 		log.Fatalf("LoadBalancer IP not assigned to agentregistry service within %s — is MetalLB running?", timeout)
 	}
 
-	return fmt.Sprintf("http://%s:12121/v0", ip)
+	if runtime.GOOS == "darwin" {
+		log.Printf("macOS: LoadBalancer IP %s not routable from host — using port-forward", ip)
+		return startPortForward(servicePort)
+	}
+	return fmt.Sprintf("http://%s:%d/v0", ip, servicePort), func() {}
+}
+
+// startPortForward tunnels the agentregistry service to localhost so that tests
+// can reach it when the MetalLB IP is not routable from the host (macOS + Docker Desktop).
+// Returns the localhost URL once the forward is ready, and a stop function.
+func startPortForward(servicePort int) (string, func()) {
+	const localPort = 18121 // arbitrary local port; must not conflict with other services
+	const pollInterval = 500 * time.Millisecond
+	const readyTimeout = 30 * time.Second
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cmd := exec.CommandContext(ctx, "kubectl",
+		"--context", e2eKubeContext,
+		"-n", "agentregistry",
+		"port-forward",
+		"svc/agentregistry",
+		fmt.Sprintf("%d:%d", localPort, servicePort),
+	)
+	cmd.Stdout = io.Discard
+	cmd.Stderr = io.Discard
+	if err := cmd.Start(); err != nil {
+		cancel()
+		log.Fatalf("Failed to start kubectl port-forward: %v", err)
+	}
+	log.Printf("Port-forward started (pid %d): localhost:%d → agentregistry:%d", cmd.Process.Pid, localPort, servicePort)
+
+	stop := func() {
+		cancel()
+		if cmd.Process != nil {
+			cmd.Process.Kill() //nolint:errcheck
+		}
+		_ = cmd.Wait()
+	}
+
+	localURL := fmt.Sprintf("http://localhost:%d/v0", localPort)
+	client := &http.Client{Timeout: 2 * time.Second}
+
+	if err := wait.PollUntilContextTimeout(ctx, pollInterval, readyTimeout, true, func(_ context.Context) (bool, error) {
+		resp, err := client.Get(localURL)
+		if err != nil {
+			return false, nil
+		}
+		resp.Body.Close()
+		return true, nil
+	}); err != nil {
+		stop()
+		log.Fatalf("Port-forward did not become ready within %v at %s", readyTimeout, localURL)
+	}
+
+	log.Printf("Port-forward ready: %s", localURL)
+	return localURL, stop
 }
 
 // checkPrerequisites verifies required tools are available.

--- a/examples/declarative/agent.yaml
+++ b/examples/declarative/agent.yaml
@@ -7,7 +7,7 @@ spec:
   image: ghcr.io/acme/summarizer:v1.0.0
   language: python
   framework: adk
-  modelProvider: Gemini         # OpenAI | Anthropic | Gemini | AzureOpenAI | Agentgateway
+  modelProvider: gemini         # OpenAI | Anthropic | Gemini | AzureOpenAI | Agentgateway
   modelName: gemini-2.0-flash
   description: "An agent that summarizes documents"
   # repository:                 # optional: link to source code

--- a/examples/declarative/agent.yaml
+++ b/examples/declarative/agent.yaml
@@ -1,0 +1,16 @@
+apiVersion: ar.dev/v1alpha1
+kind: Agent
+metadata:
+  name: summarizer
+  version: "1.0.0"
+spec:
+  image: ghcr.io/acme/summarizer:v1.0.0
+  language: python
+  framework: adk
+  modelProvider: Gemini         # OpenAI | Anthropic | Gemini | AzureOpenAI | Agentgateway
+  modelName: gemini-2.0-flash
+  description: "An agent that summarizes documents"
+  # repository:                 # optional: link to source code
+  #   url: https://github.com/acme/summarizer
+  #   source: github            # github | gitlab | bitbucket
+  # See full-stack.yaml for an agent with mcpServers, skills, and prompts references.

--- a/examples/declarative/full-stack.yaml
+++ b/examples/declarative/full-stack.yaml
@@ -53,7 +53,7 @@ spec:
   image: ghcr.io/acme/summarizer:v1.0.0
   language: python
   framework: adk
-  modelProvider: Gemini
+  modelProvider: gemini
   modelName: gemini-2.0-flash
   description: "An agent that summarizes documents using Gemini"
   mcpServers:

--- a/examples/declarative/full-stack.yaml
+++ b/examples/declarative/full-stack.yaml
@@ -1,0 +1,74 @@
+# full-stack.yaml
+#
+# A single file defining an agent and all its dependencies.
+# Apply with: arctl apply -f full-stack.yaml
+#
+# Resources are applied in document order, so define dependencies first:
+#   1. MCP servers and skills the agent references
+#   2. Prompts the agent uses
+#   3. The agent itself
+---
+apiVersion: ar.dev/v1alpha1
+kind: MCPServer
+metadata:
+  name: acme/fetch
+  version: "1.0.0"
+spec:
+  title: Fetch Server
+  description: "Fetches and extracts content from URLs"
+  packages:
+    - registryType: oci
+      identifier: ghcr.io/acme/fetch:1.0.0     # version goes in the image tag for OCI
+      runtimeHint: docker
+      transport:
+        type: stdio
+---
+apiVersion: ar.dev/v1alpha1
+kind: Skill
+metadata:
+  name: summarize
+  version: "1.0.0"
+spec:
+  title: Summarization
+  category: nlp
+  description: "Summarizes long text into concise form"
+---
+apiVersion: ar.dev/v1alpha1
+kind: Prompt
+metadata:
+  name: summarizer-system-prompt
+  version: "1.0.0"
+spec:
+  description: "Default system prompt for summarization agents"
+  content: |
+    You are a document summarization assistant.
+    Keep summaries concise and accurate.
+---
+apiVersion: ar.dev/v1alpha1
+kind: Agent
+metadata:
+  name: summarizer
+  version: "1.0.0"
+spec:
+  image: ghcr.io/acme/summarizer:v1.0.0
+  language: python
+  framework: adk
+  modelProvider: Gemini
+  modelName: gemini-2.0-flash
+  description: "An agent that summarizes documents using Gemini"
+  mcpServers:
+    - type: registry
+      name: fetch
+      registryURL: http://127.0.0.1:12121      # override with ARCTL_API_BASE_URL
+      registryServerName: acme/fetch
+      registryServerVersion: "1.0.0"
+  skills:
+    - name: summarize
+      registryURL: http://127.0.0.1:12121
+      registrySkillName: summarize
+      registrySkillVersion: "1.0.0"
+  prompts:
+    - name: summarizer-system-prompt
+      registryURL: http://127.0.0.1:12121
+      registryPromptName: summarizer-system-prompt
+      registryPromptVersion: "1.0.0"

--- a/examples/declarative/mcp-remote.yaml
+++ b/examples/declarative/mcp-remote.yaml
@@ -1,0 +1,14 @@
+apiVersion: ar.dev/v1alpha1
+kind: MCPServer
+metadata:
+  name: com.databricks.cloud.workspace/unity-catalog
+  version: "1.0.0"
+spec:
+  title: Databricks Unity Catalog
+  description: "Pre-deployed Unity Catalog MCP server"
+  remotes:
+    - type: streamable-http                     # stdio | sse | streamable-http
+      url: https://workspace.cloud.databricks.com/mcp
+      # headers:                                # optional: HTTP headers (e.g. auth tokens)
+      #   - name: Authorization
+      #     value: Bearer {token}

--- a/examples/declarative/mcp.yaml
+++ b/examples/declarative/mcp.yaml
@@ -1,0 +1,14 @@
+apiVersion: ar.dev/v1alpha1
+kind: MCPServer
+metadata:
+  name: acme/fetch
+  version: "1.0.0"
+spec:
+  title: Fetch Server
+  description: "Fetches and extracts content from URLs"
+  packages:
+    - registryType: oci
+      identifier: ghcr.io/acme/fetch:1.0.0     # version goes in the image tag for OCI
+      runtimeHint: docker                       # optional: hint for local runtime
+      transport:
+        type: stdio                             # stdio | sse | streamable-http

--- a/examples/declarative/prompt.yaml
+++ b/examples/declarative/prompt.yaml
@@ -1,0 +1,16 @@
+apiVersion: ar.dev/v1alpha1
+kind: Prompt
+metadata:
+  name: summarizer-system-prompt
+  version: "1.0.0"
+spec:
+  description: "Default system prompt for summarization agents"
+  content: |
+    You are a document summarization assistant. Given a document,
+    produce a concise summary that captures the key points.
+
+    Guidelines:
+    - Keep summaries under 200 words
+    - Preserve factual accuracy
+    - Use bullet points for lists of 3+ items
+    - Highlight any action items or deadlines

--- a/examples/declarative/skill.yaml
+++ b/examples/declarative/skill.yaml
@@ -1,0 +1,15 @@
+apiVersion: ar.dev/v1alpha1
+kind: Skill
+metadata:
+  name: summarize
+  version: "1.0.0"
+spec:
+  title: Summarization
+  category: nlp
+  description: "Summarizes long text into concise form"
+  packages:
+    - registryType: docker
+      identifier: ghcr.io/acme/summarize-skill:1.0.0
+      version: "1.0.0"
+      transport:
+        type: stdio                             # docker containers communicate via stdio

--- a/internal/cli/agent/tui/mcp_wizard.go
+++ b/internal/cli/agent/tui/mcp_wizard.go
@@ -1353,7 +1353,7 @@ func (w *McpServerWizard) renderRegistryEnvStep() string {
 					displayValue = v[:7] + "***"
 				}
 			}
-			sb.WriteString(fmt.Sprintf("  • %s=%s\n", k, displayValue))
+			fmt.Fprintf(&sb, "  • %s=%s\n", k, displayValue)
 		}
 		sb.WriteString("\n")
 	}
@@ -1391,7 +1391,7 @@ func (w *McpServerWizard) renderHeadersStep() string {
 					displayValue = v[:7] + "***"
 				}
 			}
-			sb.WriteString(fmt.Sprintf("  • %s: %s\n", k, displayValue))
+			fmt.Fprintf(&sb, "  • %s: %s\n", k, displayValue)
 		}
 		sb.WriteString("\n")
 	}

--- a/internal/cli/declarative/apply.go
+++ b/internal/cli/declarative/apply.go
@@ -85,10 +85,13 @@ func runApply(cmd *cobra.Command, _ []string) error {
 		allResources = append(allResources, resources...)
 	}
 
-	// 2. Validate all kinds before any API call.
+	// 2. Validate all kinds and required fields before any API call.
 	for _, r := range allResources {
 		if _, err := resource.Lookup(r.Kind); err != nil {
 			return err
+		}
+		if r.Metadata.Version == "" {
+			return fmt.Errorf("%s/%s: metadata.version is required", r.Kind, r.Metadata.Name)
 		}
 	}
 

--- a/internal/cli/declarative/apply.go
+++ b/internal/cli/declarative/apply.go
@@ -1,0 +1,123 @@
+package declarative
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/agentregistry-dev/agentregistry/internal/cli/resource"
+	"github.com/agentregistry-dev/agentregistry/internal/cli/scheme"
+	"github.com/spf13/cobra"
+)
+
+// ApplyCmd is the cobra command for "apply". It is initialized by newApplyCmd.
+// Tests should use NewApplyCmd() to obtain a fresh command instance.
+var ApplyCmd = newApplyCmd()
+
+// NewApplyCmd returns a new "apply" cobra command. Each call creates an
+// independent command with its own flag state, which is required for testing
+// since cobra's StringArray flags accumulate across Execute() calls on the
+// same command instance.
+func NewApplyCmd() *cobra.Command {
+	return newApplyCmd()
+}
+
+func newApplyCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "apply -f FILE",
+		Short: "Create or update registry resources from YAML files",
+		Long: `Apply declarative YAML files to the registry.
+
+Each file may contain one or more resources separated by ---. Supported kinds:
+  Agent, MCPServer, Skill, Prompt
+
+Examples:
+  arctl apply -f agent.yaml
+  arctl apply -f stack.yaml --dry-run
+  arctl apply -f agent.yaml -f mcpserver.yaml --overwrite
+  cat stack.yaml | arctl apply -f -`,
+		SilenceUsage: true,
+		RunE:         runApply,
+	}
+	cmd.Flags().StringArrayP("filename", "f", nil,
+		"YAML file to apply (repeatable; use - for stdin)")
+	_ = cmd.MarkFlagRequired("filename")
+	cmd.Flags().Bool("dry-run", false,
+		"Preview what would be applied without making API calls")
+	cmd.Flags().Bool("overwrite", false,
+		"Overwrite an existing resource version")
+	return cmd
+}
+
+func runApply(cmd *cobra.Command, _ []string) error {
+	filePaths, err := cmd.Flags().GetStringArray("filename")
+	if err != nil {
+		return fmt.Errorf("getting filename flag: %w", err)
+	}
+	dryRun, err := cmd.Flags().GetBool("dry-run")
+	if err != nil {
+		return fmt.Errorf("getting dry-run flag: %w", err)
+	}
+	overwrite, err := cmd.Flags().GetBool("overwrite")
+	if err != nil {
+		return fmt.Errorf("getting overwrite flag: %w", err)
+	}
+
+	// 1. Parse all input files into resources.
+	var allResources []*scheme.Resource
+	for _, path := range filePaths {
+		var resources []*scheme.Resource
+		var readErr error
+
+		if path == "-" {
+			data, ioErr := io.ReadAll(os.Stdin)
+			if ioErr != nil {
+				return fmt.Errorf("reading stdin: %w", ioErr)
+			}
+			resources, readErr = scheme.DecodeBytes(data)
+		} else {
+			resources, readErr = scheme.DecodeFile(path)
+		}
+		if readErr != nil {
+			return fmt.Errorf("file %s: %w", path, readErr)
+		}
+		allResources = append(allResources, resources...)
+	}
+
+	// 2. Validate all kinds before any API call.
+	for _, r := range allResources {
+		if _, err := resource.Lookup(r.Kind); err != nil {
+			return err
+		}
+	}
+
+	// 3. Dry-run: just print what would happen.
+	if dryRun {
+		for _, r := range allResources {
+			fmt.Fprintf(cmd.OutOrStdout(), "[dry-run] would apply %s/%s\n", strings.ToLower(r.Kind), r.Metadata.Name)
+		}
+		return nil
+	}
+
+	// 4. Apply each resource; continue on error (kubectl-style).
+	if apiClient == nil {
+		return fmt.Errorf("API client not initialized")
+	}
+
+	var errCount int
+	for _, r := range allResources {
+		h, _ := resource.Lookup(r.Kind) // already validated above
+		if err := h.Apply(apiClient, r, overwrite); err != nil {
+			fmt.Fprintf(cmd.ErrOrStderr(), "Error: %s/%s: %v\n", strings.ToLower(r.Kind), r.Metadata.Name, err)
+			errCount++
+			continue
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "%s/%s applied\n", strings.ToLower(r.Kind), r.Metadata.Name)
+	}
+
+	if errCount > 0 {
+		return fmt.Errorf("%d resource(s) failed to apply", errCount)
+	}
+	return nil
+}

--- a/internal/cli/declarative/apply_test.go
+++ b/internal/cli/declarative/apply_test.go
@@ -1,0 +1,109 @@
+package declarative_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/agentregistry-dev/agentregistry/internal/cli/declarative"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestApplyCmd_DryRun(t *testing.T) {
+	dir := t.TempDir()
+	yamlPath := filepath.Join(dir, "test.yaml")
+	err := os.WriteFile(yamlPath, []byte(`
+apiVersion: ar.dev/v1alpha1
+kind: Agent
+metadata:
+  name: acme/bot
+  version: "1.0.0"
+spec:
+  image: ghcr.io/acme/bot:latest
+  description: "A bot"
+  language: python
+  framework: adk
+  modelProvider: google
+  modelName: gemini-2.0-flash
+`), 0644)
+	require.NoError(t, err)
+
+	declarative.SetAPIClient(nil)
+
+	var buf bytes.Buffer
+	cmd := declarative.NewApplyCmd()
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{"-f", yamlPath, "--dry-run"})
+	err = cmd.Execute()
+	require.NoError(t, err)
+	output := buf.String()
+	assert.Contains(t, output, "[dry-run]")
+	assert.Contains(t, output, "agent/acme/bot")
+}
+
+func TestApplyCmd_RejectsUnknownKind(t *testing.T) {
+	dir := t.TempDir()
+	yamlPath := filepath.Join(dir, "bad.yaml")
+	err := os.WriteFile(yamlPath, []byte(`
+apiVersion: ar.dev/v1alpha1
+kind: UnknownKind
+metadata:
+  name: acme/test
+  version: "1.0.0"
+spec:
+  description: "test"
+`), 0644)
+	require.NoError(t, err)
+
+	declarative.SetAPIClient(nil)
+	cmd := declarative.NewApplyCmd()
+	cmd.SetArgs([]string{"-f", yamlPath, "--dry-run"})
+	err = cmd.Execute()
+	require.Error(t, err)
+	assert.True(t, strings.Contains(err.Error(), "unknown resource type") ||
+		strings.Contains(err.Error(), "UnknownKind"))
+}
+
+func TestApplyCmd_RejectsInvalidYAML(t *testing.T) {
+	dir := t.TempDir()
+	yamlPath := filepath.Join(dir, "invalid.yaml")
+	err := os.WriteFile(yamlPath, []byte(`not: valid: yaml: [[[`), 0644)
+	require.NoError(t, err)
+
+	declarative.SetAPIClient(nil)
+	cmd := declarative.NewApplyCmd()
+	cmd.SetArgs([]string{"-f", yamlPath, "--dry-run"})
+	err = cmd.Execute()
+	require.Error(t, err)
+}
+
+func TestApplyCmd_NoAPIClientWithoutDryRun(t *testing.T) {
+	dir := t.TempDir()
+	yamlPath := filepath.Join(dir, "test.yaml")
+	err := os.WriteFile(yamlPath, []byte(`
+apiVersion: ar.dev/v1alpha1
+kind: Agent
+metadata:
+  name: acme/bot
+  version: "1.0.0"
+spec:
+  description: "A bot"
+  image: ghcr.io/acme/bot:latest
+  language: python
+  framework: adk
+  modelProvider: google
+  modelName: gemini-2.0-flash
+`), 0644)
+	require.NoError(t, err)
+
+	declarative.SetAPIClient(nil)
+	cmd := declarative.NewApplyCmd()
+	cmd.SetArgs([]string{"-f", yamlPath})
+	err = cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "API client not initialized")
+}

--- a/internal/cli/declarative/build.go
+++ b/internal/cli/declarative/build.go
@@ -1,0 +1,250 @@
+package declarative
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/agentregistry-dev/agentregistry/internal/cli/common/docker"
+	mcpbuild "github.com/agentregistry-dev/agentregistry/internal/cli/mcp/build"
+	"github.com/agentregistry-dev/agentregistry/internal/cli/scheme"
+	"github.com/agentregistry-dev/agentregistry/internal/version"
+	"github.com/spf13/cobra"
+)
+
+// BuildCmd is the cobra command for "build".
+// Tests should use NewBuildCmd() for a fresh instance.
+var BuildCmd = newBuildCmd()
+
+// NewBuildCmd returns a new "build" cobra command.
+func NewBuildCmd() *cobra.Command {
+	return newBuildCmd()
+}
+
+func newBuildCmd() *cobra.Command {
+	var (
+		buildImage    string
+		buildPush     bool
+		buildPlatform string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "build DIRECTORY",
+		Short: "Build a Docker image for a declarative resource project",
+		Long: `Build the Docker image for a project created with 'arctl init'.
+
+Reads the declarative YAML file in the project directory (agent.yaml, mcp.yaml,
+or skill.yaml) to determine the resource kind and image tag, then runs docker build.
+
+Supported kinds: Agent, MCPServer, Skill
+
+Examples:
+  arctl build ./my-agent
+  arctl build ./my-server --push
+  arctl build ./my-skill  --image ghcr.io/acme/my-skill:v1.0.0 --platform linux/amd64`,
+		Args:         cobra.ExactArgs(1),
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			projectDir, err := filepath.Abs(args[0])
+			if err != nil {
+				return fmt.Errorf("resolving project directory: %w", err)
+			}
+			info, err := os.Stat(projectDir)
+			if err != nil {
+				return fmt.Errorf("project directory not found: %s", projectDir)
+			}
+			if !info.IsDir() {
+				return fmt.Errorf("expected a project directory, not a file — try: arctl build ./my-project")
+			}
+
+			r, yamlFile, err := findDeclarativeResource(projectDir)
+			if err != nil {
+				return err
+			}
+
+			out := cmd.OutOrStdout()
+			switch r.Kind {
+			case "Agent":
+				return buildAgent(out, projectDir, r, buildImage, buildPlatform, buildPush)
+			case "MCPServer":
+				return buildMCPServer(out, projectDir, r, buildImage, buildPlatform, buildPush)
+			case "Skill":
+				return buildSkill(out, projectDir, r, buildImage, buildPlatform, buildPush)
+			case "Prompt":
+				return fmt.Errorf("prompts have no build step — use 'arctl apply -f %s' directly", yamlFile)
+			default:
+				return fmt.Errorf("unknown kind %q in %s", r.Kind, yamlFile)
+			}
+		},
+	}
+
+	cmd.Flags().StringVar(&buildImage, "image", "", "Docker image tag override (default: from spec.image / spec.packages[0].identifier)")
+	cmd.Flags().BoolVar(&buildPush, "push", false, "Push the image after building")
+	cmd.Flags().StringVar(&buildPlatform, "platform", "", "Target platform (e.g. linux/amd64, linux/arm64)")
+
+	return cmd
+}
+
+// findDeclarativeResource looks for a known declarative YAML file in the
+// project directory and returns the parsed resource and file name found.
+func findDeclarativeResource(projectDir string) (*scheme.Resource, string, error) {
+	candidates := []string{"agent.yaml", "mcp.yaml", "skill.yaml", "prompt.yaml"}
+	for _, name := range candidates {
+		path := filepath.Join(projectDir, name)
+		if _, err := os.Stat(path); err != nil {
+			continue
+		}
+		resources, err := scheme.DecodeFile(path)
+		if err != nil {
+			return nil, name, fmt.Errorf("parsing %s: %w", name, err)
+		}
+		if len(resources) == 0 {
+			continue
+		}
+		return resources[0], name, nil
+	}
+	return nil, "", fmt.Errorf(
+		"no declarative YAML found in %s (expected agent.yaml, mcp.yaml, skill.yaml, or prompt.yaml)",
+		projectDir,
+	)
+}
+
+// defaultImage returns registry/name:latest as a fallback image tag.
+func defaultImage(name string) string {
+	registry := strings.TrimSuffix(version.DockerRegistry, "/")
+	if registry == "" {
+		registry = "localhost:5001"
+	}
+	return fmt.Sprintf("%s/%s:latest", registry, name)
+}
+
+// resolveImage returns the image to use, in priority order:
+//  1. --image flag
+//  2. specImage (from spec.image or spec.packages[0].identifier)
+//  3. default registry/name:latest
+func resolveImage(flagImage, specImage, name string) string {
+	if flagImage != "" {
+		return flagImage
+	}
+	if specImage != "" {
+		return specImage
+	}
+	return defaultImage(name)
+}
+
+// specString extracts a string field from the resource spec.
+func specString(r *scheme.Resource, key string) string {
+	if v, ok := r.Spec[key].(string); ok {
+		return v
+	}
+	return ""
+}
+
+// specPackageIdentifier extracts spec.packages[0].identifier for MCPServer / Skill.
+func specPackageIdentifier(r *scheme.Resource) string {
+	pkgs, ok := r.Spec["packages"].([]any)
+	if !ok || len(pkgs) == 0 {
+		return ""
+	}
+	pkg, ok := pkgs[0].(map[string]any)
+	if !ok {
+		return ""
+	}
+	id, _ := pkg["identifier"].(string)
+	return id
+}
+
+func buildAgent(out io.Writer, projectDir string, r *scheme.Resource, flagImage, platform string, push bool) error {
+	dockerfilePath := filepath.Join(projectDir, "Dockerfile")
+	if _, err := os.Stat(dockerfilePath); err != nil {
+		return fmt.Errorf("dockerfile not found in %s", projectDir)
+	}
+
+	image := resolveImage(flagImage, specString(r, "image"), r.Metadata.Name)
+
+	exec := docker.NewExecutor(false, projectDir)
+	if err := exec.CheckAvailability(); err != nil {
+		return fmt.Errorf("docker check failed: %w", err)
+	}
+
+	var extraArgs []string
+	if platform != "" {
+		extraArgs = append(extraArgs, "--platform", platform)
+	}
+
+	fmt.Fprintf(out, "Building agent image: %s\n", image)
+	if err := exec.Build(image, ".", extraArgs...); err != nil {
+		return err
+	}
+	if push {
+		return exec.Push(image)
+	}
+	return nil
+}
+
+func buildMCPServer(out io.Writer, projectDir string, r *scheme.Resource, flagImage, platform string, push bool) error {
+	image := resolveImage(flagImage, specPackageIdentifier(r), r.Metadata.Name)
+
+	fmt.Fprintf(out, "Building MCP server image: %s\n", image)
+	builder := mcpbuild.New()
+	if err := builder.Build(mcpbuild.Options{
+		ProjectDir: projectDir,
+		Tag:        image,
+		Platform:   platform,
+	}); err != nil {
+		return err
+	}
+	if push {
+		exec := docker.NewExecutor(false, "")
+		return exec.Push(image)
+	}
+	return nil
+}
+
+// CheckDockerAvailable returns nil if docker is reachable, or an error.
+// Exported for use in tests.
+func CheckDockerAvailable() error {
+	return docker.NewExecutor(false, "").CheckAvailability()
+}
+
+// skillDockerfile packages skill assets into a minimal OCI image.
+// Skills are metadata-only containers (no runtime); FROM scratch is intentional —
+// there is no entrypoint or shell, just the raw files copied in.
+const skillDockerfile = "FROM scratch\nCOPY . .\n"
+
+func buildSkill(out io.Writer, projectDir string, r *scheme.Resource, flagImage, platform string, push bool) error {
+	image := resolveImage(flagImage, specPackageIdentifier(r), r.Metadata.Name)
+
+	fmt.Fprintf(out, "Building skill image: %s\n", image)
+
+	tmpFile, err := os.CreateTemp("", "skill-dockerfile-*")
+	if err != nil {
+		return fmt.Errorf("creating temp Dockerfile: %w", err)
+	}
+	defer os.Remove(tmpFile.Name())
+	if _, err := tmpFile.WriteString(skillDockerfile); err != nil {
+		tmpFile.Close()
+		return fmt.Errorf("writing temp Dockerfile: %w", err)
+	}
+	tmpFile.Close()
+
+	var extraArgs []string
+	extraArgs = append(extraArgs, "-f", tmpFile.Name())
+	if platform != "" {
+		extraArgs = append(extraArgs, "--platform", platform)
+	}
+
+	exec := docker.NewExecutor(false, projectDir)
+	if err := exec.CheckAvailability(); err != nil {
+		return fmt.Errorf("docker check failed: %w", err)
+	}
+	if err := exec.Build(image, projectDir, extraArgs...); err != nil {
+		return err
+	}
+	if push {
+		return exec.Push(image)
+	}
+	return nil
+}

--- a/internal/cli/declarative/build_test.go
+++ b/internal/cli/declarative/build_test.go
@@ -1,0 +1,210 @@
+package declarative_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/agentregistry-dev/agentregistry/internal/cli/declarative"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeBuildYAML writes a declarative YAML fixture to a project directory.
+func writeBuildYAML(t *testing.T, projectDir, filename, content string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(projectDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(projectDir, filename), []byte(content), 0o644))
+}
+
+// writeDockerfile writes a minimal Dockerfile so docker build checks pass in tests.
+func writeDockerfile(t *testing.T, projectDir string) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(filepath.Join(projectDir, "Dockerfile"), []byte("FROM scratch\n"), 0o644))
+}
+
+// TestBuildCmd_NoDirectory verifies the command fails when the directory doesn't exist.
+func TestBuildCmd_NoDirectory(t *testing.T) {
+	cmd := declarative.NewBuildCmd()
+	cmd.SetArgs([]string{"/tmp/nonexistent-declarative-build-dir-xyz"})
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+// TestBuildCmd_FileInsteadOfDirectory verifies the command fails with a helpful error
+// when a YAML file is passed instead of a project directory.
+func TestBuildCmd_FileInsteadOfDirectory(t *testing.T) {
+	tmpDir := t.TempDir()
+	yamlFile := filepath.Join(tmpDir, "my-prompt.yaml")
+	require.NoError(t, os.WriteFile(yamlFile, []byte("apiVersion: ar.dev/v1alpha1\nkind: Prompt\n"), 0o644))
+
+	cmd := declarative.NewBuildCmd()
+	cmd.SetArgs([]string{yamlFile})
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "expected a project directory, not a file")
+}
+
+// TestBuildCmd_SkillFileInsteadOfDirectory verifies the same helpful error for skill YAML files.
+func TestBuildCmd_SkillFileInsteadOfDirectory(t *testing.T) {
+	tmpDir := t.TempDir()
+	yamlFile := filepath.Join(tmpDir, "my-skill.yaml")
+	require.NoError(t, os.WriteFile(yamlFile, []byte("apiVersion: ar.dev/v1alpha1\nkind: Skill\n"), 0o644))
+
+	cmd := declarative.NewBuildCmd()
+	cmd.SetArgs([]string{yamlFile})
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "expected a project directory, not a file")
+}
+
+// TestBuildCmd_NoYAML verifies the command fails when no declarative YAML is present.
+func TestBuildCmd_NoYAML(t *testing.T) {
+	tmpDir := t.TempDir()
+	cmd := declarative.NewBuildCmd()
+	cmd.SetArgs([]string{tmpDir})
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no declarative YAML found")
+}
+
+// TestBuildCmd_PromptKindError verifies that building a Prompt returns a helpful error.
+func TestBuildCmd_PromptKindError(t *testing.T) {
+	tmpDir := t.TempDir()
+	writeBuildYAML(t, tmpDir, "prompt.yaml", `
+apiVersion: ar.dev/v1alpha1
+kind: Prompt
+metadata:
+  name: my-prompt
+  version: 0.1.0
+spec:
+  description: A test prompt
+  content: You are a helpful assistant.
+`)
+
+	cmd := declarative.NewBuildCmd()
+	cmd.SetArgs([]string{tmpDir})
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "prompts have no build step")
+}
+
+// TestBuildCmd_UnknownKindError verifies that an unknown kind returns an error.
+func TestBuildCmd_UnknownKindError(t *testing.T) {
+	tmpDir := t.TempDir()
+	writeBuildYAML(t, tmpDir, "agent.yaml", `
+apiVersion: ar.dev/v1alpha1
+kind: BogusKind
+metadata:
+  name: my-thing
+  version: 0.1.0
+spec:
+  description: Unknown
+`)
+
+	cmd := declarative.NewBuildCmd()
+	cmd.SetArgs([]string{tmpDir})
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown kind")
+}
+
+// TestBuildCmd_AgentMissingDockerfile verifies a clear error when Dockerfile is absent.
+func TestBuildCmd_AgentMissingDockerfile(t *testing.T) {
+	tmpDir := t.TempDir()
+	writeBuildYAML(t, tmpDir, "agent.yaml", `
+apiVersion: ar.dev/v1alpha1
+kind: Agent
+metadata:
+  name: my-agent
+  version: 0.1.0
+spec:
+  image: localhost:5001/my-agent:latest
+  language: python
+  framework: adk
+  modelProvider: gemini
+  modelName: gemini-2.0-flash
+  description: test agent
+`)
+	// No Dockerfile written — should fail with a clear message.
+	cmd := declarative.NewBuildCmd()
+	cmd.SetArgs([]string{tmpDir})
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "dockerfile not found")
+}
+
+// TestBuildCmd_YAMLPrecedence verifies agent.yaml is preferred over mcp.yaml when both exist.
+func TestBuildCmd_YAMLPrecedence(t *testing.T) {
+	tmpDir := t.TempDir()
+	// Write both files; agent.yaml should be found first.
+	writeBuildYAML(t, tmpDir, "agent.yaml", `
+apiVersion: ar.dev/v1alpha1
+kind: Agent
+metadata:
+  name: my-agent
+  version: 0.1.0
+spec:
+  image: localhost:5001/my-agent:latest
+  language: python
+  framework: adk
+  modelProvider: gemini
+  modelName: gemini-2.0-flash
+  description: test agent
+`)
+	writeBuildYAML(t, tmpDir, "mcp.yaml", `
+apiVersion: ar.dev/v1alpha1
+kind: MCPServer
+metadata:
+  name: my-server
+  version: 0.1.0
+spec:
+  title: my-server
+  description: test server
+`)
+	// No Dockerfile — the error is agent-specific (dockerfile not found), confirming
+	// agent.yaml was selected over mcp.yaml.
+	cmd := declarative.NewBuildCmd()
+	cmd.SetArgs([]string{tmpDir})
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "dockerfile not found")
+}
+
+// TestBuildCmd_AgentDockerNotAvailable verifies a clear error when Docker is not found.
+// This test only runs when docker is not in PATH (CI environments without Docker).
+func TestBuildCmd_AgentDockerNotAvailable(t *testing.T) {
+	// Only meaningful in environments without Docker — skip if Docker is present.
+	if isDockerAvailable() {
+		t.Skip("Docker is available; skipping no-docker error test")
+	}
+
+	tmpDir := t.TempDir()
+	writeBuildYAML(t, tmpDir, "agent.yaml", `
+apiVersion: ar.dev/v1alpha1
+kind: Agent
+metadata:
+  name: my-agent
+  version: 0.1.0
+spec:
+  image: localhost:5001/my-agent:latest
+  language: python
+  framework: adk
+  modelProvider: gemini
+  modelName: gemini-2.0-flash
+  description: test agent
+`)
+	writeDockerfile(t, tmpDir)
+
+	cmd := declarative.NewBuildCmd()
+	cmd.SetArgs([]string{tmpDir})
+	err := cmd.Execute()
+	require.Error(t, err)
+}
+
+// isDockerAvailable checks if the docker CLI is present and daemon is reachable.
+func isDockerAvailable() bool {
+	cmd := declarative.CheckDockerAvailable()
+	return cmd == nil
+}

--- a/internal/cli/declarative/declarative.go
+++ b/internal/cli/declarative/declarative.go
@@ -1,0 +1,16 @@
+package declarative
+
+import (
+	"github.com/agentregistry-dev/agentregistry/internal/client"
+
+	// Trigger init() registrations for all resource handlers.
+	_ "github.com/agentregistry-dev/agentregistry/internal/cli/resource"
+)
+
+var apiClient *client.Client
+
+// SetAPIClient sets the API client used by all declarative commands.
+// Called by pkg/cli/root.go's PersistentPreRunE.
+func SetAPIClient(c *client.Client) {
+	apiClient = c
+}

--- a/internal/cli/declarative/delete.go
+++ b/internal/cli/declarative/delete.go
@@ -65,7 +65,7 @@ func runDeclarativeDelete(cmd *cobra.Command, args []string) error {
 func deleteFromFile(cmd *cobra.Command, filename string) error {
 	resources, err := scheme.DecodeFile(filename)
 	if err != nil {
-		return fmt.Errorf("reading %s: %w", filename, err)
+		return fmt.Errorf("decoding %s: %w", filename, err)
 	}
 
 	errCount := 0

--- a/internal/cli/declarative/delete.go
+++ b/internal/cli/declarative/delete.go
@@ -1,0 +1,113 @@
+package declarative
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/agentregistry-dev/agentregistry/internal/cli/resource"
+	"github.com/agentregistry-dev/agentregistry/internal/cli/scheme"
+	"github.com/spf13/cobra"
+)
+
+// DeleteCmd is the cobra command for "delete".
+// Tests should use NewDeleteCmd() for a fresh instance.
+var DeleteCmd = newDeleteCmd()
+
+// NewDeleteCmd returns a new "delete" cobra command.
+func NewDeleteCmd() *cobra.Command {
+	return newDeleteCmd()
+}
+
+func newDeleteCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "delete (TYPE NAME | -f FILE)",
+		Short: "Delete a registry resource version",
+		Long: `Delete a specific version of a registry resource.
+
+File mode (declarative): reads name and version from the YAML file.
+  arctl delete -f agent.yaml
+
+Explicit mode: specify type, name, and --version directly.
+  arctl delete TYPE NAME --version VERSION
+
+TYPE must be one of: agent, mcp, skill, prompt
+(plural and uppercase forms also accepted)`,
+		Example: `  arctl delete -f my-agent/agent.yaml
+  arctl delete -f my-server/mcp.yaml
+  arctl delete agent acme/summarizer --version 1.0.0
+  arctl delete mcp acme/fetch --version 1.0.0`,
+		SilenceUsage: true,
+		RunE:         runDeclarativeDelete,
+	}
+	cmd.Flags().StringP("filename", "f", "", "YAML file to read name and version from")
+	cmd.Flags().String("version", "", "Version to delete (required in explicit mode)")
+	return cmd
+}
+
+func runDeclarativeDelete(cmd *cobra.Command, args []string) error {
+	filename, _ := cmd.Flags().GetString("filename")
+
+	if filename != "" {
+		return deleteFromFile(cmd, filename)
+	}
+
+	// Explicit mode: TYPE NAME --version VERSION
+	if len(args) != 2 {
+		return fmt.Errorf("explicit mode requires TYPE and NAME arguments (or use -f FILE)")
+	}
+	version, _ := cmd.Flags().GetString("version")
+	if version == "" {
+		return fmt.Errorf("required flag \"version\" not set (or use -f FILE to read from YAML)")
+	}
+	return deleteResource(cmd, args[0], args[1], version)
+}
+
+func deleteFromFile(cmd *cobra.Command, filename string) error {
+	resources, err := scheme.DecodeFile(filename)
+	if err != nil {
+		return fmt.Errorf("reading %s: %w", filename, err)
+	}
+
+	errCount := 0
+	for _, r := range resources {
+		if r.Metadata.Version == "" {
+			fmt.Fprintf(cmd.ErrOrStderr(), "error: %s/%s: metadata.version is required for delete\n", r.Kind, r.Metadata.Name)
+			errCount++
+			continue
+		}
+		h, err := resource.Lookup(r.Kind)
+		if err != nil {
+			fmt.Fprintf(cmd.ErrOrStderr(), "error: %v\n", err)
+			errCount++
+			continue
+		}
+		if err := deleteResource(cmd, h.Singular(), r.Metadata.Name, r.Metadata.Version); err != nil {
+			fmt.Fprintf(cmd.ErrOrStderr(), "error: %v\n", err)
+			errCount++
+		}
+	}
+	if errCount > 0 {
+		return fmt.Errorf("%d error(s) during delete", errCount)
+	}
+	return nil
+}
+
+func deleteResource(cmd *cobra.Command, typeName, name, version string) error {
+	h, err := resource.Lookup(typeName)
+	if err != nil {
+		return err
+	}
+
+	if apiClient == nil {
+		return fmt.Errorf("API client not initialized")
+	}
+
+	fmt.Fprintf(cmd.OutOrStdout(), "Deleting %s %s version %s...\n", h.Singular(), name, version)
+	if err := h.Delete(apiClient, name, version); err != nil {
+		return fmt.Errorf("failed to delete %s %q version %s: %w",
+			h.Singular(), name, version, err)
+	}
+
+	fmt.Fprintf(cmd.OutOrStdout(), "Deleted: %s/%s (%s)\n", strings.ToLower(h.Kind()), name, version)
+	return nil
+}

--- a/internal/cli/declarative/get.go
+++ b/internal/cli/declarative/get.go
@@ -1,0 +1,189 @@
+package declarative
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/agentregistry-dev/agentregistry/internal/cli/resource"
+	"github.com/agentregistry-dev/agentregistry/pkg/printer"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+)
+
+// GetCmd is the cobra command for "get".
+// Tests should use NewGetCmd() for a fresh instance.
+var GetCmd = newGetCmd()
+
+// NewGetCmd returns a new "get" cobra command.
+func NewGetCmd() *cobra.Command {
+	return newGetCmd()
+}
+
+func newGetCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "get TYPE [NAME]",
+		Short: "List or retrieve registry resources",
+		Long: `List or retrieve registry resources by type.
+
+Supported types: agents, mcps, skills, prompts
+(singular and uppercase forms also accepted, e.g. Agent, agent, agents)
+
+Examples:
+  arctl get all
+  arctl get agents
+  arctl get mcps
+  arctl get agent acme/summarizer
+  arctl get agent acme/summarizer -o yaml
+  arctl get skills -o json`,
+		Args:         cobra.RangeArgs(1, 2),
+		SilenceUsage: true,
+		RunE:         runGet,
+	}
+	cmd.Flags().StringP("output", "o", "table", "Output format: table, yaml, json")
+	return cmd
+}
+
+func runGet(cmd *cobra.Command, args []string) error {
+	outputFormat, _ := cmd.Flags().GetString("output")
+
+	if args[0] == "all" {
+		return runGetAll(cmd, outputFormat)
+	}
+
+	typeName := args[0]
+	h, err := resource.Lookup(typeName)
+	if err != nil {
+		return err
+	}
+
+	if apiClient == nil {
+		return fmt.Errorf("API client not initialized")
+	}
+
+	if len(args) == 2 {
+		name := args[1]
+		item, err := h.Get(apiClient, name)
+		if err != nil {
+			return fmt.Errorf("getting %s %q: %w", h.Singular(), name, err)
+		}
+		if item == nil {
+			fmt.Fprintf(cmd.OutOrStdout(), "%s %q not found\n", h.Singular(), name)
+			return nil
+		}
+		return printItem(cmd, h, item, outputFormat)
+	}
+
+	items, err := h.List(apiClient)
+	if err != nil {
+		return fmt.Errorf("listing %s: %w", h.Plural(), err)
+	}
+	if len(items) == 0 {
+		fmt.Fprintf(cmd.OutOrStdout(), "No %s found.\n", h.Plural())
+		return nil
+	}
+	return printItems(cmd, h, items, outputFormat)
+}
+
+func runGetAll(cmd *cobra.Command, outputFormat string) error {
+	if apiClient == nil {
+		return fmt.Errorf("API client not initialized")
+	}
+
+	handlers := resource.All()
+	first := true
+	for _, h := range handlers {
+		items, err := h.List(apiClient)
+		if err != nil {
+			fmt.Fprintf(cmd.ErrOrStderr(), "Error listing %s: %v\n", h.Plural(), err)
+			continue
+		}
+		if len(items) == 0 {
+			continue
+		}
+		if !first {
+			fmt.Fprintln(cmd.OutOrStdout())
+		}
+		first = false
+		fmt.Fprintf(cmd.OutOrStdout(), "%s\n", h.Plural())
+		if err := printItems(cmd, h, items, outputFormat); err != nil {
+			return err
+		}
+	}
+	if first {
+		fmt.Fprintln(cmd.OutOrStdout(), "No resources found.")
+	}
+	return nil
+}
+
+func printItem(cmd *cobra.Command, h resource.ResourceHandler, item any, outputFormat string) error {
+	switch outputFormat {
+	case "yaml":
+		r := h.ToResource(item)
+		if r == nil {
+			return fmt.Errorf("failed to convert %s to YAML", h.Singular())
+		}
+		return marshalYAML(cmd, r)
+	case "json":
+		return marshalJSON(cmd, item)
+	default:
+		t := printer.NewTablePrinter(cmd.OutOrStdout())
+		t.SetHeaders(h.TableColumns()...)
+		t.AddRow(stringsToAny(h.TableRow(item))...)
+		return t.Render()
+	}
+}
+
+func printItems(cmd *cobra.Command, h resource.ResourceHandler, items []any, outputFormat string) error {
+	switch outputFormat {
+	case "yaml":
+		for i, item := range items {
+			r := h.ToResource(item)
+			if r == nil {
+				continue
+			}
+			if i > 0 {
+				fmt.Fprintln(cmd.OutOrStdout(), "---")
+			}
+			if err := marshalYAML(cmd, r); err != nil {
+				return err
+			}
+		}
+		return nil
+	case "json":
+		return marshalJSON(cmd, items)
+	default:
+		t := printer.NewTablePrinter(cmd.OutOrStdout())
+		t.SetHeaders(h.TableColumns()...)
+		for _, item := range items {
+			t.AddRow(stringsToAny(h.TableRow(item))...)
+		}
+		return t.Render()
+	}
+}
+
+func stringsToAny(ss []string) []any {
+	out := make([]any, len(ss))
+	for i, s := range ss {
+		out[i] = s
+	}
+	return out
+}
+
+func marshalYAML(cmd *cobra.Command, v any) error {
+	b, err := yaml.Marshal(v)
+	if err != nil {
+		return fmt.Errorf("encoding YAML: %w", err)
+	}
+	_, err = fmt.Fprint(cmd.OutOrStdout(), strings.TrimRight(string(b), "\n")+"\n")
+	return err
+}
+
+func marshalJSON(cmd *cobra.Command, v any) error {
+	b, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encoding JSON: %w", err)
+	}
+	_, err = fmt.Fprintln(cmd.OutOrStdout(), string(b))
+	return err
+}

--- a/internal/cli/declarative/get_test.go
+++ b/internal/cli/declarative/get_test.go
@@ -1,0 +1,34 @@
+package declarative_test
+
+import (
+	"testing"
+
+	"github.com/agentregistry-dev/agentregistry/internal/cli/declarative"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetCmd_RejectsUnknownType(t *testing.T) {
+	declarative.SetAPIClient(nil)
+	cmd := declarative.NewGetCmd()
+	cmd.SetArgs([]string{"unknowntype"})
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "unknown resource type")
+}
+
+func TestGetCmd_RequiresTypeArg(t *testing.T) {
+	cmd := declarative.NewGetCmd()
+	cmd.SetArgs([]string{})
+	err := cmd.Execute()
+	assert.Error(t, err)
+}
+
+func TestGetCmd_NoAPIClientErrors(t *testing.T) {
+	declarative.SetAPIClient(nil)
+	cmd := declarative.NewGetCmd()
+	cmd.SetArgs([]string{"agents"})
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "API client not initialized")
+}

--- a/internal/cli/declarative/init.go
+++ b/internal/cli/declarative/init.go
@@ -567,12 +567,12 @@ func newInitPromptCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "prompt NAME",
-		Short: "Create a new declarative prompt.yaml",
-		Long: `Create a new prompt.yaml in the current directory using the
+		Short: "Create a new declarative <name>.yaml for a prompt",
+		Long: `Create a new <name>.yaml in the current directory using the
 ar.dev/v1alpha1 declarative format. No code scaffolding is generated.
 
-The generated prompt.yaml can be applied directly:
-  arctl apply -f prompt.yaml`,
+The generated file can be applied directly:
+  arctl apply -f my-prompt.yaml`,
 		Example: `  arctl init prompt my-prompt
   arctl init prompt my-prompt --description "System prompt for summarization"`,
 		Args:         cobra.ExactArgs(1),

--- a/internal/cli/declarative/init.go
+++ b/internal/cli/declarative/init.go
@@ -1,0 +1,638 @@
+package declarative
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	agentframeworks "github.com/agentregistry-dev/agentregistry/internal/cli/agent/frameworks"
+	agentcommon "github.com/agentregistry-dev/agentregistry/internal/cli/agent/frameworks/common"
+	agentutils "github.com/agentregistry-dev/agentregistry/internal/cli/agent/utils"
+	mcpframeworks "github.com/agentregistry-dev/agentregistry/internal/cli/mcp/frameworks"
+	mcptemplates "github.com/agentregistry-dev/agentregistry/internal/cli/mcp/templates"
+	"github.com/agentregistry-dev/agentregistry/internal/cli/scheme"
+	skilltemplates "github.com/agentregistry-dev/agentregistry/internal/cli/skill/templates"
+	"github.com/agentregistry-dev/agentregistry/internal/version"
+	"github.com/agentregistry-dev/agentregistry/pkg/validators"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+)
+
+// InitCmd is the cobra command for "init".
+// Tests should use NewInitCmd() for a fresh instance.
+var InitCmd = newInitCmd()
+
+// NewInitCmd returns a new "init" cobra command.
+func NewInitCmd() *cobra.Command {
+	return newInitCmd()
+}
+
+func newInitCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "init TYPE ...",
+		Short: "Scaffold a new resource project with declarative YAML",
+		Long: `Scaffold a new project. The generated YAML uses the ar.dev/v1alpha1
+declarative format and can be applied directly with 'arctl apply'.
+
+Supported types:
+  agent FRAMEWORK LANGUAGE NAME
+  mcp   FRAMEWORK NAME
+  skill NAME
+  prompt NAME
+
+Examples:
+  arctl init agent adk python my-agent
+  arctl init mcp fastmcp-python myorg/my-server
+  arctl init skill my-skill
+  arctl init prompt my-prompt`,
+		SilenceUsage: true,
+	}
+	cmd.AddCommand(newInitAgentCmd())
+	cmd.AddCommand(newInitMCPCmd())
+	cmd.AddCommand(newInitSkillCmd())
+	cmd.AddCommand(newInitPromptCmd())
+	return cmd
+}
+
+func newInitAgentCmd() *cobra.Command {
+	var (
+		initVersion       string
+		initDescription   string
+		initModelProvider string
+		initModelName     string
+		initImage         string
+		initGit           string
+		initMCPs          []string
+		initSkills        []string
+		initPrompts       []string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "agent FRAMEWORK LANGUAGE NAME",
+		Short: "Scaffold a new agent project with declarative agent.yaml",
+		Long: `Scaffold a new ADK Python agent project. Creates a project directory
+containing a declarative agent.yaml (ar.dev/v1alpha1), Dockerfile, and source stubs.
+
+The generated agent.yaml can be applied directly:
+  arctl apply -f NAME/agent.yaml
+
+Supported frameworks: adk
+Supported languages:  python (for adk)`,
+		Example: `  arctl init agent adk python my-agent
+  arctl init agent adk python my-agent --model-provider openai --model-name gpt-4o
+  arctl init agent adk python my-agent --git https://github.com/acme/my-agent
+  arctl init agent adk python my-agent --mcp acme/fetch@1.0.0 --skill summarize --prompt system-prompt`,
+		Args:         cobra.ExactArgs(3),
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			framework := strings.ToLower(args[0])
+			language := strings.ToLower(args[1])
+			name := args[2]
+
+			if err := validateInitFrameworkAndLanguage(framework, language); err != nil {
+				return err
+			}
+			if err := validators.ValidateAgentName(name); err != nil {
+				return fmt.Errorf("invalid agent name: %w", err)
+			}
+
+			modelProvider, err := normalizeInitModelProvider(initModelProvider)
+			if err != nil {
+				return err
+			}
+			modelName := resolveInitModelName(cmd, modelProvider, initModelName)
+
+			image := initImage
+			if image == "" {
+				registry := strings.TrimSuffix(version.DockerRegistry, "/")
+				if registry == "" {
+					registry = "localhost:5001"
+				}
+				image = fmt.Sprintf("%s/%s:latest", registry, name)
+			}
+
+			cwd, err := os.Getwd()
+			if err != nil {
+				return fmt.Errorf("getting working directory: %w", err)
+			}
+			projectDir := filepath.Join(cwd, name)
+
+			// Scaffold all code files (Dockerfile, Python source, etc.) using
+			// the existing framework generator. This also writes a flat agent.yaml
+			// which we overwrite below with the declarative format.
+			generator, err := agentframeworks.NewGenerator(framework, language)
+			if err != nil {
+				return err
+			}
+			agentConfig := &agentcommon.AgentConfig{
+				Name:                  name,
+				Version:               initVersion,
+				Description:           initDescription,
+				Image:                 image,
+				Directory:             projectDir,
+				ModelProvider:         modelProvider,
+				ModelName:             modelName,
+				Framework:             framework,
+				Language:              language,
+				KagentADKImageVersion: "0.8.0-beta6",
+				KagentADKPyVersion:    "0.8.0b6",
+				Port:                  8080,
+				InitGit:               true,
+			}
+			if err := generator.Generate(agentConfig); err != nil {
+				return err
+			}
+
+			// Overwrite agent.yaml with the declarative format.
+			if err := writeDeclarativeAgentYAML(projectDir, name, initVersion, image, language, framework, modelProvider, modelName, initDescription, initGit, initMCPs, initSkills, initPrompts); err != nil {
+				return fmt.Errorf("writing declarative agent.yaml: %w", err)
+			}
+
+			fmt.Fprintf(cmd.OutOrStdout(), "✓ Successfully created agent: %s\n", name)
+			fmt.Fprintf(cmd.OutOrStdout(), "\n🚀 Next steps:\n")
+			fmt.Fprintf(cmd.OutOrStdout(), "  1. cd %s\n", name)
+			fmt.Fprintf(cmd.OutOrStdout(), "  2. (Optional) Build and push the image if developing locally:\n")
+			fmt.Fprintf(cmd.OutOrStdout(), "     arctl build . --push\n")
+			fmt.Fprintf(cmd.OutOrStdout(), "  3. Publish the agent to the registry:\n")
+			fmt.Fprintf(cmd.OutOrStdout(), "     arctl apply -f agent.yaml\n")
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&initVersion, "version", "0.1.0", "Initial version")
+	cmd.Flags().StringVar(&initDescription, "description", "", "Agent description")
+	cmd.Flags().StringVar(&initModelProvider, "model-provider", "Gemini", "Model provider (OpenAI, Anthropic, Gemini, AzureOpenAI, Agentgateway)")
+	cmd.Flags().StringVar(&initModelName, "model-name", "gemini-2.0-flash", "Model name")
+	cmd.Flags().StringVar(&initImage, "image", "", "Docker image (default: localhost:5001/<name>:latest)")
+	cmd.Flags().StringVar(&initGit, "git", "", "Git repository URL (GitHub, GitLab, Bitbucket)")
+	cmd.Flags().StringArrayVar(&initMCPs, "mcp", nil, "Registry MCP server to reference: name[@version] (repeatable)")
+	cmd.Flags().StringArrayVar(&initSkills, "skill", nil, "Registry skill to reference: name[@version] (repeatable)")
+	cmd.Flags().StringArrayVar(&initPrompts, "prompt", nil, "Registry prompt to reference: name[@version] (repeatable)")
+
+	return cmd
+}
+
+// parseNameVersion splits "name@version" into (name, version).
+// If no @ is present, version defaults to "latest".
+// If the name part is empty (e.g. "@1.0.0"), the whole string is treated as the name.
+func parseNameVersion(s string) (string, string) {
+	if i := strings.LastIndex(s, "@"); i > 0 {
+		return s[:i], s[i+1:]
+	}
+	return s, "latest"
+}
+
+// localMCPName returns the local name for an MCP server reference.
+// For namespace/name format, returns the name part; otherwise returns as-is.
+func localMCPName(registryName string) string {
+	if i := strings.LastIndex(registryName, "/"); i >= 0 {
+		return registryName[i+1:]
+	}
+	return registryName
+}
+
+// writeDeclarativeAgentYAML writes agent.yaml in the ar.dev/v1alpha1 declarative format.
+func writeDeclarativeAgentYAML(projectDir, name, ver, image, language, framework, modelProvider, modelName, description, gitURL string, mcps, skills, prompts []string) error {
+	registryURL := agentutils.GetDefaultRegistryURL()
+
+	spec := map[string]any{
+		"image":         image,
+		"language":      language,
+		"framework":     framework,
+		"modelProvider": modelProvider,
+		"modelName":     modelName,
+	}
+	if description != "" {
+		spec["description"] = description
+	} else {
+		spec["description"] = fmt.Sprintf("%s agent", name)
+	}
+	if gitURL != "" {
+		spec["repository"] = map[string]any{
+			"url":    gitURL,
+			"source": "git",
+		}
+	}
+	if len(mcps) > 0 {
+		var mcpList []map[string]any
+		for _, raw := range mcps {
+			serverName, version := parseNameVersion(raw)
+			mcpList = append(mcpList, map[string]any{
+				"type":                  "registry",
+				"name":                  localMCPName(serverName),
+				"registryURL":           registryURL,
+				"registryServerName":    serverName,
+				"registryServerVersion": version,
+			})
+		}
+		spec["mcpServers"] = mcpList
+	}
+	if len(skills) > 0 {
+		var skillList []map[string]any
+		for _, raw := range skills {
+			skillName, version := parseNameVersion(raw)
+			skillList = append(skillList, map[string]any{
+				"name":                 skillName,
+				"registryURL":          registryURL,
+				"registrySkillName":    skillName,
+				"registrySkillVersion": version,
+			})
+		}
+		spec["skills"] = skillList
+	}
+	if len(prompts) > 0 {
+		var promptList []map[string]any
+		for _, raw := range prompts {
+			promptName, version := parseNameVersion(raw)
+			promptList = append(promptList, map[string]any{
+				"name":                  promptName,
+				"registryURL":           registryURL,
+				"registryPromptName":    promptName,
+				"registryPromptVersion": version,
+			})
+		}
+		spec["prompts"] = promptList
+	}
+
+	r := &scheme.Resource{
+		APIVersion: scheme.APIVersion,
+		Kind:       "Agent",
+		Metadata: scheme.Metadata{
+			Name:    name,
+			Version: ver,
+		},
+		Spec: spec,
+	}
+
+	b, err := yaml.Marshal(r)
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(filepath.Join(projectDir, "agent.yaml"), b, 0o644)
+}
+
+var supportedInitModelProviders = map[string]struct{}{
+	"openai":       {},
+	"anthropic":    {},
+	"gemini":       {},
+	"azureopenai":  {},
+	"agentgateway": {},
+}
+
+func validateInitFrameworkAndLanguage(framework, language string) error {
+	if framework != "adk" {
+		return fmt.Errorf("unsupported framework %q — only 'adk' is supported", framework)
+	}
+	if language != "python" {
+		return fmt.Errorf("unsupported language %q for framework 'adk' — only 'python' is supported", language)
+	}
+	return nil
+}
+
+func normalizeInitModelProvider(value string) (string, error) {
+	trimmed := strings.ToLower(strings.TrimSpace(value))
+	if trimmed == "" {
+		return "", nil
+	}
+	if _, ok := supportedInitModelProviders[trimmed]; !ok {
+		return "", fmt.Errorf("unsupported model provider %q — supported: OpenAI, Anthropic, Gemini, AzureOpenAI, Agentgateway", value)
+	}
+	return trimmed, nil
+}
+
+func resolveInitModelName(cmd *cobra.Command, modelProvider, modelName string) string {
+	providerChanged := cmd.Flags().Changed("model-provider")
+	modelNameChanged := cmd.Flags().Changed("model-name")
+	name := strings.TrimSpace(modelName)
+	if providerChanged && !modelNameChanged {
+		if defaultName, ok := defaultInitModelName(modelProvider); ok {
+			return defaultName
+		}
+	}
+	return name
+}
+
+func defaultInitModelName(provider string) (string, bool) {
+	switch provider {
+	case "openai", "agentgateway":
+		return "gpt-4o-mini", true
+	case "anthropic":
+		return "claude-3-5-sonnet", true
+	case "gemini":
+		return "gemini-2.0-flash", true
+	case "azureopenai":
+		return "your-deployment-name", true
+	default:
+		return "", false
+	}
+}
+
+// --- mcp init ---
+
+var supportedMCPFrameworks = map[string]struct{}{
+	"fastmcp-python": {},
+	"mcp-go":         {},
+}
+
+func newInitMCPCmd() *cobra.Command {
+	var (
+		initVersion     string
+		initDescription string
+		initImage       string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "mcp FRAMEWORK NAMESPACE/NAME",
+		Short: "Scaffold a new MCP server project with declarative mcp.yaml",
+		Long: `Scaffold a new MCP server project. Creates a project directory
+containing a declarative mcp.yaml (ar.dev/v1alpha1) and source stubs.
+
+NAME must be in namespace/name format as required by the registry.
+
+The generated mcp.yaml can be applied directly:
+  arctl apply -f NAME/mcp.yaml
+
+Supported frameworks: fastmcp-python, mcp-go`,
+		Example: `  arctl init mcp fastmcp-python myorg/my-server
+  arctl init mcp mcp-go myorg/my-server --version 1.0.0`,
+		Args:         cobra.ExactArgs(2),
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			framework := strings.ToLower(args[0])
+			fullName := args[1]
+
+			if _, ok := supportedMCPFrameworks[framework]; !ok {
+				return fmt.Errorf("unsupported framework %q — supported: fastmcp-python, mcp-go", framework)
+			}
+			if err := validators.ValidateMCPServerName(fullName); err != nil {
+				return fmt.Errorf("invalid MCP server name: %w", err)
+			}
+
+			// Use just the name part (after /) as the project directory name.
+			parts := strings.SplitN(fullName, "/", 2)
+			dirName := parts[len(parts)-1]
+
+			image := initImage
+			if image == "" {
+				registry := strings.TrimSuffix(version.DockerRegistry, "/")
+				if registry == "" {
+					registry = "localhost:5001"
+				}
+				image = fmt.Sprintf("%s/%s:latest", registry, dirName)
+			}
+
+			cwd, err := os.Getwd()
+			if err != nil {
+				return fmt.Errorf("getting working directory: %w", err)
+			}
+			projectDir := filepath.Join(cwd, dirName)
+
+			generator, err := mcpframeworks.GetGenerator(framework)
+			if err != nil {
+				return err
+			}
+			cfg := mcptemplates.ProjectConfig{
+				ProjectName: dirName,
+				Version:     initVersion,
+				Description: initDescription,
+				Directory:   projectDir,
+				NoGit:       false,
+			}
+			if err := generator.GenerateProject(cfg); err != nil {
+				return fmt.Errorf("generating MCP project: %w", err)
+			}
+
+			if err := writeDeclarativeMCPYAML(projectDir, fullName, initVersion, image, initDescription); err != nil {
+				return fmt.Errorf("writing declarative mcp.yaml: %w", err)
+			}
+
+			fmt.Fprintf(cmd.OutOrStdout(), "✓ Successfully created MCP server: %s\n", fullName)
+			fmt.Fprintf(cmd.OutOrStdout(), "\n🚀 Next steps:\n")
+			fmt.Fprintf(cmd.OutOrStdout(), "  1. cd %s\n", dirName)
+			fmt.Fprintf(cmd.OutOrStdout(), "  2. (Optional) Build and push the image if developing locally:\n")
+			fmt.Fprintf(cmd.OutOrStdout(), "     arctl build . --push\n")
+			fmt.Fprintf(cmd.OutOrStdout(), "  3. Publish the MCP server to the registry:\n")
+			fmt.Fprintf(cmd.OutOrStdout(), "     arctl apply -f mcp.yaml\n")
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&initVersion, "version", "0.1.0", "Initial version")
+	cmd.Flags().StringVar(&initDescription, "description", "", "MCP server description")
+	cmd.Flags().StringVar(&initImage, "image", "", "Docker image (default: localhost:5001/<name>:latest)")
+
+	return cmd
+}
+
+func writeDeclarativeMCPYAML(projectDir, name, ver, image, description string) error {
+	spec := map[string]any{
+		"title": name,
+		"packages": []map[string]any{
+			{
+				"registryType": "oci",
+				"identifier":   image,
+				"version":      ver,
+				"transport": map[string]any{
+					"type": "stdio",
+				},
+			},
+		},
+	}
+	if description != "" {
+		spec["description"] = description
+	} else {
+		// Use just the name part after the slash for the description.
+		parts := strings.SplitN(name, "/", 2)
+		spec["description"] = fmt.Sprintf("%s MCP server", parts[len(parts)-1])
+	}
+	// title should also use just the name part.
+	nameParts := strings.SplitN(name, "/", 2)
+	spec["title"] = nameParts[len(nameParts)-1]
+
+	r := &scheme.Resource{
+		APIVersion: scheme.APIVersion,
+		Kind:       "MCPServer",
+		Metadata:   scheme.Metadata{Name: name, Version: ver},
+		Spec:       spec,
+	}
+
+	b, err := yaml.Marshal(r)
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(filepath.Join(projectDir, "mcp.yaml"), b, 0o644)
+}
+
+// --- skill init ---
+
+func newInitSkillCmd() *cobra.Command {
+	var (
+		initVersion     string
+		initDescription string
+		initCategory    string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "skill NAME",
+		Short: "Scaffold a new skill project with declarative skill.yaml",
+		Long: `Scaffold a new skill project. Creates a project directory
+containing a declarative skill.yaml (ar.dev/v1alpha1) and source stubs.
+
+The generated skill.yaml can be applied directly:
+  arctl apply -f NAME/skill.yaml`,
+		Example: `  arctl init skill my-skill
+  arctl init skill my-skill --category nlp --description "Text summarizer"`,
+		Args:         cobra.ExactArgs(1),
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			name := args[0]
+
+			if err := validators.ValidateSkillName(name); err != nil {
+				return fmt.Errorf("invalid skill name: %w", err)
+			}
+
+			cwd, err := os.Getwd()
+			if err != nil {
+				return fmt.Errorf("getting working directory: %w", err)
+			}
+			projectDir := filepath.Join(cwd, name)
+
+			if err := skilltemplates.NewGenerator().GenerateProject(skilltemplates.ProjectConfig{
+				ProjectName: name,
+				Directory:   projectDir,
+				NoGit:       false,
+			}); err != nil {
+				return fmt.Errorf("generating skill project: %w", err)
+			}
+
+			if err := writeDeclarativeSkillYAML(projectDir, name, initVersion, initDescription, initCategory); err != nil {
+				return fmt.Errorf("writing declarative skill.yaml: %w", err)
+			}
+
+			fmt.Fprintf(cmd.OutOrStdout(), "✓ Successfully created skill: %s\n", name)
+			fmt.Fprintf(cmd.OutOrStdout(), "\n🚀 Next steps:\n")
+			fmt.Fprintf(cmd.OutOrStdout(), "  1. cd %s\n", name)
+			fmt.Fprintf(cmd.OutOrStdout(), "  2. (Optional) Build and push the image if developing locally:\n")
+			fmt.Fprintf(cmd.OutOrStdout(), "     arctl build . --push\n")
+			fmt.Fprintf(cmd.OutOrStdout(), "  3. Publish the skill to the registry:\n")
+			fmt.Fprintf(cmd.OutOrStdout(), "     arctl apply -f skill.yaml\n")
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&initVersion, "version", "0.1.0", "Initial version")
+	cmd.Flags().StringVar(&initDescription, "description", "", "Skill description")
+	cmd.Flags().StringVar(&initCategory, "category", "general", "Skill category (e.g. nlp, general)")
+
+	return cmd
+}
+
+func writeDeclarativeSkillYAML(projectDir, name, ver, description, category string) error {
+	spec := map[string]any{
+		"title":    name,
+		"category": category,
+	}
+	if description != "" {
+		spec["description"] = description
+	} else {
+		spec["description"] = fmt.Sprintf("%s skill", name)
+	}
+
+	r := &scheme.Resource{
+		APIVersion: scheme.APIVersion,
+		Kind:       "Skill",
+		Metadata:   scheme.Metadata{Name: name, Version: ver},
+		Spec:       spec,
+	}
+
+	b, err := yaml.Marshal(r)
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(filepath.Join(projectDir, "skill.yaml"), b, 0o644)
+}
+
+// --- prompt init ---
+
+func newInitPromptCmd() *cobra.Command {
+	var (
+		initVersion     string
+		initDescription string
+		initContent     string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "prompt NAME",
+		Short: "Create a new declarative prompt.yaml",
+		Long: `Create a new prompt.yaml in the current directory using the
+ar.dev/v1alpha1 declarative format. No code scaffolding is generated.
+
+The generated prompt.yaml can be applied directly:
+  arctl apply -f prompt.yaml`,
+		Example: `  arctl init prompt my-prompt
+  arctl init prompt my-prompt --description "System prompt for summarization"`,
+		Args:         cobra.ExactArgs(1),
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			name := args[0]
+
+			// Prompt names follow the same DB constraint as skill names (^[a-zA-Z0-9_-]+$).
+			if err := validators.ValidateSkillName(name); err != nil {
+				return fmt.Errorf("invalid prompt name: %w", err)
+			}
+
+			cwd, err := os.Getwd()
+			if err != nil {
+				return fmt.Errorf("getting working directory: %w", err)
+			}
+			// Prompts are just a YAML file — no project directory needed.
+			outPath := filepath.Join(cwd, name+".yaml")
+
+			if err := writeDeclarativePromptYAML(outPath, name, initVersion, initDescription, initContent); err != nil {
+				return fmt.Errorf("writing declarative prompt.yaml: %w", err)
+			}
+
+			fmt.Fprintf(cmd.OutOrStdout(), "✓ Successfully created prompt: %s\n", name)
+			fmt.Fprintf(cmd.OutOrStdout(), "\n🚀 Next steps:\n")
+			fmt.Fprintf(cmd.OutOrStdout(), "  1. Edit %s.yaml if needed\n", name)
+			fmt.Fprintf(cmd.OutOrStdout(), "  2. Publish the prompt to the registry:\n")
+			fmt.Fprintf(cmd.OutOrStdout(), "     arctl apply -f %s.yaml\n", name)
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&initVersion, "version", "0.1.0", "Initial version")
+	cmd.Flags().StringVar(&initDescription, "description", "", "Prompt description")
+	cmd.Flags().StringVar(&initContent, "content", "You are a helpful assistant.", "Initial prompt content")
+
+	return cmd
+}
+
+func writeDeclarativePromptYAML(path, name, ver, description, content string) error {
+	spec := map[string]any{
+		"content": content,
+	}
+	if description != "" {
+		spec["description"] = description
+	} else {
+		spec["description"] = fmt.Sprintf("%s prompt", name)
+	}
+
+	r := &scheme.Resource{
+		APIVersion: scheme.APIVersion,
+		Kind:       "Prompt",
+		Metadata:   scheme.Metadata{Name: name, Version: ver},
+		Spec:       spec,
+	}
+
+	b, err := yaml.Marshal(r)
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(path, b, 0o644)
+}

--- a/internal/cli/declarative/init_test.go
+++ b/internal/cli/declarative/init_test.go
@@ -1,0 +1,541 @@
+package declarative_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/agentregistry-dev/agentregistry/internal/cli/declarative"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+// readYAMLFile parses a YAML file at the given absolute path and returns it as a map.
+func readYAMLFile(t *testing.T, path string) map[string]any {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	require.NoError(t, err, "YAML file should exist at %s", path)
+	var m map[string]any
+	require.NoError(t, yaml.Unmarshal(data, &m), "file should be valid YAML")
+	return m
+}
+
+// readAgentYAML parses the generated agent.yaml inside dir/name/ and returns it as a map.
+func readAgentYAML(t *testing.T, dir, name string) map[string]any {
+	t.Helper()
+	return readYAMLFile(t, filepath.Join(dir, name, "agent.yaml"))
+}
+
+func TestInitAgentCmd_BasicScaffold(t *testing.T) {
+	tmpDir := t.TempDir()
+	origDir, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(tmpDir))
+	defer func() { _ = os.Chdir(origDir) }()
+
+	cmd := declarative.NewInitCmd()
+	cmd.SetArgs([]string{"agent", "adk", "python", "myagent"})
+	require.NoError(t, cmd.Execute())
+
+	// agent.yaml must exist and have declarative format
+	m := readAgentYAML(t, tmpDir, "myagent")
+	assert.Equal(t, "ar.dev/v1alpha1", m["apiVersion"])
+	assert.Equal(t, "Agent", m["kind"])
+
+	metadata, ok := m["metadata"].(map[string]any)
+	require.True(t, ok, "metadata should be a map")
+	assert.Equal(t, "myagent", metadata["name"])
+	assert.Equal(t, "0.1.0", metadata["version"])
+
+	spec, ok := m["spec"].(map[string]any)
+	require.True(t, ok, "spec should be a map")
+	assert.Equal(t, "adk", spec["framework"])
+	assert.Equal(t, "python", spec["language"])
+	assert.Equal(t, "gemini", spec["modelProvider"])
+	assert.Equal(t, "gemini-2.0-flash", spec["modelName"])
+	assert.NotEmpty(t, spec["image"])
+	assert.NotEmpty(t, spec["description"])
+}
+
+func TestInitAgentCmd_CustomFlags(t *testing.T) {
+	tmpDir := t.TempDir()
+	origDir, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(tmpDir))
+	defer func() { _ = os.Chdir(origDir) }()
+
+	cmd := declarative.NewInitCmd()
+	cmd.SetArgs([]string{
+		"agent", "adk", "python", "mybot",
+		"--version", "2.0.0",
+		"--description", "My custom bot",
+		"--model-provider", "openai",
+		"--model-name", "gpt-4o",
+		"--image", "ghcr.io/acme/mybot:v2",
+	})
+	require.NoError(t, cmd.Execute())
+
+	m := readAgentYAML(t, tmpDir, "mybot")
+	metadata := m["metadata"].(map[string]any)
+	assert.Equal(t, "2.0.0", metadata["version"])
+
+	spec := m["spec"].(map[string]any)
+	assert.Equal(t, "openai", spec["modelProvider"])
+	assert.Equal(t, "gpt-4o", spec["modelName"])
+	assert.Equal(t, "ghcr.io/acme/mybot:v2", spec["image"])
+	assert.Equal(t, "My custom bot", spec["description"])
+}
+
+func TestInitAgentCmd_MCPSkillPromptRefs(t *testing.T) {
+	tmpDir := t.TempDir()
+	origDir, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(tmpDir))
+	defer func() { _ = os.Chdir(origDir) }()
+
+	cmd := declarative.NewInitCmd()
+	cmd.SetArgs([]string{
+		"agent", "adk", "python", "mybot",
+		"--mcp", "acme/fetch@1.0.0",
+		"--mcp", "myorg/weather",
+		"--skill", "summarize@2.0.0",
+		"--prompt", "system-prompt",
+	})
+	require.NoError(t, cmd.Execute())
+
+	m := readAgentYAML(t, tmpDir, "mybot")
+	spec := m["spec"].(map[string]any)
+
+	mcps := spec["mcpServers"].([]any)
+	require.Len(t, mcps, 2)
+	mcp0 := mcps[0].(map[string]any)
+	assert.Equal(t, "registry", mcp0["type"])
+	assert.Equal(t, "fetch", mcp0["name"])
+	assert.Equal(t, "acme/fetch", mcp0["registryServerName"])
+	assert.Equal(t, "1.0.0", mcp0["registryServerVersion"])
+	mcp1 := mcps[1].(map[string]any)
+	assert.Equal(t, "weather", mcp1["name"])
+	assert.Equal(t, "myorg/weather", mcp1["registryServerName"])
+	assert.Equal(t, "latest", mcp1["registryServerVersion"])
+
+	skills := spec["skills"].([]any)
+	require.Len(t, skills, 1)
+	skill0 := skills[0].(map[string]any)
+	assert.Equal(t, "summarize", skill0["name"])
+	assert.Equal(t, "summarize", skill0["registrySkillName"])
+	assert.Equal(t, "2.0.0", skill0["registrySkillVersion"])
+
+	prompts := spec["prompts"].([]any)
+	require.Len(t, prompts, 1)
+	prompt0 := prompts[0].(map[string]any)
+	assert.Equal(t, "system-prompt", prompt0["name"])
+	assert.Equal(t, "system-prompt", prompt0["registryPromptName"])
+	assert.Equal(t, "latest", prompt0["registryPromptVersion"])
+}
+
+func TestInitAgentCmd_GitRepository(t *testing.T) {
+	tmpDir := t.TempDir()
+	origDir, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(tmpDir))
+	defer func() { _ = os.Chdir(origDir) }()
+
+	cmd := declarative.NewInitCmd()
+	cmd.SetArgs([]string{
+		"agent", "adk", "python", "mybot",
+		"--git", "https://github.com/acme/mybot",
+	})
+	require.NoError(t, cmd.Execute())
+
+	m := readAgentYAML(t, tmpDir, "mybot")
+	spec := m["spec"].(map[string]any)
+	repo, ok := spec["repository"].(map[string]any)
+	require.True(t, ok, "repository should be present in spec")
+	assert.Equal(t, "https://github.com/acme/mybot", repo["url"])
+	assert.Equal(t, "git", repo["source"])
+}
+
+func TestInitAgentCmd_NoGitRepository(t *testing.T) {
+	tmpDir := t.TempDir()
+	origDir, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(tmpDir))
+	defer func() { _ = os.Chdir(origDir) }()
+
+	cmd := declarative.NewInitCmd()
+	cmd.SetArgs([]string{"agent", "adk", "python", "mybot"})
+	require.NoError(t, cmd.Execute())
+
+	m := readAgentYAML(t, tmpDir, "mybot")
+	spec := m["spec"].(map[string]any)
+	assert.NotContains(t, spec, "repository")
+}
+
+func TestInitAgentCmd_ModelProviderDefaultsModelName(t *testing.T) {
+	tmpDir := t.TempDir()
+	origDir, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(tmpDir))
+	defer func() { _ = os.Chdir(origDir) }()
+
+	cmd := declarative.NewInitCmd()
+	cmd.SetArgs([]string{"agent", "adk", "python", "anthrobot", "--model-provider", "anthropic"})
+	require.NoError(t, cmd.Execute())
+
+	m := readAgentYAML(t, tmpDir, "anthrobot")
+	spec := m["spec"].(map[string]any)
+	assert.Equal(t, "anthropic", spec["modelProvider"])
+	// When only --model-provider is set, model name should default to provider's default
+	assert.Equal(t, "claude-3-5-sonnet", spec["modelName"])
+}
+
+func TestInitAgentCmd_SuccessMessage(t *testing.T) {
+	tmpDir := t.TempDir()
+	origDir, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(tmpDir))
+	defer func() { _ = os.Chdir(origDir) }()
+
+	var buf bytes.Buffer
+	cmd := declarative.NewInitCmd()
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"agent", "adk", "python", "myagent"})
+	require.NoError(t, cmd.Execute())
+
+	out := buf.String()
+	assert.Contains(t, out, "✓ Successfully created agent: myagent")
+	assert.Contains(t, out, "arctl apply -f agent.yaml")
+}
+
+func TestInitAgentCmd_InvalidName_Hyphen(t *testing.T) {
+	cmd := declarative.NewInitCmd()
+	cmd.SetArgs([]string{"agent", "adk", "python", "my-agent"})
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid agent name")
+}
+
+func TestInitAgentCmd_UnsupportedFramework(t *testing.T) {
+	cmd := declarative.NewInitCmd()
+	cmd.SetArgs([]string{"agent", "langchain", "python", "myagent"})
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported framework")
+}
+
+func TestInitAgentCmd_UnsupportedLanguage(t *testing.T) {
+	cmd := declarative.NewInitCmd()
+	cmd.SetArgs([]string{"agent", "adk", "javascript", "myagent"})
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported language")
+}
+
+func TestInitAgentCmd_InvalidModelProvider(t *testing.T) {
+	cmd := declarative.NewInitCmd()
+	cmd.SetArgs([]string{"agent", "adk", "python", "myagent", "--model-provider", "badprovider"})
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported model provider")
+}
+
+func TestInitAgentCmd_DefaultImageUsesRegistryName(t *testing.T) {
+	tmpDir := t.TempDir()
+	origDir, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(tmpDir))
+	defer func() { _ = os.Chdir(origDir) }()
+
+	cmd := declarative.NewInitCmd()
+	cmd.SetArgs([]string{"agent", "adk", "python", "coolbot"})
+	require.NoError(t, cmd.Execute())
+
+	m := readAgentYAML(t, tmpDir, "coolbot")
+	spec := m["spec"].(map[string]any)
+	image, _ := spec["image"].(string)
+	assert.True(t, strings.HasSuffix(image, "/coolbot:latest"),
+		"default image should end with /<name>:latest, got: %s", image)
+}
+
+func TestInitAgentCmd_DeclarativeYAMLHasCorrectStructure(t *testing.T) {
+	tmpDir := t.TempDir()
+	origDir, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(tmpDir))
+	defer func() { _ = os.Chdir(origDir) }()
+
+	cmd := declarative.NewInitCmd()
+	cmd.SetArgs([]string{"agent", "adk", "python", "structbot"})
+	require.NoError(t, cmd.Execute())
+
+	data, err := os.ReadFile(filepath.Join(tmpDir, "structbot", "agent.yaml"))
+	require.NoError(t, err)
+	content := string(data)
+
+	// Must have declarative format fields
+	assert.Contains(t, content, "apiVersion:")
+	assert.Contains(t, content, "ar.dev/v1alpha1")
+	assert.Contains(t, content, "kind: Agent")
+	assert.Contains(t, content, "metadata:")
+	assert.Contains(t, content, "spec:")
+}
+
+// ---- mcp init ----
+
+func TestInitMCPCmd_BasicScaffold(t *testing.T) {
+	tmpDir := t.TempDir()
+	origDir, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(tmpDir))
+	defer func() { _ = os.Chdir(origDir) }()
+
+	cmd := declarative.NewInitCmd()
+	cmd.SetArgs([]string{"mcp", "fastmcp-python", "myorg/myserver"})
+	require.NoError(t, cmd.Execute())
+
+	// Directory uses just the name part after "/"
+	m := readYAMLFile(t, filepath.Join(tmpDir, "myserver", "mcp.yaml"))
+	assert.Equal(t, "ar.dev/v1alpha1", m["apiVersion"])
+	assert.Equal(t, "MCPServer", m["kind"])
+
+	metadata := m["metadata"].(map[string]any)
+	assert.Equal(t, "myorg/myserver", metadata["name"])
+	assert.Equal(t, "0.1.0", metadata["version"])
+
+	spec := m["spec"].(map[string]any)
+	assert.Equal(t, "myserver", spec["title"])
+	assert.NotEmpty(t, spec["description"])
+	pkgs, ok := spec["packages"].([]any)
+	require.True(t, ok, "spec.packages should be a list")
+	require.Len(t, pkgs, 1)
+	pkg := pkgs[0].(map[string]any)
+	assert.Equal(t, "oci", pkg["registryType"])
+	assert.NotEmpty(t, pkg["identifier"])
+}
+
+func TestInitMCPCmd_CustomFlags(t *testing.T) {
+	tmpDir := t.TempDir()
+	origDir, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(tmpDir))
+	defer func() { _ = os.Chdir(origDir) }()
+
+	cmd := declarative.NewInitCmd()
+	cmd.SetArgs([]string{
+		"mcp", "fastmcp-python", "myorg/myserver",
+		"--version", "2.0.0",
+		"--description", "My weather server",
+		"--image", "ghcr.io/acme/myserver:v2",
+	})
+	require.NoError(t, cmd.Execute())
+
+	m := readYAMLFile(t, filepath.Join(tmpDir, "myserver", "mcp.yaml"))
+	metadata := m["metadata"].(map[string]any)
+	assert.Equal(t, "myorg/myserver", metadata["name"])
+	assert.Equal(t, "2.0.0", metadata["version"])
+
+	spec := m["spec"].(map[string]any)
+	assert.Equal(t, "My weather server", spec["description"])
+	pkgs := spec["packages"].([]any)
+	pkg := pkgs[0].(map[string]any)
+	assert.Equal(t, "ghcr.io/acme/myserver:v2", pkg["identifier"])
+}
+
+func TestInitMCPCmd_DefaultImageUsesName(t *testing.T) {
+	tmpDir := t.TempDir()
+	origDir, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(tmpDir))
+	defer func() { _ = os.Chdir(origDir) }()
+
+	cmd := declarative.NewInitCmd()
+	cmd.SetArgs([]string{"mcp", "fastmcp-python", "myorg/coolserver"})
+	require.NoError(t, cmd.Execute())
+
+	// Directory uses just the name part after "/"
+	m := readYAMLFile(t, filepath.Join(tmpDir, "coolserver", "mcp.yaml"))
+	spec := m["spec"].(map[string]any)
+	pkgs := spec["packages"].([]any)
+	pkg := pkgs[0].(map[string]any)
+	identifier, _ := pkg["identifier"].(string)
+	assert.True(t, strings.HasSuffix(identifier, "/coolserver:latest"),
+		"default image should end with /<name>:latest, got: %s", identifier)
+}
+
+func TestInitMCPCmd_UnsupportedFramework(t *testing.T) {
+	cmd := declarative.NewInitCmd()
+	cmd.SetArgs([]string{"mcp", "typescript", "myorg/myserver"})
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported framework")
+}
+
+func TestInitMCPCmd_InvalidName_NoNamespace(t *testing.T) {
+	cmd := declarative.NewInitCmd()
+	cmd.SetArgs([]string{"mcp", "fastmcp-python", "myserver"})
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid MCP server name")
+}
+
+func TestInitMCPCmd_ProjectFilesCreated(t *testing.T) {
+	tmpDir := t.TempDir()
+	origDir, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(tmpDir))
+	defer func() { _ = os.Chdir(origDir) }()
+
+	cmd := declarative.NewInitCmd()
+	cmd.SetArgs([]string{"mcp", "fastmcp-python", "myorg/myserver"})
+	require.NoError(t, cmd.Execute())
+
+	// Directory uses just the name part after "/"; YAML metadata.name uses full namespace/name
+	_, err = os.Stat(filepath.Join(tmpDir, "myserver"))
+	require.NoError(t, err, "project directory should be created (using name part only)")
+	_, err = os.Stat(filepath.Join(tmpDir, "myserver", "mcp.yaml"))
+	require.NoError(t, err, "mcp.yaml should exist")
+}
+
+// ---- skill init ----
+
+func TestInitSkillCmd_BasicScaffold(t *testing.T) {
+	tmpDir := t.TempDir()
+	origDir, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(tmpDir))
+	defer func() { _ = os.Chdir(origDir) }()
+
+	cmd := declarative.NewInitCmd()
+	cmd.SetArgs([]string{"skill", "myskill"})
+	require.NoError(t, cmd.Execute())
+
+	m := readYAMLFile(t, filepath.Join(tmpDir, "myskill", "skill.yaml"))
+	assert.Equal(t, "ar.dev/v1alpha1", m["apiVersion"])
+	assert.Equal(t, "Skill", m["kind"])
+
+	metadata := m["metadata"].(map[string]any)
+	assert.Equal(t, "myskill", metadata["name"])
+	assert.Equal(t, "0.1.0", metadata["version"])
+
+	spec := m["spec"].(map[string]any)
+	assert.Equal(t, "myskill", spec["title"])
+	assert.Equal(t, "general", spec["category"])
+	assert.NotEmpty(t, spec["description"])
+}
+
+func TestInitSkillCmd_CustomFlags(t *testing.T) {
+	tmpDir := t.TempDir()
+	origDir, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(tmpDir))
+	defer func() { _ = os.Chdir(origDir) }()
+
+	cmd := declarative.NewInitCmd()
+	cmd.SetArgs([]string{
+		"skill", "myskill",
+		"--version", "1.2.0",
+		"--description", "Text summarizer",
+		"--category", "nlp",
+	})
+	require.NoError(t, cmd.Execute())
+
+	m := readYAMLFile(t, filepath.Join(tmpDir, "myskill", "skill.yaml"))
+	metadata := m["metadata"].(map[string]any)
+	assert.Equal(t, "1.2.0", metadata["version"])
+
+	spec := m["spec"].(map[string]any)
+	assert.Equal(t, "nlp", spec["category"])
+	assert.Equal(t, "Text summarizer", spec["description"])
+}
+
+func TestInitSkillCmd_ProjectFilesCreated(t *testing.T) {
+	tmpDir := t.TempDir()
+	origDir, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(tmpDir))
+	defer func() { _ = os.Chdir(origDir) }()
+
+	cmd := declarative.NewInitCmd()
+	cmd.SetArgs([]string{"skill", "myskill"})
+	require.NoError(t, cmd.Execute())
+
+	_, err = os.Stat(filepath.Join(tmpDir, "myskill"))
+	require.NoError(t, err, "project directory should be created")
+	_, err = os.Stat(filepath.Join(tmpDir, "myskill", "skill.yaml"))
+	require.NoError(t, err, "skill.yaml should exist")
+}
+
+// ---- prompt init ----
+
+func TestInitPromptCmd_BasicScaffold(t *testing.T) {
+	tmpDir := t.TempDir()
+	origDir, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(tmpDir))
+	defer func() { _ = os.Chdir(origDir) }()
+
+	cmd := declarative.NewInitCmd()
+	cmd.SetArgs([]string{"prompt", "myprompt"})
+	require.NoError(t, cmd.Execute())
+
+	// Prompt writes NAME.yaml in cwd, not a subdir
+	m := readYAMLFile(t, filepath.Join(tmpDir, "myprompt.yaml"))
+	assert.Equal(t, "ar.dev/v1alpha1", m["apiVersion"])
+	assert.Equal(t, "Prompt", m["kind"])
+
+	metadata := m["metadata"].(map[string]any)
+	assert.Equal(t, "myprompt", metadata["name"])
+	assert.Equal(t, "0.1.0", metadata["version"])
+
+	spec := m["spec"].(map[string]any)
+	assert.NotEmpty(t, spec["content"])
+	assert.NotEmpty(t, spec["description"])
+}
+
+func TestInitPromptCmd_CustomContent(t *testing.T) {
+	tmpDir := t.TempDir()
+	origDir, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(tmpDir))
+	defer func() { _ = os.Chdir(origDir) }()
+
+	cmd := declarative.NewInitCmd()
+	cmd.SetArgs([]string{
+		"prompt", "summarizer",
+		"--description", "Summarize text",
+		"--content", "You are a text summarizer. Be concise.",
+		"--version", "2.0.0",
+	})
+	require.NoError(t, cmd.Execute())
+
+	m := readYAMLFile(t, filepath.Join(tmpDir, "summarizer.yaml"))
+	metadata := m["metadata"].(map[string]any)
+	assert.Equal(t, "2.0.0", metadata["version"])
+
+	spec := m["spec"].(map[string]any)
+	assert.Equal(t, "Summarize text", spec["description"])
+	assert.Equal(t, "You are a text summarizer. Be concise.", spec["content"])
+}
+
+func TestInitPromptCmd_WritesFileNotDirectory(t *testing.T) {
+	tmpDir := t.TempDir()
+	origDir, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(tmpDir))
+	defer func() { _ = os.Chdir(origDir) }()
+
+	cmd := declarative.NewInitCmd()
+	cmd.SetArgs([]string{"prompt", "myprompt"})
+	require.NoError(t, cmd.Execute())
+
+	// Must write myprompt.yaml in cwd, NOT create a directory
+	info, err := os.Stat(filepath.Join(tmpDir, "myprompt.yaml"))
+	require.NoError(t, err, "myprompt.yaml should exist")
+	assert.False(t, info.IsDir(), "myprompt.yaml should be a file, not a directory")
+
+	_, err = os.Stat(filepath.Join(tmpDir, "myprompt"))
+	assert.True(t, os.IsNotExist(err), "no directory named myprompt should be created")
+}

--- a/internal/cli/declarative/integration_test.go
+++ b/internal/cli/declarative/integration_test.go
@@ -1,0 +1,672 @@
+package declarative_test
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/agentregistry-dev/agentregistry/internal/cli/declarative"
+	"github.com/agentregistry-dev/agentregistry/internal/client"
+	apitypes "github.com/agentregistry-dev/agentregistry/internal/registry/api/apitypes"
+	"github.com/agentregistry-dev/agentregistry/internal/registry/api/router"
+	"github.com/agentregistry-dev/agentregistry/internal/registry/config"
+	servicetesting "github.com/agentregistry-dev/agentregistry/internal/registry/service/testing"
+	"github.com/agentregistry-dev/agentregistry/internal/registry/telemetry"
+	"github.com/agentregistry-dev/agentregistry/pkg/models"
+	"github.com/agentregistry-dev/agentregistry/pkg/registry/database"
+	apiv0 "github.com/modelcontextprotocol/registry/pkg/api/v0"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/metric/noop"
+)
+
+// newTestServer spins up an in-process HTTP server backed by the given FakeRegistry
+// and returns a configured client plus a cleanup function.
+func newTestServer(t *testing.T, fake *servicetesting.FakeRegistry) (*client.Client, func()) {
+	t.Helper()
+
+	mux := http.NewServeMux()
+	meter := noop.NewMeterProvider().Meter("declarative-integration-tests")
+	metrics, err := telemetry.NewMetrics(meter)
+	if err != nil {
+		t.Fatalf("failed to initialize test metrics: %v", err)
+	}
+
+	versionInfo := &apitypes.VersionBody{
+		Version:   "test-version",
+		GitCommit: "test-commit",
+		BuildTime: "2026-01-02T03:04:05Z",
+	}
+	cfg := &config.Config{
+		JWTPrivateKey: "0000000000000000000000000000000000000000000000000000000000000000",
+	}
+
+	router.NewHumaAPI(cfg, fake, mux, metrics, versionInfo, nil, nil, nil)
+	server := httptest.NewServer(mux)
+
+	c := client.NewClient(server.URL+"/v0", "test-token")
+	return c, server.Close
+}
+
+// writeYAML writes content to a temp file and returns its path.
+func writeYAML(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(content), 0644))
+	return path
+}
+
+// --- apply integration tests ---
+
+func TestApplyIntegration_Agent(t *testing.T) {
+	var capturedReq *models.AgentJSON
+	fake := servicetesting.NewFakeRegistry()
+	fake.CreateAgentFn = func(_ context.Context, req *models.AgentJSON) (*models.AgentResponse, error) {
+		capturedReq = req
+		return &models.AgentResponse{Agent: *req}, nil
+	}
+
+	c, cleanup := newTestServer(t, fake)
+	defer cleanup()
+	declarative.SetAPIClient(c)
+
+	yamlPath := writeYAML(t, `
+apiVersion: ar.dev/v1alpha1
+kind: Agent
+metadata:
+  name: acme/bot
+  version: "1.0.0"
+spec:
+  image: ghcr.io/acme/bot:latest
+  description: "A test bot"
+  language: python
+  framework: adk
+  modelProvider: google
+  modelName: gemini-2.0-flash
+`)
+
+	var buf bytes.Buffer
+	cmd := declarative.NewApplyCmd()
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{"-f", yamlPath})
+	require.NoError(t, cmd.Execute())
+
+	require.NotNil(t, capturedReq, "CreateAgent was not called")
+	assert.Equal(t, "acme/bot", capturedReq.Name)
+	assert.Equal(t, "1.0.0", capturedReq.Version)
+	assert.Equal(t, "adk", capturedReq.Framework)
+	assert.Equal(t, "python", capturedReq.Language)
+	assert.Equal(t, "google", capturedReq.ModelProvider)
+	assert.Equal(t, "gemini-2.0-flash", capturedReq.ModelName)
+	assert.Contains(t, buf.String(), "agent/acme/bot applied")
+}
+
+func TestApplyIntegration_MCPServer(t *testing.T) {
+	var capturedReq *apiv0.ServerJSON
+	fake := servicetesting.NewFakeRegistry()
+	fake.CreateServerFn = func(_ context.Context, req *apiv0.ServerJSON) (*apiv0.ServerResponse, error) {
+		capturedReq = req
+		return &apiv0.ServerResponse{Server: *req}, nil
+	}
+
+	c, cleanup := newTestServer(t, fake)
+	defer cleanup()
+	declarative.SetAPIClient(c)
+
+	yamlPath := writeYAML(t, `
+apiVersion: ar.dev/v1alpha1
+kind: MCPServer
+metadata:
+  name: acme/weather
+  version: "1.0.0"
+spec:
+  description: "Weather MCP server"
+`)
+
+	var buf bytes.Buffer
+	cmd := declarative.NewApplyCmd()
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{"-f", yamlPath})
+	require.NoError(t, cmd.Execute())
+
+	require.NotNil(t, capturedReq, "CreateServer was not called")
+	assert.Equal(t, "acme/weather", capturedReq.Name)
+	assert.Equal(t, "1.0.0", capturedReq.Version)
+	assert.Contains(t, buf.String(), "mcpserver/acme/weather applied")
+}
+
+func TestApplyIntegration_MultiDoc(t *testing.T) {
+	var agentCalled, serverCalled bool
+	fake := servicetesting.NewFakeRegistry()
+	fake.CreateAgentFn = func(_ context.Context, req *models.AgentJSON) (*models.AgentResponse, error) {
+		agentCalled = true
+		return &models.AgentResponse{Agent: *req}, nil
+	}
+	fake.CreateServerFn = func(_ context.Context, req *apiv0.ServerJSON) (*apiv0.ServerResponse, error) {
+		serverCalled = true
+		return &apiv0.ServerResponse{Server: *req}, nil
+	}
+
+	c, cleanup := newTestServer(t, fake)
+	defer cleanup()
+	declarative.SetAPIClient(c)
+
+	yamlPath := writeYAML(t, `
+apiVersion: ar.dev/v1alpha1
+kind: MCPServer
+metadata:
+  name: acme/weather
+  version: "1.0.0"
+spec:
+  description: "Weather MCP server"
+---
+apiVersion: ar.dev/v1alpha1
+kind: Agent
+metadata:
+  name: acme/bot
+  version: "1.0.0"
+spec:
+  image: ghcr.io/acme/bot:latest
+  description: "A test bot"
+  language: python
+  framework: adk
+  modelProvider: google
+  modelName: gemini-2.0-flash
+`)
+
+	var buf bytes.Buffer
+	cmd := declarative.NewApplyCmd()
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs([]string{"-f", yamlPath})
+	require.NoError(t, cmd.Execute())
+
+	assert.True(t, serverCalled, "CreateServer was not called")
+	assert.True(t, agentCalled, "CreateAgent was not called")
+	out := buf.String()
+	assert.Contains(t, out, "mcpserver/acme/weather applied")
+	assert.Contains(t, out, "agent/acme/bot applied")
+}
+
+func TestApplyIntegration_Overwrite_ReplacesExisting(t *testing.T) {
+	existing := &models.AgentResponse{
+		Agent: models.AgentJSON{
+			AgentManifest: models.AgentManifest{
+				Name:    "acme/bot",
+				Version: "1.0.0",
+			},
+			Version: "1.0.0",
+		},
+	}
+	var deletedName, deletedVersion string
+	var createCalled bool
+
+	fake := servicetesting.NewFakeRegistry()
+	fake.GetAgentByNameAndVersionFn = func(_ context.Context, name, version string) (*models.AgentResponse, error) {
+		return existing, nil
+	}
+	fake.DeleteAgentFn = func(_ context.Context, name, version string) error {
+		deletedName = name
+		deletedVersion = version
+		return nil
+	}
+	fake.CreateAgentFn = func(_ context.Context, req *models.AgentJSON) (*models.AgentResponse, error) {
+		createCalled = true
+		return &models.AgentResponse{Agent: *req}, nil
+	}
+
+	c, cleanup := newTestServer(t, fake)
+	defer cleanup()
+	declarative.SetAPIClient(c)
+
+	yamlPath := writeYAML(t, `
+apiVersion: ar.dev/v1alpha1
+kind: Agent
+metadata:
+  name: acme/bot
+  version: "1.0.0"
+spec:
+  image: ghcr.io/acme/bot:v2
+  description: "Updated bot"
+  language: python
+  framework: adk
+  modelProvider: google
+  modelName: gemini-2.0-flash
+`)
+
+	cmd := declarative.NewApplyCmd()
+	cmd.SetArgs([]string{"-f", yamlPath, "--overwrite"})
+	require.NoError(t, cmd.Execute())
+
+	assert.Equal(t, "acme/bot", deletedName)
+	assert.Equal(t, "1.0.0", deletedVersion)
+	assert.True(t, createCalled)
+}
+
+func TestApplyIntegration_Overwrite_CreatesWhenNotFound(t *testing.T) {
+	var createCalled bool
+
+	fake := servicetesting.NewFakeRegistry()
+	// Leave f.Agents empty → GetAgentByNameAndVersion returns ErrNotFound → client returns nil, nil
+	fake.CreateAgentFn = func(_ context.Context, req *models.AgentJSON) (*models.AgentResponse, error) {
+		createCalled = true
+		return &models.AgentResponse{Agent: *req}, nil
+	}
+
+	c, cleanup := newTestServer(t, fake)
+	defer cleanup()
+	declarative.SetAPIClient(c)
+
+	yamlPath := writeYAML(t, `
+apiVersion: ar.dev/v1alpha1
+kind: Agent
+metadata:
+  name: acme/new-bot
+  version: "1.0.0"
+spec:
+  image: ghcr.io/acme/new-bot:latest
+  description: "New bot"
+  language: python
+  framework: adk
+  modelProvider: google
+  modelName: gemini-2.0-flash
+`)
+
+	cmd := declarative.NewApplyCmd()
+	cmd.SetArgs([]string{"-f", yamlPath, "--overwrite"})
+	require.NoError(t, cmd.Execute())
+
+	assert.True(t, createCalled, "CreateAgent was not called")
+}
+
+// --- get integration tests ---
+
+func TestGetIntegration_ListAgents(t *testing.T) {
+	fake := servicetesting.NewFakeRegistry()
+	fake.ListAgentsFn = func(_ context.Context, _ *database.AgentFilter, _ string, _ int) ([]*models.AgentResponse, string, error) {
+		return []*models.AgentResponse{
+			{
+				Agent: models.AgentJSON{
+					AgentManifest: models.AgentManifest{
+						Name:          "acme/planner",
+						Description:   "Planning agent",
+						Version:       "1.0.0",
+						Framework:     "adk",
+						Language:      "python",
+						ModelProvider: "google",
+						ModelName:     "gemini-2.0-flash",
+					},
+					Version: "1.0.0",
+				},
+			},
+		}, "", nil
+	}
+
+	c, cleanup := newTestServer(t, fake)
+	defer cleanup()
+	declarative.SetAPIClient(c)
+
+	var buf bytes.Buffer
+	cmd := declarative.NewGetCmd()
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"agents"})
+	require.NoError(t, cmd.Execute())
+
+	out := buf.String()
+	assert.Contains(t, out, "acme/planner")
+}
+
+func TestGetIntegration_GetAgent_YAML(t *testing.T) {
+	fake := servicetesting.NewFakeRegistry()
+	fake.GetAgentByNameFn = func(_ context.Context, _ string) (*models.AgentResponse, error) {
+		return &models.AgentResponse{
+			Agent: models.AgentJSON{
+				AgentManifest: models.AgentManifest{
+					Name:          "acme/bot",
+					Description:   "A test bot",
+					Version:       "1.0.0",
+					Framework:     "adk",
+					Language:      "python",
+					ModelProvider: "google",
+					ModelName:     "gemini-2.0-flash",
+				},
+				Version: "1.0.0",
+			},
+		}, nil
+	}
+
+	c, cleanup := newTestServer(t, fake)
+	defer cleanup()
+	declarative.SetAPIClient(c)
+
+	var buf bytes.Buffer
+	cmd := declarative.NewGetCmd()
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"agent", "acme/bot", "-o", "yaml"})
+	require.NoError(t, cmd.Execute())
+
+	out := buf.String()
+	assert.Contains(t, out, "apiVersion: ar.dev/v1alpha1")
+	assert.Contains(t, out, "kind: Agent")
+	assert.Contains(t, out, "name: acme/bot")
+	assert.Contains(t, out, "version: 1.0.0")
+}
+
+func TestGetIntegration_GetAgent_JSON(t *testing.T) {
+	fake := servicetesting.NewFakeRegistry()
+	fake.GetAgentByNameFn = func(_ context.Context, _ string) (*models.AgentResponse, error) {
+		return &models.AgentResponse{
+			Agent: models.AgentJSON{
+				AgentManifest: models.AgentManifest{
+					Name:          "acme/bot",
+					Description:   "A test bot",
+					Version:       "1.0.0",
+					Framework:     "adk",
+					Language:      "python",
+					ModelProvider: "google",
+					ModelName:     "gemini-2.0-flash",
+				},
+				Version: "1.0.0",
+			},
+		}, nil
+	}
+
+	c, cleanup := newTestServer(t, fake)
+	defer cleanup()
+	declarative.SetAPIClient(c)
+
+	var buf bytes.Buffer
+	cmd := declarative.NewGetCmd()
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"agent", "acme/bot", "-o", "json"})
+	require.NoError(t, cmd.Execute())
+
+	out := buf.String()
+	assert.Contains(t, out, `"name"`)
+	assert.Contains(t, out, `"acme/bot"`)
+	assert.Contains(t, out, `"framework"`)
+}
+
+// --- delete integration tests ---
+
+func TestDeleteIntegration_Agent(t *testing.T) {
+	var deletedName, deletedVersion string
+	fake := servicetesting.NewFakeRegistry()
+	fake.DeleteAgentFn = func(_ context.Context, name, version string) error {
+		deletedName = name
+		deletedVersion = version
+		return nil
+	}
+
+	c, cleanup := newTestServer(t, fake)
+	defer cleanup()
+	declarative.SetAPIClient(c)
+
+	cmd := declarative.NewDeleteCmd()
+	cmd.SetArgs([]string{"agent", "acme/bot", "--version", "1.0.0"})
+	require.NoError(t, cmd.Execute())
+
+	assert.Equal(t, "acme/bot", deletedName)
+	assert.Equal(t, "1.0.0", deletedVersion)
+}
+
+func TestDeleteIntegration_MCPServer(t *testing.T) {
+	var deletedName, deletedVersion string
+	fake := servicetesting.NewFakeRegistry()
+	fake.DeleteServerFn = func(_ context.Context, name, version string) error {
+		deletedName = name
+		deletedVersion = version
+		return nil
+	}
+
+	c, cleanup := newTestServer(t, fake)
+	defer cleanup()
+	declarative.SetAPIClient(c)
+
+	cmd := declarative.NewDeleteCmd()
+	cmd.SetArgs([]string{"mcp", "acme/weather", "--version", "2.0.0"})
+	require.NoError(t, cmd.Execute())
+
+	assert.Equal(t, "acme/weather", deletedName)
+	assert.Equal(t, "2.0.0", deletedVersion)
+}
+
+func TestDeleteIntegration_FromFile(t *testing.T) {
+	var deletedName, deletedVersion string
+	fake := servicetesting.NewFakeRegistry()
+	fake.DeleteAgentFn = func(_ context.Context, name, version string) error {
+		deletedName = name
+		deletedVersion = version
+		return nil
+	}
+
+	c, cleanup := newTestServer(t, fake)
+	defer cleanup()
+	declarative.SetAPIClient(c)
+
+	// Write a declarative YAML file.
+	tmpDir := t.TempDir()
+	yamlFile := filepath.Join(tmpDir, "agent.yaml")
+	require.NoError(t, os.WriteFile(yamlFile, []byte(`
+apiVersion: ar.dev/v1alpha1
+kind: Agent
+metadata:
+  name: acme/bot
+  version: 1.0.0
+spec:
+  image: localhost:5001/bot:latest
+  language: python
+  framework: adk
+  modelProvider: google
+  modelName: gemini-2.0-flash
+  description: test
+`), 0o644))
+
+	cmd := declarative.NewDeleteCmd()
+	cmd.SetArgs([]string{"-f", yamlFile})
+	require.NoError(t, cmd.Execute())
+
+	assert.Equal(t, "acme/bot", deletedName)
+	assert.Equal(t, "1.0.0", deletedVersion)
+}
+
+func TestGetIntegration_ListMCPServers(t *testing.T) {
+	fake := servicetesting.NewFakeRegistry()
+	fake.ListServersFn = func(_ context.Context, _ *database.ServerFilter, _ string, _ int) ([]*apiv0.ServerResponse, string, error) {
+		return []*apiv0.ServerResponse{
+			{
+				Server: apiv0.ServerJSON{
+					Name:        "acme/weather",
+					Description: "Weather MCP server",
+					Version:     "1.0.0",
+				},
+			},
+		}, "", nil
+	}
+
+	c, cleanup := newTestServer(t, fake)
+	defer cleanup()
+	declarative.SetAPIClient(c)
+
+	var buf bytes.Buffer
+	cmd := declarative.NewGetCmd()
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"mcps"})
+	require.NoError(t, cmd.Execute())
+
+	out := buf.String()
+	assert.Contains(t, out, "acme/weather")
+}
+
+func TestGetIntegration_EmptyList(t *testing.T) {
+	fake := servicetesting.NewFakeRegistry()
+	// f.Agents is nil/empty → returns empty list
+
+	c, cleanup := newTestServer(t, fake)
+	defer cleanup()
+	declarative.SetAPIClient(c)
+
+	var buf bytes.Buffer
+	cmd := declarative.NewGetCmd()
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"agents"})
+	require.NoError(t, cmd.Execute())
+
+	assert.True(t, strings.Contains(buf.String(), "No agents found") ||
+		buf.String() == "", "expected empty output or 'No agents found'")
+}
+
+func TestGetIntegration_GetAll(t *testing.T) {
+	fake := servicetesting.NewFakeRegistry()
+	fake.ListAgentsFn = func(_ context.Context, _ *database.AgentFilter, _ string, _ int) ([]*models.AgentResponse, string, error) {
+		return []*models.AgentResponse{
+			{Agent: models.AgentJSON{AgentManifest: models.AgentManifest{Name: "summarizer", Version: "1.0.0"}, Version: "1.0.0"}},
+		}, "", nil
+	}
+	fake.ListServersFn = func(_ context.Context, _ *database.ServerFilter, _ string, _ int) ([]*apiv0.ServerResponse, string, error) {
+		return []*apiv0.ServerResponse{
+			{Server: apiv0.ServerJSON{Name: "acme/fetch", Version: "1.0.0"}},
+		}, "", nil
+	}
+
+	c, cleanup := newTestServer(t, fake)
+	defer cleanup()
+	declarative.SetAPIClient(c)
+
+	var buf bytes.Buffer
+	cmd := declarative.NewGetCmd()
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"all"})
+	require.NoError(t, cmd.Execute())
+
+	out := buf.String()
+	assert.Contains(t, out, "agents")
+	assert.Contains(t, out, "summarizer")
+	assert.Contains(t, out, "mcps")
+	assert.Contains(t, out, "acme/fetch")
+}
+
+func TestDeleteIntegration_MissingVersion(t *testing.T) {
+	fake := servicetesting.NewFakeRegistry()
+	c, cleanup := newTestServer(t, fake)
+	defer cleanup()
+	declarative.SetAPIClient(c)
+
+	cmd := declarative.NewDeleteCmd()
+	cmd.SetArgs([]string{"agent", "acme/bot"}) // no --version
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "version")
+}
+
+func TestDeleteIntegration_WrongArgCount(t *testing.T) {
+	fake := servicetesting.NewFakeRegistry()
+	c, cleanup := newTestServer(t, fake)
+	defer cleanup()
+	declarative.SetAPIClient(c)
+
+	cmd := declarative.NewDeleteCmd()
+	cmd.SetArgs([]string{"agent"}) // only TYPE, no NAME
+	err := cmd.Execute()
+	require.Error(t, err)
+}
+
+func TestDeleteIntegration_FromFile_MissingVersion(t *testing.T) {
+	fake := servicetesting.NewFakeRegistry()
+	c, cleanup := newTestServer(t, fake)
+	defer cleanup()
+	declarative.SetAPIClient(c)
+
+	// YAML with no metadata.version
+	yamlPath := writeYAML(t, `
+apiVersion: ar.dev/v1alpha1
+kind: Agent
+metadata:
+  name: acme/bot
+spec:
+  image: localhost:5001/bot:latest
+  language: python
+  framework: adk
+  modelProvider: google
+  modelName: gemini-2.0-flash
+  description: test
+`)
+
+	var errBuf bytes.Buffer
+	cmd := declarative.NewDeleteCmd()
+	cmd.SetErr(&errBuf)
+	cmd.SetArgs([]string{"-f", yamlPath})
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, errBuf.String(), "metadata.version is required")
+}
+
+func TestDeleteIntegration_FromFile_ContinuesOnError(t *testing.T) {
+	// Multi-doc: first resource has no version, second should still be attempted.
+	var deletedNames []string
+	fake := servicetesting.NewFakeRegistry()
+	fake.DeleteAgentFn = func(_ context.Context, name, version string) error {
+		deletedNames = append(deletedNames, name)
+		return nil
+	}
+
+	c, cleanup := newTestServer(t, fake)
+	defer cleanup()
+	declarative.SetAPIClient(c)
+
+	yamlPath := writeYAML(t, `
+apiVersion: ar.dev/v1alpha1
+kind: Agent
+metadata:
+  name: acme/bad
+spec:
+  description: missing version
+---
+apiVersion: ar.dev/v1alpha1
+kind: Agent
+metadata:
+  name: acme/good
+  version: "1.0.0"
+spec:
+  image: localhost:5001/good:latest
+  language: python
+  framework: adk
+  modelProvider: google
+  modelName: gemini-2.0-flash
+  description: test
+`)
+
+	var errBuf bytes.Buffer
+	cmd := declarative.NewDeleteCmd()
+	cmd.SetErr(&errBuf)
+	cmd.SetArgs([]string{"-f", yamlPath})
+	err := cmd.Execute()
+	require.Error(t, err, "should report error for missing version")
+	// The second resource (acme/good) must still be deleted
+	assert.Contains(t, deletedNames, "acme/good", "second resource should be processed despite first error")
+}
+
+func TestGetIntegration_GetAll_Empty(t *testing.T) {
+	fake := servicetesting.NewFakeRegistry()
+	// everything empty
+
+	c, cleanup := newTestServer(t, fake)
+	defer cleanup()
+	declarative.SetAPIClient(c)
+
+	var buf bytes.Buffer
+	cmd := declarative.NewGetCmd()
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"all"})
+	require.NoError(t, cmd.Execute())
+
+	assert.Contains(t, buf.String(), "No resources found.")
+}

--- a/internal/cli/mcp/frameworks/python/generator.go
+++ b/internal/cli/mcp/frameworks/python/generator.go
@@ -128,7 +128,7 @@ Do not edit manually - it will be overwritten when tools are loaded.
 
 	// Add import statements
 	for _, tool := range tools {
-		content.WriteString(fmt.Sprintf("from .%s import %s\n", tool, tool))
+		fmt.Fprintf(&content, "from .%s import %s\n", tool, tool)
 	}
 
 	// Add empty line
@@ -140,7 +140,7 @@ Do not edit manually - it will be overwritten when tools are loaded.
 		if i > 0 {
 			content.WriteString(", ")
 		}
-		content.WriteString(fmt.Sprintf(`"%s"`, tool))
+		fmt.Fprintf(&content, `"%s"`, tool)
 	}
 	content.WriteString("]\n")
 

--- a/internal/cli/resource/agent.go
+++ b/internal/cli/resource/agent.go
@@ -27,6 +27,7 @@ func (h *AgentHandler) Apply(c *client.Client, r *scheme.Resource, overwrite boo
 		return err
 	}
 
+	var deleted bool
 	if overwrite {
 		exists, err := c.GetAgentByNameAndVersion(agentJSON.Name, agentJSON.Version)
 		if err != nil {
@@ -36,11 +37,17 @@ func (h *AgentHandler) Apply(c *client.Client, r *scheme.Resource, overwrite boo
 			if err := c.DeleteAgent(agentJSON.Name, agentJSON.Version); err != nil {
 				return fmt.Errorf("deleting existing agent for overwrite: %w", err)
 			}
+			deleted = true
 		}
 	}
 
-	_, err = c.CreateAgent(agentJSON)
-	return err
+	if _, err = c.CreateAgent(agentJSON); err != nil {
+		if deleted {
+			return fmt.Errorf("agent/%s (%s) was deleted but re-create failed — resource no longer exists: %w", agentJSON.Name, agentJSON.Version, err)
+		}
+		return err
+	}
+	return nil
 }
 
 func (h *AgentHandler) List(c *client.Client) ([]any, error) {
@@ -93,6 +100,8 @@ func (h *AgentHandler) ToResource(item any) *scheme.Resource {
 	delete(spec, "name")
 	delete(spec, "version")
 	delete(spec, "updatedAt")
+	delete(spec, "status")
+	delete(spec, "publishedAt")
 
 	meta := scheme.Metadata{
 		Name:    a.Agent.Name,

--- a/internal/cli/resource/agent.go
+++ b/internal/cli/resource/agent.go
@@ -1,0 +1,135 @@
+package resource
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/agentregistry-dev/agentregistry/internal/cli/scheme"
+	"github.com/agentregistry-dev/agentregistry/internal/client"
+	"github.com/agentregistry-dev/agentregistry/pkg/models"
+	"github.com/agentregistry-dev/agentregistry/pkg/printer"
+)
+
+func init() {
+	Register(&AgentHandler{})
+}
+
+// AgentHandler implements ResourceHandler for the Agent kind.
+type AgentHandler struct{}
+
+func (h *AgentHandler) Kind() string     { return "Agent" }
+func (h *AgentHandler) Singular() string { return "agent" }
+func (h *AgentHandler) Plural() string   { return "agents" }
+
+func (h *AgentHandler) Apply(c *client.Client, r *scheme.Resource, overwrite bool) error {
+	agentJSON, err := h.toAgentJSON(r)
+	if err != nil {
+		return err
+	}
+
+	if overwrite {
+		exists, err := c.GetAgentByNameAndVersion(agentJSON.Name, agentJSON.Version)
+		if err != nil {
+			return fmt.Errorf("checking existing agent: %w", err)
+		}
+		if exists != nil {
+			if err := c.DeleteAgent(agentJSON.Name, agentJSON.Version); err != nil {
+				return fmt.Errorf("deleting existing agent for overwrite: %w", err)
+			}
+		}
+	}
+
+	_, err = c.CreateAgent(agentJSON)
+	return err
+}
+
+func (h *AgentHandler) List(c *client.Client) ([]any, error) {
+	agents, err := c.GetAgents()
+	if err != nil {
+		return nil, err
+	}
+	items := make([]any, len(agents))
+	for i, a := range agents {
+		items[i] = a
+	}
+	return items, nil
+}
+
+func (h *AgentHandler) Get(c *client.Client, name string) (any, error) {
+	return c.GetAgentByName(name)
+}
+
+func (h *AgentHandler) Delete(c *client.Client, name, version string) error {
+	return c.DeleteAgent(name, version)
+}
+
+func (h *AgentHandler) TableColumns() []string {
+	return []string{"Name", "Version", "Framework", "Language", "Provider", "Model"}
+}
+
+func (h *AgentHandler) TableRow(item any) []string {
+	a, ok := item.(*models.AgentResponse)
+	if !ok {
+		return []string{"<invalid>"}
+	}
+	return []string{
+		printer.TruncateString(a.Agent.Name, 40),
+		a.Agent.Version,
+		printer.EmptyValueOrDefault(a.Agent.Framework, "<none>"),
+		printer.EmptyValueOrDefault(a.Agent.Language, "<none>"),
+		printer.EmptyValueOrDefault(a.Agent.ModelProvider, "<none>"),
+		printer.TruncateString(printer.EmptyValueOrDefault(a.Agent.ModelName, "<none>"), 30),
+	}
+}
+
+func (h *AgentHandler) ToResource(item any) *scheme.Resource {
+	a, ok := item.(*models.AgentResponse)
+	if !ok {
+		return nil
+	}
+	b, _ := json.Marshal(a.Agent)
+	var spec map[string]any
+	_ = json.Unmarshal(b, &spec)
+	delete(spec, "name")
+	delete(spec, "version")
+	delete(spec, "updatedAt")
+
+	meta := scheme.Metadata{
+		Name:    a.Agent.Name,
+		Version: a.Agent.Version,
+	}
+	if a.Meta.Official != nil {
+		if !a.Meta.Official.PublishedAt.IsZero() {
+			t := a.Meta.Official.PublishedAt
+			meta.PublishedAt = &t
+		}
+		if !a.Meta.Official.UpdatedAt.IsZero() {
+			t := a.Meta.Official.UpdatedAt
+			meta.UpdatedAt = &t
+		}
+	}
+
+	return &scheme.Resource{
+		APIVersion: scheme.APIVersion,
+		Kind:       "Agent",
+		Metadata:   meta,
+		Spec:       spec,
+	}
+}
+
+func (h *AgentHandler) toAgentJSON(r *scheme.Resource) (*models.AgentJSON, error) {
+	b, err := json.Marshal(r.Spec)
+	if err != nil {
+		return nil, fmt.Errorf("marshalling Agent spec: %w", err)
+	}
+	var agentJSON models.AgentJSON
+	if err := json.Unmarshal(b, &agentJSON); err != nil {
+		return nil, fmt.Errorf("invalid Agent spec: %w", err)
+	}
+	agentJSON.Name = r.Metadata.Name
+	agentJSON.Version = r.Metadata.Version
+	if agentJSON.Status == "" {
+		agentJSON.Status = "active"
+	}
+	return &agentJSON, nil
+}

--- a/internal/cli/resource/handler.go
+++ b/internal/cli/resource/handler.go
@@ -1,0 +1,112 @@
+package resource
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+	"sync"
+
+	"github.com/agentregistry-dev/agentregistry/internal/cli/scheme"
+	"github.com/agentregistry-dev/agentregistry/internal/client"
+)
+
+// ResourceHandler translates between declarative YAML Resources and the registry API.
+type ResourceHandler interface {
+	Kind() string
+	Singular() string
+	Plural() string
+	Apply(c *client.Client, r *scheme.Resource, overwrite bool) error
+	List(c *client.Client) ([]any, error)
+	Get(c *client.Client, name string) (any, error)
+	Delete(c *client.Client, name, version string) error
+	TableColumns() []string
+	TableRow(item any) []string
+	ToResource(item any) *scheme.Resource
+}
+
+// Registry maps kind names and aliases to ResourceHandler implementations.
+type Registry struct {
+	mu      sync.RWMutex
+	byKind  map[string]ResourceHandler
+	aliases map[string]string
+}
+
+func NewRegistry() *Registry {
+	return &Registry{
+		byKind:  make(map[string]ResourceHandler),
+		aliases: make(map[string]string),
+	}
+}
+
+func (reg *Registry) Register(h ResourceHandler) {
+	reg.mu.Lock()
+	defer reg.mu.Unlock()
+
+	kind := h.Kind()
+	if _, exists := reg.byKind[kind]; exists {
+		panic(fmt.Sprintf("resource: duplicate registration for kind %q", kind))
+	}
+	reg.byKind[kind] = h
+	reg.aliases[strings.ToLower(kind)] = kind
+	reg.aliases[h.Singular()] = kind
+	reg.aliases[h.Plural()] = kind
+}
+
+func (reg *Registry) Lookup(name string) (ResourceHandler, error) {
+	reg.mu.RLock()
+	defer reg.mu.RUnlock()
+
+	lower := strings.ToLower(name)
+	if kind, ok := reg.aliases[lower]; ok {
+		return reg.byKind[kind], nil
+	}
+	return nil, fmt.Errorf("unknown resource type %q; supported types: %s", name, reg.knownTypes())
+}
+
+// All returns all registered handlers in a stable display order.
+func (reg *Registry) All() []ResourceHandler {
+	reg.mu.RLock()
+	defer reg.mu.RUnlock()
+
+	// Fixed display order: agents, mcps, skills, prompts
+	order := []string{"Agent", "MCPServer", "Skill", "Prompt"}
+	var out []ResourceHandler
+	for _, kind := range order {
+		if h, ok := reg.byKind[kind]; ok {
+			out = append(out, h)
+		}
+	}
+	// Append any kinds not in the fixed order. Note: map iteration is non-deterministic,
+	// so new resource types should be added to the order slice above to ensure stable output.
+	for kind, h := range reg.byKind {
+		found := slices.Contains(order, kind)
+		if !found {
+			out = append(out, h)
+		}
+	}
+	return out
+}
+
+func (reg *Registry) knownTypes() string {
+	var names []string
+	for _, h := range reg.byKind {
+		names = append(names, h.Plural())
+	}
+	slices.Sort(names)
+	return strings.Join(names, ", ")
+}
+
+// DefaultRegistry is the global registry used by CLI commands.
+var DefaultRegistry = NewRegistry()
+
+func Register(h ResourceHandler) {
+	DefaultRegistry.Register(h)
+}
+
+func Lookup(name string) (ResourceHandler, error) {
+	return DefaultRegistry.Lookup(name)
+}
+
+func All() []ResourceHandler {
+	return DefaultRegistry.All()
+}

--- a/internal/cli/resource/handler.go
+++ b/internal/cli/resource/handler.go
@@ -76,13 +76,16 @@ func (reg *Registry) All() []ResourceHandler {
 			out = append(out, h)
 		}
 	}
-	// Append any kinds not in the fixed order. Note: map iteration is non-deterministic,
-	// so new resource types should be added to the order slice above to ensure stable output.
-	for kind, h := range reg.byKind {
-		found := slices.Contains(order, kind)
-		if !found {
-			out = append(out, h)
+	// Append any kinds not in the fixed order, sorted for deterministic output.
+	var extra []string
+	for kind := range reg.byKind {
+		if !slices.Contains(order, kind) {
+			extra = append(extra, kind)
 		}
+	}
+	slices.Sort(extra)
+	for _, kind := range extra {
+		out = append(out, reg.byKind[kind])
 	}
 	return out
 }

--- a/internal/cli/resource/handler_test.go
+++ b/internal/cli/resource/handler_test.go
@@ -1,0 +1,299 @@
+package resource_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/agentregistry-dev/agentregistry/internal/cli/resource"
+	"github.com/agentregistry-dev/agentregistry/internal/cli/scheme"
+	"github.com/agentregistry-dev/agentregistry/internal/client"
+	"github.com/agentregistry-dev/agentregistry/pkg/models"
+	v0 "github.com/modelcontextprotocol/registry/pkg/api/v0"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// stubHandler is a minimal ResourceHandler for testing the registry.
+type stubHandler struct{ kind, singular, plural string }
+
+func (s *stubHandler) Kind() string                                             { return s.kind }
+func (s *stubHandler) Singular() string                                         { return s.singular }
+func (s *stubHandler) Plural() string                                           { return s.plural }
+func (s *stubHandler) Apply(_ *client.Client, _ *scheme.Resource, _ bool) error { return nil }
+func (s *stubHandler) List(_ *client.Client) ([]any, error)                     { return nil, nil }
+func (s *stubHandler) Get(_ *client.Client, _ string) (any, error)              { return nil, nil }
+func (s *stubHandler) Delete(_ *client.Client, _, _ string) error               { return nil }
+func (s *stubHandler) TableColumns() []string                                   { return nil }
+func (s *stubHandler) TableRow(_ any) []string                                  { return nil }
+func (s *stubHandler) ToResource(_ any) *scheme.Resource                        { return nil }
+
+func TestLookup_ByKind(t *testing.T) {
+	r := resource.NewRegistry()
+	r.Register(&stubHandler{kind: "Widget", singular: "widget", plural: "widgets"})
+
+	h, err := r.Lookup("Widget")
+	require.NoError(t, err)
+	assert.Equal(t, "Widget", h.Kind())
+}
+
+func TestLookup_ByPlural(t *testing.T) {
+	r := resource.NewRegistry()
+	r.Register(&stubHandler{kind: "Widget", singular: "widget", plural: "widgets"})
+
+	h, err := r.Lookup("widgets")
+	require.NoError(t, err)
+	assert.Equal(t, "Widget", h.Kind())
+}
+
+func TestLookup_BySingular(t *testing.T) {
+	r := resource.NewRegistry()
+	r.Register(&stubHandler{kind: "Widget", singular: "widget", plural: "widgets"})
+
+	h, err := r.Lookup("widget")
+	require.NoError(t, err)
+	assert.Equal(t, "Widget", h.Kind())
+}
+
+func TestLookup_Unknown(t *testing.T) {
+	r := resource.NewRegistry()
+	_, err := r.Lookup("Unknown")
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "unknown resource type")
+}
+
+func TestAgentHandler_Lookup(t *testing.T) {
+	h, err := resource.Lookup("agents")
+	require.NoError(t, err)
+	assert.Equal(t, "Agent", h.Kind())
+	assert.Equal(t, "agents", h.Plural())
+	assert.Equal(t, "agent", h.Singular())
+}
+
+func TestAgentHandler_TableColumns(t *testing.T) {
+	h, err := resource.Lookup("Agent")
+	require.NoError(t, err)
+	cols := h.TableColumns()
+	assert.Contains(t, cols, "Name")
+	assert.Contains(t, cols, "Version")
+	assert.Contains(t, cols, "Framework")
+}
+
+func TestAgentHandler_TableRow(t *testing.T) {
+	h, err := resource.Lookup("Agent")
+	require.NoError(t, err)
+
+	item := &models.AgentResponse{
+		Agent: models.AgentJSON{
+			AgentManifest: models.AgentManifest{
+				Name:          "acme/bot",
+				Framework:     "adk",
+				Language:      "python",
+				ModelProvider: "google",
+				ModelName:     "gemini-2.0-flash",
+			},
+			Version: "1.0.0",
+		},
+	}
+	row := h.TableRow(item)
+	assert.Equal(t, "acme/bot", row[0])
+	assert.Equal(t, "1.0.0", row[1])
+}
+
+func TestAgentHandler_ToResource(t *testing.T) {
+	h, err := resource.Lookup("Agent")
+	require.NoError(t, err)
+
+	item := &models.AgentResponse{
+		Agent: models.AgentJSON{
+			AgentManifest: models.AgentManifest{
+				Name:          "acme/bot",
+				Framework:     "adk",
+				Language:      "python",
+				ModelProvider: "google",
+				ModelName:     "gemini-2.0-flash",
+				Description:   "A bot",
+			},
+			Version: "1.0.0",
+		},
+	}
+	r := h.ToResource(item)
+	require.NotNil(t, r)
+	assert.Equal(t, scheme.APIVersion, r.APIVersion)
+	assert.Equal(t, "Agent", r.Kind)
+	assert.Equal(t, "acme/bot", r.Metadata.Name)
+	assert.Equal(t, "1.0.0", r.Metadata.Version)
+	assert.Equal(t, "adk", r.Spec["framework"])
+	// updatedAt must not appear in spec
+	assert.NotContains(t, r.Spec, "updatedAt")
+	// timestamps absent when registry hasn't set them
+	assert.Nil(t, r.Metadata.PublishedAt)
+	assert.Nil(t, r.Metadata.UpdatedAt)
+}
+
+func TestAgentHandler_ToResource_Timestamps(t *testing.T) {
+	h, err := resource.Lookup("Agent")
+	require.NoError(t, err)
+
+	published := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	updated := time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC)
+
+	item := &models.AgentResponse{
+		Agent: models.AgentJSON{
+			AgentManifest: models.AgentManifest{
+				Name:          "acme/bot",
+				Framework:     "adk",
+				Language:      "python",
+				ModelProvider: "google",
+				ModelName:     "gemini-2.0-flash",
+				Description:   "A bot",
+			},
+			Version: "1.0.0",
+		},
+		Meta: models.AgentResponseMeta{
+			Official: &models.AgentRegistryExtensions{
+				PublishedAt: published,
+				UpdatedAt:   updated,
+			},
+		},
+	}
+	r := h.ToResource(item)
+	require.NotNil(t, r)
+	assert.NotContains(t, r.Spec, "updatedAt")
+	require.NotNil(t, r.Metadata.PublishedAt)
+	assert.Equal(t, published, *r.Metadata.PublishedAt)
+	require.NotNil(t, r.Metadata.UpdatedAt)
+	assert.Equal(t, updated, *r.Metadata.UpdatedAt)
+}
+
+func TestMCPServerHandler_ToResource_Timestamps(t *testing.T) {
+	h, err := resource.Lookup("MCPServer")
+	require.NoError(t, err)
+
+	published := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	updated := time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC)
+
+	item := &v0.ServerResponse{
+		Server: v0.ServerJSON{Name: "acme/fetch", Version: "1.0.0", Description: "Fetches URLs"},
+		Meta: v0.ResponseMeta{
+			Official: &v0.RegistryExtensions{PublishedAt: published, UpdatedAt: updated},
+		},
+	}
+	r := h.ToResource(item)
+	require.NotNil(t, r)
+	assert.NotContains(t, r.Spec, "updatedAt")
+	require.NotNil(t, r.Metadata.PublishedAt)
+	assert.Equal(t, published, *r.Metadata.PublishedAt)
+	require.NotNil(t, r.Metadata.UpdatedAt)
+	assert.Equal(t, updated, *r.Metadata.UpdatedAt)
+}
+
+func TestMCPServerHandler_Lookup(t *testing.T) {
+	h, err := resource.Lookup("mcps")
+	require.NoError(t, err)
+	assert.Equal(t, "MCPServer", h.Kind())
+	assert.Equal(t, "mcp", h.Singular())
+}
+
+func TestMCPServerHandler_TableRow(t *testing.T) {
+	h, err := resource.Lookup("MCPServer")
+	require.NoError(t, err)
+
+	item := &v0.ServerResponse{
+		Server: v0.ServerJSON{
+			Name:        "acme/fetch",
+			Version:     "1.0.0",
+			Description: "Fetches URLs",
+		},
+	}
+	row := h.TableRow(item)
+	assert.Equal(t, "acme/fetch", row[0])
+	assert.Equal(t, "1.0.0", row[1])
+}
+
+func TestSkillHandler_Lookup(t *testing.T) {
+	h, err := resource.Lookup("skills")
+	require.NoError(t, err)
+	assert.Equal(t, "Skill", h.Kind())
+}
+
+func TestSkillHandler_TableRow(t *testing.T) {
+	h, err := resource.Lookup("Skill")
+	require.NoError(t, err)
+
+	item := &models.SkillResponse{
+		Skill: models.SkillJSON{
+			Name:        "acme/summarize",
+			Version:     "1.0.0",
+			Description: "Summarizes text",
+		},
+	}
+	row := h.TableRow(item)
+	assert.Equal(t, "acme/summarize", row[0])
+	assert.Equal(t, "1.0.0", row[1])
+}
+
+func TestSkillHandler_ToResource_Timestamps(t *testing.T) {
+	h, err := resource.Lookup("Skill")
+	require.NoError(t, err)
+
+	published := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	updated := time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC)
+
+	item := &models.SkillResponse{
+		Skill: models.SkillJSON{Name: "acme/summarize", Version: "1.0.0", Description: "Summarizes text"},
+		Meta: models.SkillResponseMeta{
+			Official: &models.SkillRegistryExtensions{PublishedAt: published, UpdatedAt: updated},
+		},
+	}
+	r := h.ToResource(item)
+	require.NotNil(t, r)
+	assert.NotContains(t, r.Spec, "updatedAt")
+	require.NotNil(t, r.Metadata.PublishedAt)
+	assert.Equal(t, published, *r.Metadata.PublishedAt)
+	require.NotNil(t, r.Metadata.UpdatedAt)
+	assert.Equal(t, updated, *r.Metadata.UpdatedAt)
+}
+
+func TestPromptHandler_Lookup(t *testing.T) {
+	h, err := resource.Lookup("prompts")
+	require.NoError(t, err)
+	assert.Equal(t, "Prompt", h.Kind())
+}
+
+func TestPromptHandler_ToResource_Timestamps(t *testing.T) {
+	h, err := resource.Lookup("Prompt")
+	require.NoError(t, err)
+
+	published := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	updated := time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC)
+
+	item := &models.PromptResponse{
+		Prompt: models.PromptJSON{Name: "acme/system", Version: "1.0.0", Content: "You are helpful."},
+		Meta: models.PromptResponseMeta{
+			Official: &models.PromptRegistryExtensions{PublishedAt: published, UpdatedAt: updated},
+		},
+	}
+	r := h.ToResource(item)
+	require.NotNil(t, r)
+	assert.NotContains(t, r.Spec, "updatedAt")
+	require.NotNil(t, r.Metadata.PublishedAt)
+	assert.Equal(t, published, *r.Metadata.PublishedAt)
+	require.NotNil(t, r.Metadata.UpdatedAt)
+	assert.Equal(t, updated, *r.Metadata.UpdatedAt)
+}
+
+func TestPromptHandler_TableRow(t *testing.T) {
+	h, err := resource.Lookup("Prompt")
+	require.NoError(t, err)
+
+	item := &models.PromptResponse{
+		Prompt: models.PromptJSON{
+			Name:    "acme/system",
+			Version: "1.0.0",
+			Content: "You are a helpful assistant.",
+		},
+	}
+	row := h.TableRow(item)
+	assert.Equal(t, "acme/system", row[0])
+	assert.Equal(t, "1.0.0", row[1])
+}

--- a/internal/cli/resource/mcpserver.go
+++ b/internal/cli/resource/mcpserver.go
@@ -28,6 +28,7 @@ func (h *MCPServerHandler) Apply(c *client.Client, r *scheme.Resource, overwrite
 		return err
 	}
 
+	var deleted bool
 	if overwrite {
 		exists, err := c.GetServerByNameAndVersion(serverJSON.Name, serverJSON.Version)
 		if err != nil {
@@ -37,11 +38,17 @@ func (h *MCPServerHandler) Apply(c *client.Client, r *scheme.Resource, overwrite
 			if err := c.DeleteMCPServer(serverJSON.Name, serverJSON.Version); err != nil {
 				return fmt.Errorf("deleting existing server for overwrite: %w", err)
 			}
+			deleted = true
 		}
 	}
 
-	_, err = c.CreateMCPServer(serverJSON)
-	return err
+	if _, err = c.CreateMCPServer(serverJSON); err != nil {
+		if deleted {
+			return fmt.Errorf("mcpserver/%s (%s) was deleted but re-create failed — resource no longer exists: %w", serverJSON.Name, serverJSON.Version, err)
+		}
+		return err
+	}
+	return nil
 }
 
 func (h *MCPServerHandler) List(c *client.Client) ([]any, error) {
@@ -91,6 +98,8 @@ func (h *MCPServerHandler) ToResource(item any) *scheme.Resource {
 	delete(spec, "name")
 	delete(spec, "version")
 	delete(spec, "updatedAt")
+	delete(spec, "status")
+	delete(spec, "publishedAt")
 
 	meta := scheme.Metadata{
 		Name:    s.Server.Name,

--- a/internal/cli/resource/mcpserver.go
+++ b/internal/cli/resource/mcpserver.go
@@ -1,0 +1,133 @@
+package resource
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/agentregistry-dev/agentregistry/internal/cli/scheme"
+	"github.com/agentregistry-dev/agentregistry/internal/client"
+	"github.com/agentregistry-dev/agentregistry/pkg/printer"
+	v0 "github.com/modelcontextprotocol/registry/pkg/api/v0"
+	"github.com/modelcontextprotocol/registry/pkg/model"
+)
+
+func init() {
+	Register(&MCPServerHandler{})
+}
+
+// MCPServerHandler implements ResourceHandler for the MCPServer kind.
+type MCPServerHandler struct{}
+
+func (h *MCPServerHandler) Kind() string     { return "MCPServer" }
+func (h *MCPServerHandler) Singular() string { return "mcp" }
+func (h *MCPServerHandler) Plural() string   { return "mcps" }
+
+func (h *MCPServerHandler) Apply(c *client.Client, r *scheme.Resource, overwrite bool) error {
+	serverJSON, err := h.toServerJSON(r)
+	if err != nil {
+		return err
+	}
+
+	if overwrite {
+		exists, err := c.GetServerByNameAndVersion(serverJSON.Name, serverJSON.Version)
+		if err != nil {
+			return fmt.Errorf("checking existing server: %w", err)
+		}
+		if exists != nil {
+			if err := c.DeleteMCPServer(serverJSON.Name, serverJSON.Version); err != nil {
+				return fmt.Errorf("deleting existing server for overwrite: %w", err)
+			}
+		}
+	}
+
+	_, err = c.CreateMCPServer(serverJSON)
+	return err
+}
+
+func (h *MCPServerHandler) List(c *client.Client) ([]any, error) {
+	servers, err := c.GetPublishedServers()
+	if err != nil {
+		return nil, err
+	}
+	items := make([]any, len(servers))
+	for i, s := range servers {
+		items[i] = s
+	}
+	return items, nil
+}
+
+func (h *MCPServerHandler) Get(c *client.Client, name string) (any, error) {
+	return c.GetServerByName(name)
+}
+
+func (h *MCPServerHandler) Delete(c *client.Client, name, version string) error {
+	return c.DeleteMCPServer(name, version)
+}
+
+func (h *MCPServerHandler) TableColumns() []string {
+	return []string{"Name", "Version", "Description"}
+}
+
+func (h *MCPServerHandler) TableRow(item any) []string {
+	s, ok := item.(*v0.ServerResponse)
+	if !ok {
+		return []string{"<invalid>"}
+	}
+	return []string{
+		printer.TruncateString(s.Server.Name, 40),
+		s.Server.Version,
+		printer.TruncateString(printer.EmptyValueOrDefault(s.Server.Description, "<none>"), 60),
+	}
+}
+
+func (h *MCPServerHandler) ToResource(item any) *scheme.Resource {
+	s, ok := item.(*v0.ServerResponse)
+	if !ok {
+		return nil
+	}
+	b, _ := json.Marshal(s.Server)
+	var spec map[string]any
+	_ = json.Unmarshal(b, &spec)
+	delete(spec, "name")
+	delete(spec, "version")
+	delete(spec, "updatedAt")
+
+	meta := scheme.Metadata{
+		Name:    s.Server.Name,
+		Version: s.Server.Version,
+	}
+	if s.Meta.Official != nil {
+		if !s.Meta.Official.PublishedAt.IsZero() {
+			t := s.Meta.Official.PublishedAt
+			meta.PublishedAt = &t
+		}
+		if !s.Meta.Official.UpdatedAt.IsZero() {
+			t := s.Meta.Official.UpdatedAt
+			meta.UpdatedAt = &t
+		}
+	}
+
+	return &scheme.Resource{
+		APIVersion: scheme.APIVersion,
+		Kind:       "MCPServer",
+		Metadata:   meta,
+		Spec:       spec,
+	}
+}
+
+func (h *MCPServerHandler) toServerJSON(r *scheme.Resource) (*v0.ServerJSON, error) {
+	b, err := json.Marshal(r.Spec)
+	if err != nil {
+		return nil, fmt.Errorf("marshalling MCPServer spec: %w", err)
+	}
+	var serverJSON v0.ServerJSON
+	if err := json.Unmarshal(b, &serverJSON); err != nil {
+		return nil, fmt.Errorf("invalid MCPServer spec: %w", err)
+	}
+	serverJSON.Name = r.Metadata.Name
+	serverJSON.Version = r.Metadata.Version
+	if serverJSON.Schema == "" {
+		serverJSON.Schema = model.CurrentSchemaURL
+	}
+	return &serverJSON, nil
+}

--- a/internal/cli/resource/prompt.go
+++ b/internal/cli/resource/prompt.go
@@ -25,6 +25,7 @@ func (h *PromptHandler) Apply(c *client.Client, r *scheme.Resource, overwrite bo
 	if err != nil {
 		return err
 	}
+	var deleted bool
 	if overwrite {
 		exists, err := c.GetPromptByNameAndVersion(promptJSON.Name, promptJSON.Version)
 		if err != nil {
@@ -34,10 +35,16 @@ func (h *PromptHandler) Apply(c *client.Client, r *scheme.Resource, overwrite bo
 			if err := c.DeletePrompt(promptJSON.Name, promptJSON.Version); err != nil {
 				return fmt.Errorf("deleting existing prompt for overwrite: %w", err)
 			}
+			deleted = true
 		}
 	}
-	_, err = c.CreatePrompt(promptJSON)
-	return err
+	if _, err = c.CreatePrompt(promptJSON); err != nil {
+		if deleted {
+			return fmt.Errorf("prompt/%s (%s) was deleted but re-create failed — resource no longer exists: %w", promptJSON.Name, promptJSON.Version, err)
+		}
+		return err
+	}
+	return nil
 }
 
 func (h *PromptHandler) List(c *client.Client) ([]any, error) {
@@ -87,6 +94,8 @@ func (h *PromptHandler) ToResource(item any) *scheme.Resource {
 	delete(spec, "name")
 	delete(spec, "version")
 	delete(spec, "updatedAt")
+	delete(spec, "status")
+	delete(spec, "publishedAt")
 
 	meta := scheme.Metadata{Name: p.Prompt.Name, Version: p.Prompt.Version}
 	if p.Meta.Official != nil {

--- a/internal/cli/resource/prompt.go
+++ b/internal/cli/resource/prompt.go
@@ -1,0 +1,122 @@
+package resource
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/agentregistry-dev/agentregistry/internal/cli/scheme"
+	"github.com/agentregistry-dev/agentregistry/internal/client"
+	"github.com/agentregistry-dev/agentregistry/pkg/models"
+	"github.com/agentregistry-dev/agentregistry/pkg/printer"
+)
+
+func init() {
+	Register(&PromptHandler{})
+}
+
+type PromptHandler struct{}
+
+func (h *PromptHandler) Kind() string     { return "Prompt" }
+func (h *PromptHandler) Singular() string { return "prompt" }
+func (h *PromptHandler) Plural() string   { return "prompts" }
+
+func (h *PromptHandler) Apply(c *client.Client, r *scheme.Resource, overwrite bool) error {
+	promptJSON, err := h.toPromptJSON(r)
+	if err != nil {
+		return err
+	}
+	if overwrite {
+		exists, err := c.GetPromptByNameAndVersion(promptJSON.Name, promptJSON.Version)
+		if err != nil {
+			return fmt.Errorf("checking existing prompt: %w", err)
+		}
+		if exists != nil {
+			if err := c.DeletePrompt(promptJSON.Name, promptJSON.Version); err != nil {
+				return fmt.Errorf("deleting existing prompt for overwrite: %w", err)
+			}
+		}
+	}
+	_, err = c.CreatePrompt(promptJSON)
+	return err
+}
+
+func (h *PromptHandler) List(c *client.Client) ([]any, error) {
+	prompts, err := c.GetPrompts()
+	if err != nil {
+		return nil, err
+	}
+	items := make([]any, len(prompts))
+	for i, p := range prompts {
+		items[i] = p
+	}
+	return items, nil
+}
+
+func (h *PromptHandler) Get(c *client.Client, name string) (any, error) {
+	return c.GetPromptByName(name)
+}
+
+func (h *PromptHandler) Delete(c *client.Client, name, version string) error {
+	return c.DeletePrompt(name, version)
+}
+
+func (h *PromptHandler) TableColumns() []string {
+	return []string{"Name", "Version", "Description"}
+}
+
+func (h *PromptHandler) TableRow(item any) []string {
+	p, ok := item.(*models.PromptResponse)
+	if !ok {
+		return []string{"<invalid>"}
+	}
+	return []string{
+		printer.TruncateString(p.Prompt.Name, 40),
+		p.Prompt.Version,
+		printer.TruncateString(printer.EmptyValueOrDefault(p.Prompt.Description, "<none>"), 60),
+	}
+}
+
+func (h *PromptHandler) ToResource(item any) *scheme.Resource {
+	p, ok := item.(*models.PromptResponse)
+	if !ok {
+		return nil
+	}
+	b, _ := json.Marshal(p.Prompt)
+	var spec map[string]any
+	_ = json.Unmarshal(b, &spec)
+	delete(spec, "name")
+	delete(spec, "version")
+	delete(spec, "updatedAt")
+
+	meta := scheme.Metadata{Name: p.Prompt.Name, Version: p.Prompt.Version}
+	if p.Meta.Official != nil {
+		if !p.Meta.Official.PublishedAt.IsZero() {
+			t := p.Meta.Official.PublishedAt
+			meta.PublishedAt = &t
+		}
+		if !p.Meta.Official.UpdatedAt.IsZero() {
+			t := p.Meta.Official.UpdatedAt
+			meta.UpdatedAt = &t
+		}
+	}
+	return &scheme.Resource{
+		APIVersion: scheme.APIVersion,
+		Kind:       "Prompt",
+		Metadata:   meta,
+		Spec:       spec,
+	}
+}
+
+func (h *PromptHandler) toPromptJSON(r *scheme.Resource) (*models.PromptJSON, error) {
+	b, err := json.Marshal(r.Spec)
+	if err != nil {
+		return nil, fmt.Errorf("marshalling Prompt spec: %w", err)
+	}
+	var promptJSON models.PromptJSON
+	if err := json.Unmarshal(b, &promptJSON); err != nil {
+		return nil, fmt.Errorf("invalid Prompt spec: %w", err)
+	}
+	promptJSON.Name = r.Metadata.Name
+	promptJSON.Version = r.Metadata.Version
+	return &promptJSON, nil
+}

--- a/internal/cli/resource/skill.go
+++ b/internal/cli/resource/skill.go
@@ -25,6 +25,7 @@ func (h *SkillHandler) Apply(c *client.Client, r *scheme.Resource, overwrite boo
 	if err != nil {
 		return err
 	}
+	var deleted bool
 	if overwrite {
 		exists, err := c.GetSkillByNameAndVersion(skillJSON.Name, skillJSON.Version)
 		if err != nil {
@@ -34,10 +35,16 @@ func (h *SkillHandler) Apply(c *client.Client, r *scheme.Resource, overwrite boo
 			if err := c.DeleteSkill(skillJSON.Name, skillJSON.Version); err != nil {
 				return fmt.Errorf("deleting existing skill for overwrite: %w", err)
 			}
+			deleted = true
 		}
 	}
-	_, err = c.CreateSkill(skillJSON)
-	return err
+	if _, err = c.CreateSkill(skillJSON); err != nil {
+		if deleted {
+			return fmt.Errorf("skill/%s (%s) was deleted but re-create failed — resource no longer exists: %w", skillJSON.Name, skillJSON.Version, err)
+		}
+		return err
+	}
+	return nil
 }
 
 func (h *SkillHandler) List(c *client.Client) ([]any, error) {
@@ -88,6 +95,8 @@ func (h *SkillHandler) ToResource(item any) *scheme.Resource {
 	delete(spec, "name")
 	delete(spec, "version")
 	delete(spec, "updatedAt")
+	delete(spec, "status")
+	delete(spec, "publishedAt")
 
 	meta := scheme.Metadata{Name: s.Skill.Name, Version: s.Skill.Version}
 	if s.Meta.Official != nil {

--- a/internal/cli/resource/skill.go
+++ b/internal/cli/resource/skill.go
@@ -1,0 +1,123 @@
+package resource
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/agentregistry-dev/agentregistry/internal/cli/scheme"
+	"github.com/agentregistry-dev/agentregistry/internal/client"
+	"github.com/agentregistry-dev/agentregistry/pkg/models"
+	"github.com/agentregistry-dev/agentregistry/pkg/printer"
+)
+
+func init() {
+	Register(&SkillHandler{})
+}
+
+type SkillHandler struct{}
+
+func (h *SkillHandler) Kind() string     { return "Skill" }
+func (h *SkillHandler) Singular() string { return "skill" }
+func (h *SkillHandler) Plural() string   { return "skills" }
+
+func (h *SkillHandler) Apply(c *client.Client, r *scheme.Resource, overwrite bool) error {
+	skillJSON, err := h.toSkillJSON(r)
+	if err != nil {
+		return err
+	}
+	if overwrite {
+		exists, err := c.GetSkillByNameAndVersion(skillJSON.Name, skillJSON.Version)
+		if err != nil {
+			return fmt.Errorf("checking existing skill: %w", err)
+		}
+		if exists != nil {
+			if err := c.DeleteSkill(skillJSON.Name, skillJSON.Version); err != nil {
+				return fmt.Errorf("deleting existing skill for overwrite: %w", err)
+			}
+		}
+	}
+	_, err = c.CreateSkill(skillJSON)
+	return err
+}
+
+func (h *SkillHandler) List(c *client.Client) ([]any, error) {
+	skills, err := c.GetSkills()
+	if err != nil {
+		return nil, err
+	}
+	items := make([]any, len(skills))
+	for i, s := range skills {
+		items[i] = s
+	}
+	return items, nil
+}
+
+func (h *SkillHandler) Get(c *client.Client, name string) (any, error) {
+	return c.GetSkillByName(name)
+}
+
+func (h *SkillHandler) Delete(c *client.Client, name, version string) error {
+	return c.DeleteSkill(name, version)
+}
+
+func (h *SkillHandler) TableColumns() []string {
+	return []string{"Name", "Version", "Category", "Description"}
+}
+
+func (h *SkillHandler) TableRow(item any) []string {
+	s, ok := item.(*models.SkillResponse)
+	if !ok {
+		return []string{"<invalid>"}
+	}
+	return []string{
+		printer.TruncateString(s.Skill.Name, 40),
+		s.Skill.Version,
+		printer.EmptyValueOrDefault(s.Skill.Category, "<none>"),
+		printer.TruncateString(printer.EmptyValueOrDefault(s.Skill.Description, "<none>"), 60),
+	}
+}
+
+func (h *SkillHandler) ToResource(item any) *scheme.Resource {
+	s, ok := item.(*models.SkillResponse)
+	if !ok {
+		return nil
+	}
+	b, _ := json.Marshal(s.Skill)
+	var spec map[string]any
+	_ = json.Unmarshal(b, &spec)
+	delete(spec, "name")
+	delete(spec, "version")
+	delete(spec, "updatedAt")
+
+	meta := scheme.Metadata{Name: s.Skill.Name, Version: s.Skill.Version}
+	if s.Meta.Official != nil {
+		if !s.Meta.Official.PublishedAt.IsZero() {
+			t := s.Meta.Official.PublishedAt
+			meta.PublishedAt = &t
+		}
+		if !s.Meta.Official.UpdatedAt.IsZero() {
+			t := s.Meta.Official.UpdatedAt
+			meta.UpdatedAt = &t
+		}
+	}
+	return &scheme.Resource{
+		APIVersion: scheme.APIVersion,
+		Kind:       "Skill",
+		Metadata:   meta,
+		Spec:       spec,
+	}
+}
+
+func (h *SkillHandler) toSkillJSON(r *scheme.Resource) (*models.SkillJSON, error) {
+	b, err := json.Marshal(r.Spec)
+	if err != nil {
+		return nil, fmt.Errorf("marshalling Skill spec: %w", err)
+	}
+	var skillJSON models.SkillJSON
+	if err := json.Unmarshal(b, &skillJSON); err != nil {
+		return nil, fmt.Errorf("invalid Skill spec: %w", err)
+	}
+	skillJSON.Name = r.Metadata.Name
+	skillJSON.Version = r.Metadata.Version
+	return &skillJSON, nil
+}

--- a/internal/cli/scheme/scheme.go
+++ b/internal/cli/scheme/scheme.go
@@ -1,0 +1,83 @@
+package scheme
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+const APIVersion = "ar.dev/v1alpha1"
+
+// Resource is the universal declarative envelope for all registry resources.
+type Resource struct {
+	APIVersion string         `yaml:"apiVersion"`
+	Kind       string         `yaml:"kind"`
+	Metadata   Metadata       `yaml:"metadata"`
+	Spec       map[string]any `yaml:"spec"`
+}
+
+// Metadata holds the resource identity and server-generated timestamps.
+type Metadata struct {
+	Name        string     `yaml:"name"`
+	Version     string     `yaml:"version,omitempty"`
+	PublishedAt *time.Time `yaml:"publishedAt,omitempty"`
+	UpdatedAt   *time.Time `yaml:"updatedAt,omitempty"`
+}
+
+// DecodeBytes parses one or more YAML documents from b.
+// Each document must have apiVersion, kind, and metadata.name.
+// Returns an error if any document is invalid or if no documents are found.
+func DecodeBytes(b []byte) ([]*Resource, error) {
+	dec := yaml.NewDecoder(bytes.NewReader(b))
+	var resources []*Resource
+
+	for {
+		var r Resource
+		if err := dec.Decode(&r); err != nil {
+			if err == io.EOF {
+				break
+			}
+			return nil, fmt.Errorf("parsing YAML: %w", err)
+		}
+
+		// Skip entirely empty documents (e.g. trailing ---)
+		if r.Kind == "" && r.APIVersion == "" && r.Metadata.Name == "" {
+			continue
+		}
+
+		if r.Kind == "" {
+			return nil, fmt.Errorf("resource missing required field 'kind'")
+		}
+		if r.APIVersion == "" {
+			return nil, fmt.Errorf("resource %q missing required field 'apiVersion'", r.Kind)
+		}
+		if r.APIVersion != APIVersion {
+			return nil, fmt.Errorf("resource %s/%s: unsupported apiVersion %q; expected %q",
+				r.Kind, r.Metadata.Name, r.APIVersion, APIVersion)
+		}
+		if r.Metadata.Name == "" {
+			return nil, fmt.Errorf("resource %q missing required field 'metadata.name'", r.Kind)
+		}
+
+		resources = append(resources, &r)
+	}
+
+	if len(resources) == 0 {
+		return nil, fmt.Errorf("no resources found in input")
+	}
+
+	return resources, nil
+}
+
+// DecodeFile reads a file at path and parses its YAML documents.
+func DecodeFile(path string) ([]*Resource, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading %s: %w", path, err)
+	}
+	return DecodeBytes(data)
+}

--- a/internal/cli/scheme/scheme_test.go
+++ b/internal/cli/scheme/scheme_test.go
@@ -1,0 +1,108 @@
+package scheme_test
+
+import (
+	"testing"
+
+	"github.com/agentregistry-dev/agentregistry/internal/cli/scheme"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecodeBytes_SingleDoc(t *testing.T) {
+	input := `
+apiVersion: ar.dev/v1alpha1
+kind: Agent
+metadata:
+  name: acme/bot
+  version: "1.0.0"
+spec:
+  image: ghcr.io/acme/bot:latest
+  description: "A bot"
+  language: python
+  framework: adk
+  modelProvider: google
+  modelName: gemini-2.0-flash
+`
+	resources, err := scheme.DecodeBytes([]byte(input))
+	require.NoError(t, err)
+	require.Len(t, resources, 1)
+	assert.Equal(t, "ar.dev/v1alpha1", resources[0].APIVersion)
+	assert.Equal(t, "Agent", resources[0].Kind)
+	assert.Equal(t, "acme/bot", resources[0].Metadata.Name)
+	assert.Equal(t, "1.0.0", resources[0].Metadata.Version)
+	assert.Equal(t, "ghcr.io/acme/bot:latest", resources[0].Spec["image"])
+}
+
+func TestDecodeBytes_MultiDoc(t *testing.T) {
+	input := `
+apiVersion: ar.dev/v1alpha1
+kind: MCPServer
+metadata:
+  name: acme/fetch
+  version: "1.0.0"
+spec:
+  description: "Fetches URLs"
+---
+apiVersion: ar.dev/v1alpha1
+kind: Agent
+metadata:
+  name: acme/bot
+  version: "1.0.0"
+spec:
+  description: "A bot"
+  image: ghcr.io/acme/bot:latest
+  language: python
+  framework: adk
+  modelProvider: google
+  modelName: gemini-2.0-flash
+`
+	resources, err := scheme.DecodeBytes([]byte(input))
+	require.NoError(t, err)
+	require.Len(t, resources, 2)
+	assert.Equal(t, "MCPServer", resources[0].Kind)
+	assert.Equal(t, "Agent", resources[1].Kind)
+}
+
+func TestDecodeBytes_MissingKind(t *testing.T) {
+	input := `
+apiVersion: ar.dev/v1alpha1
+metadata:
+  name: acme/bot
+  version: "1.0.0"
+spec:
+  image: ghcr.io/acme/bot:latest
+`
+	_, err := scheme.DecodeBytes([]byte(input))
+	assert.ErrorContains(t, err, "kind")
+}
+
+func TestDecodeBytes_MissingName(t *testing.T) {
+	input := `
+apiVersion: ar.dev/v1alpha1
+kind: Agent
+metadata:
+  version: "1.0.0"
+spec:
+  image: ghcr.io/acme/bot:latest
+`
+	_, err := scheme.DecodeBytes([]byte(input))
+	assert.ErrorContains(t, err, "metadata.name")
+}
+
+func TestDecodeBytes_WrongAPIVersion(t *testing.T) {
+	input := `
+apiVersion: v1
+kind: Agent
+metadata:
+  name: acme/bot
+  version: "1.0.0"
+spec: {}
+`
+	_, err := scheme.DecodeBytes([]byte(input))
+	assert.ErrorContains(t, err, "apiVersion")
+}
+
+func TestDecodeBytes_EmptyInput(t *testing.T) {
+	_, err := scheme.DecodeBytes([]byte(""))
+	assert.ErrorContains(t, err, "no resources")
+}

--- a/internal/registry/importer/importer.go
+++ b/internal/registry/importer/importer.go
@@ -156,7 +156,7 @@ func (s *Service) ImportFromPath(ctx context.Context, path string, enrichServerD
 
 	// Import each server using registry service CreateServer
 	total := len(pending)
-	var processed int32
+	var processed atomic.Int32
 
 	wg := &sync.WaitGroup{}
 	concurrencyLimit := 10
@@ -172,7 +172,7 @@ func (s *Service) ImportFromPath(ctx context.Context, path string, enrichServerD
 				wg.Done()
 			}()
 
-			current := atomic.AddInt32(&processed, 1)
+			current := processed.Add(1)
 			s.logger.Info("importing server", "current", current, "total", total, "name", srv.Name, "version", srv.Version)
 			s.importServer(ctx, srv, readmeSeeds, enrichServerData)
 		}()

--- a/pkg/cli/commands_test.go
+++ b/pkg/cli/commands_test.go
@@ -14,12 +14,17 @@ func TestCommandTree(t *testing.T) {
 
 	expectedTopLevel := []string{
 		"agent",
+		"apply",
+		"build",
 		"configure",
 		"daemon",
+		"delete",
 		"deployments",
 		"embeddings",
 		"export",
+		"get",
 		"import",
+		"init",
 		"mcp",
 		"prompt",
 		"skill",

--- a/pkg/cli/resource/resource.go
+++ b/pkg/cli/resource/resource.go
@@ -1,0 +1,39 @@
+// Package resource provides a public API for registering declarative resource
+// handlers. Enterprise or third-party extensions can implement ResourceHandler
+// and call Register to extend the arctl declarative CLI (apply/get/delete).
+package resource
+
+import (
+	"github.com/agentregistry-dev/agentregistry/internal/cli/resource"
+	"github.com/agentregistry-dev/agentregistry/internal/cli/scheme"
+	"github.com/agentregistry-dev/agentregistry/internal/client"
+)
+
+// ResourceHandler is the public alias for the internal ResourceHandler interface.
+// Implementing this interface and calling Register makes a resource type
+// available to `arctl apply`, `arctl get`, and `arctl delete`.
+type ResourceHandler = resource.ResourceHandler
+
+// Metadata is the public alias for scheme.Metadata.
+type Metadata = scheme.Metadata
+
+// Resource is the public alias for scheme.Resource.
+type Resource = scheme.Resource
+
+// Client is the public alias for the OSS registry client.
+// Handlers that only use the enterprise client can safely ignore this parameter.
+type Client = client.Client
+
+// APIVersion is the canonical apiVersion string for arctl resources ("ar.dev/v1alpha1").
+const APIVersion = scheme.APIVersion
+
+// Register adds h to the global resource registry used by arctl declarative commands.
+// Call this from an init() function or before cli.Root() is invoked.
+func Register(h ResourceHandler) {
+	resource.Register(h)
+}
+
+// Lookup resolves a type name (kind, singular, or plural) to its ResourceHandler.
+func Lookup(name string) (ResourceHandler, error) {
+	return resource.Lookup(name)
+}

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -12,6 +12,7 @@ import (
 	agentutils "github.com/agentregistry-dev/agentregistry/internal/cli/agent/utils"
 	"github.com/agentregistry-dev/agentregistry/internal/cli/configure"
 	clidaemon "github.com/agentregistry-dev/agentregistry/internal/cli/daemon"
+	"github.com/agentregistry-dev/agentregistry/internal/cli/declarative"
 	"github.com/agentregistry-dev/agentregistry/internal/cli/deployment"
 	"github.com/agentregistry-dev/agentregistry/internal/cli/mcp"
 	"github.com/agentregistry-dev/agentregistry/internal/cli/prompt"
@@ -78,6 +79,7 @@ var rootCmd = &cobra.Command{
 		prompt.SetAPIClient(c)
 		deployment.SetAPIClient(c)
 		cli.SetAPIClient(c)
+		declarative.SetAPIClient(c)
 		return nil
 	},
 }
@@ -97,6 +99,11 @@ func init() {
 	rootCmd.AddCommand(cli.EmbeddingsCmd)
 	rootCmd.AddCommand(deployment.DeploymentCmd)
 	rootCmd.AddCommand(clidaemon.New(dockercompose.NewManager(dockercompose.DefaultConfig())))
+	rootCmd.AddCommand(declarative.ApplyCmd)
+	rootCmd.AddCommand(declarative.GetCmd)
+	rootCmd.AddCommand(declarative.DeleteCmd)
+	rootCmd.AddCommand(declarative.InitCmd)
+	rootCmd.AddCommand(declarative.BuildCmd)
 }
 
 // resolveRegistryTarget returns base URL and token from flags and env.
@@ -156,6 +163,8 @@ var preRunSkipCommands = map[string]map[string]bool{
 		"completion": true,
 		"configure":  true,
 		"version":    true,
+		"init":       true,
+		"build":      true,
 	},
 	"agent": {
 		"build": true,

--- a/pkg/validators/names.go
+++ b/pkg/validators/names.go
@@ -70,7 +70,7 @@ func ValidateAgentName(name string) error {
 	}
 
 	if !agentNameRegex.MatchString(name) {
-		return fmt.Errorf("agent name must start with a letter and contain only letters and digits (minimum 2 characters)")
+		return fmt.Errorf("agent name must start with a letter and contain only letters and digits (no hyphens, underscores, or dots; minimum 2 characters)")
 	}
 
 	// Reject Python keywords to avoid issues in generated code


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don't apply.
-->

# Description

<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

**Motivation:** 
Users needed a kubectl-style declarative workflow to manage Agent Registry resources — defining agents, MCP servers, skills, and prompts as YAML files and applying them with a single command, rather than calling imperative API commands directly. 

**What changed:**
  - `arctl apply -f <file>` — applies one or more YAML documents (multi-doc files supported); resources are processed in document order so         
  dependencies can precede the agent in a single file
  - `arctl get <resource> [name] `— lists or fetches a single resource; supports -o yaml for full output                                           
  - `arctl delete -f <file>` and `arctl delete <kind> <name> --version` — removes resources declaratively or explicitly                              
  - `arctl init agent|mcp|skill|prompt` — scaffolds a project directory and generates a typed YAML manifest                                        
  - `arctl build <dir> --push `— builds and pushes a Docker image for agent/MCP/skill projects
  - Unit, integration, and e2e test coverage                                    
  - docs/declarative-cli.md and examples/declarative/ with working example YAML files for all resource types
  - fixed Mac Docker buildx pushes by routing them through a dedicated buildnet network to kind-registry:5000
  
# Change Type

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bump
/kind cleanup
/kind design
/kind deprecation
/kind documentation
/kind feature
/kind fix
/kind flake
/kind install
```
-->
/kind feature
# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
feat: add declarative cli
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
1. refer to docs/declarative-cli.md to do manual testing. 

```
## Agents

arctl init agent adk python summarizer --model-provider gemini --model-name gemini-2.0-flash
arctl build summarizer/ --push    # optional: build and push Docker image
arctl apply -f summarizer/agent.yaml
arctl get agent summarizer
arctl delete agent summarizer --version 0.1.0

## MCP Servers

arctl init mcp fastmcp-python acme/my-server
arctl build my-server/ --push    # optional: build and push Docker image
arctl apply -f my-server/mcp.yaml
arctl get mcps
arctl delete mcp acme/my-server --version 0.1.0

## Skills & Prompts

arctl init skill summarize --category nlp
arctl apply -f summarize/skill.yaml
arctl get skills
arctl delete skill summarize --version 0.1.0

arctl init prompt summarizer-system-prompt
arctl apply -f summarizer-system-prompt.yaml
arctl get prompts
arctl delete prompt summarizer-system-prompt --version 0.1.0

# Apply multiple resources from one file (separated by ---)
# List all resource types at once
arctl apply -f examples/declarative/full-stack.yaml
arctl get all
arctl delete -f examples/declarative/full-stack.yaml
```

2. **Known limitation (follow-up):** `arctl agent run .` does not work with declarative `agent.yaml` — it uses the old flat format Needs a separate fix.