### PR TITLE
feat(agents): support extensible agent manifests with additional elem…

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -363,6 +363,83 @@ huma.Get(api, "/agents/{id}", func(ctx context.Context, input *GetAgentInput) (*
 })
 ```
 
+### Extensible Agent Manifests
+
+Agent manifests support custom fields beyond the standard schema for forward compatibility and extensibility. Any additional top-level fields in an agent manifest are:
+
+- **Captured during registration** - Unknown fields are preserved in `AdditionalElements`
+- **Stored in the database** - Extra fields persist across the API lifecycle
+- **Returned in API responses** - Available as `extraElements` in `AgentResponse`
+- **Displayed in the UI** - Rendered in the agent detail view under "Additional Elements"
+
+**Example agent manifest with custom fields:**
+
+```json
+{
+  "name": "emailTemplateAgent",
+  "version": "1.0.0",
+  "framework": "custom",
+  "language": "python",
+  "description": "Template stateless email-channel agent",
+  "modelProvider": "openai",
+  "modelName": "gpt-4o-mini",
+  "card": {
+    "displayName": "Email Template Agent",
+    "category": "communication",
+    "tags": ["email", "templates"]
+  },
+  "deployment": {
+    "namespace": "email-template-dev",
+    "replicas": 3,
+    "resources": {
+      "limits": {"cpu": "500m", "memory": "512Mi"}
+    }
+  }
+}
+```
+
+**Implementation details:**
+
+The `AgentJSON` type implements custom `MarshalJSON` and `UnmarshalJSON` methods to handle additional fields:
+
+```go
+// Custom fields are captured during unmarshaling
+var agent AgentJSON
+json.Unmarshal(data, &agent)
+// agent.AdditionalElements now contains "card" and "deployment"
+
+// Custom fields are merged during marshaling
+data, _ := json.Marshal(agent)
+// data contains all standard fields plus additional elements at top level
+```
+
+**Use cases:**
+
+- **Custom metadata** - Add display names, categories, or tags for UI purposes
+- **Deployment configuration** - Include platform-specific deployment settings
+- **Integration hooks** - Store webhook URLs or external service configurations
+- **Organization context** - Add cost centers, ownership, or compliance metadata
+- **Forward compatibility** - Future schema extensions don't break existing clients
+
+**API response structure:**
+
+```json
+{
+  "agent": {
+    "name": "emailTemplateAgent",
+    "version": "1.0.0",
+    ...standard fields...
+  },
+  "extraElements": {
+    "card": {...},
+    "deployment": {...}
+  },
+  "_meta": {
+    "io.modelcontextprotocol.registry/official": {...}
+  }
+}
+```
+
 ---
 
 ## Frontend Development

--- a/internal/cli/agent/frameworks/common/manifest_manager_test.go
+++ b/internal/cli/agent/frameworks/common/manifest_manager_test.go
@@ -1,6 +1,8 @@
 package common
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -85,5 +87,55 @@ func TestValidateRemoteMcpServer(t *testing.T) {
 				t.Fatalf("unexpected error: %v", err)
 			}
 		})
+	}
+}
+
+func TestManifestManagerPreservesAdditionalElements(t *testing.T) {
+	projectDir := t.TempDir()
+	manifestPath := filepath.Join(projectDir, ManifestFileName)
+	content := `
+agentName: test-agent
+language: python
+framework: langgraph
+description: Preserves extra elements
+card:
+  name: test-agent
+  version: 1.0.0
+custom_element:
+  enabled: true
+`
+
+	if err := os.WriteFile(manifestPath, []byte(strings.TrimSpace(content)), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	manager := NewManifestManager(projectDir)
+	manifest, err := manager.Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	if _, ok := manifest.AdditionalElements["card"]; !ok {
+		t.Fatalf("expected card to be preserved, got %v", manifest.AdditionalElements)
+	}
+	if _, ok := manifest.AdditionalElements["custom_element"]; !ok {
+		t.Fatalf("expected custom_element to be preserved, got %v", manifest.AdditionalElements)
+	}
+
+	if err := manager.Save(manifest); err != nil {
+		t.Fatalf("Save() error = %v", err)
+	}
+
+	savedData, err := os.ReadFile(manifestPath)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+
+	saved := string(savedData)
+	if !strings.Contains(saved, "card:") {
+		t.Fatalf("expected saved manifest to contain card, got:\n%s", saved)
+	}
+	if !strings.Contains(saved, "custom_element:") {
+		t.Fatalf("expected saved manifest to contain custom_element, got:\n%s", saved)
 	}
 }

--- a/internal/registry/api/handlers/v0/agents.go
+++ b/internal/registry/api/handlers/v0/agents.go
@@ -2,6 +2,7 @@ package v0
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/url"
@@ -247,13 +248,23 @@ func RegisterAgentsEndpoints(api huma.API, pathPrefix string, registry service.R
 
 // CreateAgentInput represents the input for creating/updating an agent
 type CreateAgentInput struct {
-	Body agentmodels.AgentJSON `body:""`
+	Body map[string]any `body:""`
 }
 
 // createAgentHandler is the shared handler logic for creating agents
 func createAgentHandler(ctx context.Context, input *CreateAgentInput, registry service.RegistryService) (*types.Response[agentmodels.AgentResponse], error) {
+	payload, err := json.Marshal(input.Body)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Failed to parse agent payload", err)
+	}
+
+	var agentJSON agentmodels.AgentJSON
+	if err := json.Unmarshal(payload, &agentJSON); err != nil {
+		return nil, huma.Error400BadRequest("Failed to parse agent payload", err)
+	}
+
 	// Create/update the agent (published defaults to false in the service layer)
-	createdAgent, err := registry.CreateAgent(ctx, &input.Body)
+	createdAgent, err := registry.CreateAgent(ctx, &agentJSON)
 	if err != nil {
 		if errors.Is(err, database.ErrNotFound) {
 			return nil, huma.Error404NotFound("Not found")

--- a/internal/registry/api/handlers/v0/agents_test.go
+++ b/internal/registry/api/handlers/v0/agents_test.go
@@ -1,0 +1,81 @@
+package v0_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	v0 "github.com/agentregistry-dev/agentregistry/internal/registry/api/handlers/v0"
+	servicetesting "github.com/agentregistry-dev/agentregistry/internal/registry/service/testing"
+	"github.com/agentregistry-dev/agentregistry/pkg/models"
+	"github.com/danielgtaylor/huma/v2"
+	"github.com/danielgtaylor/huma/v2/adapters/humago"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateAgentAcceptsExtraTopLevelElements(t *testing.T) {
+	mux := http.NewServeMux()
+	api := humago.New(mux, huma.DefaultConfig("Test API", "1.0.0"))
+	fake := servicetesting.NewFakeRegistry()
+
+	fake.CreateAgentFn = func(_ context.Context, req *models.AgentJSON) (*models.AgentResponse, error) {
+		require.Equal(t, "emailTemplateAgent", req.Name)
+		require.Equal(t, "1.0.0", req.Version)
+		require.Contains(t, req.AdditionalElements, "card")
+		require.Contains(t, req.AdditionalElements, "deployment")
+
+		return &models.AgentResponse{
+			Agent: models.AgentJSON{
+				AgentManifest: models.AgentManifest{
+					Name:          req.Name,
+					Framework:     req.Framework,
+					Language:      req.Language,
+					Description:   req.Description,
+					Image:         req.Image,
+					ModelName:     req.ModelName,
+					ModelProvider: req.ModelProvider,
+				},
+				Version: req.Version,
+				Status:  "active",
+			},
+			ExtraElements: req.AdditionalElements,
+		}, nil
+	}
+
+	v0.RegisterAgentsCreateEndpoint(api, "/v0", fake)
+
+	body := map[string]any{
+		"name":          "emailTemplateAgent",
+		"version":       "1.0.0",
+		"framework":     "custom",
+		"language":      "python",
+		"description":   "Template stateless email-channel agent",
+		"image":         "",
+		"modelProvider": "openai",
+		"modelName":     "gpt-4o-mini",
+		"card": map[string]any{
+			"name":    "emailTemplateAgent",
+			"version": "1.0.0",
+		},
+		"deployment": map[string]any{
+			"namespace": "email-template-dev",
+		},
+	}
+
+	payload, err := json.Marshal(body)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/v0/agents", bytes.NewReader(payload))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), `"extraElements"`)
+	assert.Contains(t, w.Body.String(), `"card"`)
+	assert.Contains(t, w.Body.String(), `"deployment"`)
+}

--- a/internal/registry/database/postgres.go
+++ b/internal/registry/database/postgres.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"maps"
 	"strings"
 	"time"
 
@@ -1290,21 +1291,9 @@ func (db *PostgreSQL) ListAgents(ctx context.Context, tx pgx.Tx, filter *databas
 			return nil, "", fmt.Errorf("failed to scan agent row: %w", err)
 		}
 
-		var agentJSON models.AgentJSON
-		if err := json.Unmarshal(valueJSON, &agentJSON); err != nil {
-			return nil, "", fmt.Errorf("failed to unmarshal agent JSON: %w", err)
-		}
-
-		resp := &models.AgentResponse{
-			Agent: agentJSON,
-			Meta: models.AgentResponseMeta{
-				Official: &models.AgentRegistryExtensions{
-					Status:      status,
-					PublishedAt: publishedAt,
-					UpdatedAt:   updatedAt,
-					IsLatest:    isLatest,
-				},
-			},
+		resp, err := buildAgentResponse(valueJSON, status, publishedAt, updatedAt, isLatest)
+		if err != nil {
+			return nil, "", err
 		}
 		if semanticActive && semanticScore.Valid {
 			resp.Meta.Semantic = &models.AgentSemanticMeta{
@@ -1355,21 +1344,7 @@ func (db *PostgreSQL) GetAgentByName(ctx context.Context, tx pgx.Tx, agentName s
 		}
 		return nil, fmt.Errorf("failed to get agent by name: %w", err)
 	}
-	var agentJSON models.AgentJSON
-	if err := json.Unmarshal(valueJSON, &agentJSON); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal agent JSON: %w", err)
-	}
-	return &models.AgentResponse{
-		Agent: agentJSON,
-		Meta: models.AgentResponseMeta{
-			Official: &models.AgentRegistryExtensions{
-				Status:      status,
-				PublishedAt: publishedAt,
-				UpdatedAt:   updatedAt,
-				IsLatest:    isLatest,
-			},
-		},
-	}, nil
+	return buildAgentResponse(valueJSON, status, publishedAt, updatedAt, isLatest)
 }
 
 func (db *PostgreSQL) GetAgentByNameAndVersion(ctx context.Context, tx pgx.Tx, agentName, version string) (*models.AgentResponse, error) {
@@ -1401,12 +1376,20 @@ func (db *PostgreSQL) GetAgentByNameAndVersion(ctx context.Context, tx pgx.Tx, a
 		}
 		return nil, fmt.Errorf("failed to get agent by name and version: %w", err)
 	}
+	return buildAgentResponse(valueJSON, status, publishedAt, updatedAt, isLatest)
+}
+
+func buildAgentResponse(valueJSON []byte, status string, publishedAt, updatedAt time.Time, isLatest bool) (*models.AgentResponse, error) {
 	var agentJSON models.AgentJSON
 	if err := json.Unmarshal(valueJSON, &agentJSON); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal agent JSON: %w", err)
 	}
+
+	agentForResponse := agentJSON
+	agentForResponse.AdditionalElements = nil
+
 	return &models.AgentResponse{
-		Agent: agentJSON,
+		Agent: agentForResponse,
 		Meta: models.AgentResponseMeta{
 			Official: &models.AgentRegistryExtensions{
 				Status:      status,
@@ -1415,6 +1398,7 @@ func (db *PostgreSQL) GetAgentByNameAndVersion(ctx context.Context, tx pgx.Tx, a
 				IsLatest:    isLatest,
 			},
 		},
+		ExtraElements: cloneStringAnyMap(agentJSON.AdditionalElements),
 	}, nil
 }
 
@@ -1450,21 +1434,11 @@ func (db *PostgreSQL) GetAllVersionsByAgentName(ctx context.Context, tx pgx.Tx, 
 		if err := rows.Scan(&name, &version, &status, &publishedAt, &updatedAt, &isLatest, &valueJSON); err != nil {
 			return nil, fmt.Errorf("failed to scan agent row: %w", err)
 		}
-		var agentJSON models.AgentJSON
-		if err := json.Unmarshal(valueJSON, &agentJSON); err != nil {
-			return nil, fmt.Errorf("failed to unmarshal agent JSON: %w", err)
+		resp, err := buildAgentResponse(valueJSON, status, publishedAt, updatedAt, isLatest)
+		if err != nil {
+			return nil, err
 		}
-		results = append(results, &models.AgentResponse{
-			Agent: agentJSON,
-			Meta: models.AgentResponseMeta{
-				Official: &models.AgentRegistryExtensions{
-					Status:      status,
-					PublishedAt: publishedAt,
-					UpdatedAt:   updatedAt,
-					IsLatest:    isLatest,
-				},
-			},
-		})
+		results = append(results, resp)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("error iterating agent rows: %w", err)
@@ -1512,12 +1486,7 @@ func (db *PostgreSQL) CreateAgent(ctx context.Context, tx pgx.Tx, agentJSON *mod
 	); err != nil {
 		return nil, fmt.Errorf("failed to insert agent: %w", err)
 	}
-	return &models.AgentResponse{
-		Agent: *agentJSON,
-		Meta: models.AgentResponseMeta{
-			Official: officialMeta,
-		},
-	}, nil
+	return buildAgentResponse(valueJSON, officialMeta.Status, officialMeta.PublishedAt, officialMeta.UpdatedAt, officialMeta.IsLatest)
 }
 
 func (db *PostgreSQL) UpdateAgent(ctx context.Context, tx pgx.Tx, agentName, version string, agentJSON *models.AgentJSON) (*models.AgentResponse, error) {
@@ -1557,17 +1526,17 @@ func (db *PostgreSQL) UpdateAgent(ctx context.Context, tx pgx.Tx, agentName, ver
 		}
 		return nil, fmt.Errorf("failed to update agent: %w", err)
 	}
-	return &models.AgentResponse{
-		Agent: *agentJSON,
-		Meta: models.AgentResponseMeta{
-			Official: &models.AgentRegistryExtensions{
-				Status:      status,
-				PublishedAt: publishedAt,
-				UpdatedAt:   updatedAt,
-				IsLatest:    isLatest,
-			},
-		},
-	}, nil
+	return buildAgentResponse(valueJSON, status, publishedAt, updatedAt, isLatest)
+}
+
+func cloneStringAnyMap(input map[string]any) map[string]any {
+	if len(input) == 0 {
+		return nil
+	}
+
+	cloned := make(map[string]any, len(input))
+	maps.Copy(cloned, input)
+	return cloned
 }
 
 func (db *PostgreSQL) SetAgentStatus(ctx context.Context, tx pgx.Tx, agentName, version string, status string) (*models.AgentResponse, error) {
@@ -1598,21 +1567,7 @@ func (db *PostgreSQL) SetAgentStatus(ctx context.Context, tx pgx.Tx, agentName, 
 		}
 		return nil, fmt.Errorf("failed to update agent status: %w", err)
 	}
-	var agentJSON models.AgentJSON
-	if err := json.Unmarshal(valueJSON, &agentJSON); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal agent JSON: %w", err)
-	}
-	return &models.AgentResponse{
-		Agent: agentJSON,
-		Meta: models.AgentResponseMeta{
-			Official: &models.AgentRegistryExtensions{
-				Status:      currentStatus,
-				PublishedAt: publishedAt,
-				UpdatedAt:   updatedAt,
-				IsLatest:    isLatest,
-			},
-		},
-	}, nil
+	return buildAgentResponse(valueJSON, currentStatus, publishedAt, updatedAt, isLatest)
 }
 
 func (db *PostgreSQL) GetCurrentLatestAgentVersion(ctx context.Context, tx pgx.Tx, agentName string) (*models.AgentResponse, error) {
@@ -1644,21 +1599,7 @@ func (db *PostgreSQL) GetCurrentLatestAgentVersion(ctx context.Context, tx pgx.T
 		}
 		return nil, fmt.Errorf("failed to scan agent row: %w", err)
 	}
-	var agentJSON models.AgentJSON
-	if err := json.Unmarshal(jsonValue, &agentJSON); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal agent JSON: %w", err)
-	}
-	return &models.AgentResponse{
-		Agent: agentJSON,
-		Meta: models.AgentResponseMeta{
-			Official: &models.AgentRegistryExtensions{
-				PublishedAt: publishedAt,
-				UpdatedAt:   updatedAt,
-				IsLatest:    isLatest,
-				Status:      status,
-			},
-		},
-	}, nil
+	return buildAgentResponse(jsonValue, status, publishedAt, updatedAt, isLatest)
 }
 
 func (db *PostgreSQL) CountAgentVersions(ctx context.Context, tx pgx.Tx, agentName string) (int, error) {

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1718,6 +1718,10 @@ components:
                     $ref: '#/components/schemas/AgentResponseMeta'
                 agent:
                     $ref: '#/components/schemas/AgentJSON'
+                extraElements:
+                    type: object
+                    description: Additional top-level elements preserved from the original agent payload for UI display and forward compatibility.
+                    additionalProperties: {}
             required:
                 - agent
                 - _meta

--- a/pkg/models/agent.go
+++ b/pkg/models/agent.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"encoding/json"
 	"time"
 
 	"github.com/modelcontextprotocol/registry/pkg/model"
@@ -16,6 +17,94 @@ type AgentJSON struct {
 	Repository    *model.Repository  `json:"repository,omitempty" doc:"Optional repository metadata for the agent source code."`
 	Packages      []AgentPackageInfo `json:"packages,omitempty"`
 	Remotes       []model.Transport  `json:"remotes,omitempty"`
+}
+
+var agentJSONKnownKeys = map[string]struct{}{
+	"description":       {},
+	"framework":         {},
+	"image":             {},
+	"language":          {},
+	"mcpServers":        {},
+	"modelName":         {},
+	"modelProvider":     {},
+	"name":              {},
+	"packages":          {},
+	"prompts":           {},
+	"remotes":           {},
+	"repository":        {},
+	"skills":            {},
+	"status":            {},
+	"telemetryEndpoint": {},
+	"title":             {},
+	"updatedAt":         {},
+	"version":           {},
+	"websiteUrl":        {},
+}
+
+// MarshalJSON implements custom JSON marshaling for AgentJSON.
+// It merges AdditionalElements into the top-level JSON object,
+// allowing arbitrary fields to be preserved alongside known fields.
+// This enables forward compatibility with extended agent manifests.
+func (a AgentJSON) MarshalJSON() ([]byte, error) {
+	type alias AgentJSON
+
+	basePayload, err := json.Marshal(alias(a))
+	if err != nil {
+		return nil, err
+	}
+	if len(a.AdditionalElements) == 0 {
+		return basePayload, nil
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(basePayload, &payload); err != nil {
+		return nil, err
+	}
+
+	for key, value := range a.AdditionalElements {
+		if _, exists := payload[key]; exists {
+			continue
+		}
+		payload[key] = value
+	}
+
+	return json.Marshal(payload)
+}
+
+// UnmarshalJSON implements custom JSON unmarshaling for AgentJSON.
+// It captures any unknown fields into AdditionalElements, supporting
+// forward compatibility with extended agent manifests. This allows agents
+// to include custom metadata, deployment configurations, or other
+// extension fields that are preserved through the API lifecycle.
+func (a *AgentJSON) UnmarshalJSON(data []byte) error {
+	type alias AgentJSON
+
+	var decoded alias
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return err
+	}
+
+	var raw map[string]any
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	extraElements := make(map[string]any)
+	for key, value := range raw {
+		if _, known := agentJSONKnownKeys[key]; known {
+			continue
+		}
+		extraElements[key] = value
+	}
+
+	*a = AgentJSON(decoded)
+	if len(extraElements) > 0 {
+		a.AdditionalElements = extraElements
+	} else {
+		a.AdditionalElements = nil
+	}
+
+	return nil
 }
 
 type AgentPackageInfo struct {
@@ -46,8 +135,9 @@ type AgentResponseMeta struct {
 }
 
 type AgentResponse struct {
-	Agent AgentJSON         `json:"agent"`
-	Meta  AgentResponseMeta `json:"_meta"`
+	Agent         AgentJSON         `json:"agent"`
+	Meta          AgentResponseMeta `json:"_meta"`
+	ExtraElements map[string]any    `json:"extraElements,omitempty" doc:"Additional top-level elements preserved from the original agent payload for UI display and forward compatibility."`
 }
 
 type AgentMetadata struct {

--- a/pkg/models/agent_test.go
+++ b/pkg/models/agent_test.go
@@ -1,0 +1,80 @@
+package models
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestAgentJSONMarshalIncludesAdditionalElements(t *testing.T) {
+	agent := AgentJSON{
+		AgentManifest: AgentManifest{
+			Name:        "test-agent",
+			Language:    "python",
+			Framework:   "langgraph",
+			Description: "Agent with card metadata",
+			AdditionalElements: map[string]any{
+				"card": map[string]any{
+					"name":    "test-agent",
+					"version": "1.2.3",
+				},
+				"customElement": map[string]any{
+					"enabled": true,
+				},
+			},
+		},
+		Version: "1.2.3",
+		Status:  "active",
+	}
+
+	data, err := json.Marshal(agent)
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(data, &payload); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+
+	if _, ok := payload["card"]; !ok {
+		t.Fatalf("expected card in marshaled payload, got %v", payload)
+	}
+	if _, ok := payload["customElement"]; !ok {
+		t.Fatalf("expected customElement in marshaled payload, got %v", payload)
+	}
+}
+
+func TestAgentJSONUnmarshalCapturesAdditionalElements(t *testing.T) {
+	data := []byte(`{
+		"name": "test-agent",
+		"language": "python",
+		"framework": "langgraph",
+		"description": "Agent with extras",
+		"version": "1.2.3",
+		"card": {
+			"name": "test-agent",
+			"version": "1.2.3"
+		},
+		"otherElement": {
+			"flag": true
+		}
+	}`)
+
+	var agent AgentJSON
+	if err := json.Unmarshal(data, &agent); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+
+	if agent.Name != "test-agent" {
+		t.Fatalf("expected name to be decoded, got %q", agent.Name)
+	}
+	if len(agent.AdditionalElements) != 2 {
+		t.Fatalf("expected 2 additional elements, got %d", len(agent.AdditionalElements))
+	}
+	if _, ok := agent.AdditionalElements["card"]; !ok {
+		t.Fatalf("expected card to be captured, got %v", agent.AdditionalElements)
+	}
+	if _, ok := agent.AdditionalElements["otherElement"]; !ok {
+		t.Fatalf("expected otherElement to be captured, got %v", agent.AdditionalElements)
+	}
+}

--- a/pkg/models/manifest.go
+++ b/pkg/models/manifest.go
@@ -4,19 +4,20 @@ import "time"
 
 // AgentManifest represents the agent project configuration and metadata.
 type AgentManifest struct {
-	Name              string          `yaml:"agentName" json:"name"`
-	Image             string          `yaml:"image" json:"image"`
-	Language          string          `yaml:"language" json:"language"`
-	Framework         string          `yaml:"framework" json:"framework"`
-	ModelProvider     string          `yaml:"modelProvider" json:"modelProvider"`
-	ModelName         string          `yaml:"modelName" json:"modelName"`
-	Description       string          `yaml:"description" json:"description"`
-	Version           string          `yaml:"version,omitempty" json:"version,omitempty"`
-	TelemetryEndpoint string          `yaml:"telemetryEndpoint,omitempty" json:"telemetryEndpoint,omitempty"`
-	McpServers        []McpServerType `yaml:"mcpServers,omitempty" json:"mcpServers,omitempty"`
-	Skills            []SkillRef      `yaml:"skills,omitempty" json:"skills,omitempty"`
-	Prompts           []PromptRef     `yaml:"prompts,omitempty" json:"prompts,omitempty"`
-	UpdatedAt         time.Time       `yaml:"updatedAt,omitempty" json:"updatedAt,omitempty"`
+	Name               string          `yaml:"agentName" json:"name"`
+	Image              string          `yaml:"image" json:"image"`
+	Language           string          `yaml:"language" json:"language"`
+	Framework          string          `yaml:"framework" json:"framework"`
+	ModelProvider      string          `yaml:"modelProvider" json:"modelProvider"`
+	ModelName          string          `yaml:"modelName" json:"modelName"`
+	Description        string          `yaml:"description" json:"description"`
+	Version            string          `yaml:"version,omitempty" json:"version,omitempty"`
+	TelemetryEndpoint  string          `yaml:"telemetryEndpoint,omitempty" json:"telemetryEndpoint,omitempty"`
+	McpServers         []McpServerType `yaml:"mcpServers,omitempty" json:"mcpServers,omitempty"`
+	Skills             []SkillRef      `yaml:"skills,omitempty" json:"skills,omitempty"`
+	Prompts            []PromptRef     `yaml:"prompts,omitempty" json:"prompts,omitempty"`
+	UpdatedAt          time.Time       `yaml:"updatedAt,omitempty" json:"updatedAt,omitempty"`
+	AdditionalElements map[string]any  `yaml:",inline" json:"-"`
 }
 
 // SkillRef represents a skill reference in the agent manifest.

--- a/ui/components/__tests__/agent-elements.test.tsx
+++ b/ui/components/__tests__/agent-elements.test.tsx
@@ -1,0 +1,106 @@
+import { render, screen } from "@testing-library/react"
+import { describe, it, expect } from "vitest"
+import { AgentElements } from "../agent-elements"
+
+describe("AgentElements", () => {
+  it("renders nothing when extraElements is empty", () => {
+    const { container } = render(<AgentElements extraElements={{}} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it("renders section header when extraElements exist", () => {
+    const extraElements = {
+      card: { name: "test-agent", version: "1.0.0" },
+    }
+    render(<AgentElements extraElements={extraElements} />)
+    expect(screen.getByText("Additional Elements")).toBeInTheDocument()
+  })
+
+  it("formats element labels correctly", () => {
+    const extraElements = {
+      "custom-element": { value: "test" },
+      "snake_case_name": { enabled: true },
+      "mixedCamelCase": { flag: false },
+    }
+    render(<AgentElements extraElements={extraElements} />)
+    expect(screen.getByText("Custom Element")).toBeInTheDocument()
+    expect(screen.getByText("Snake Case Name")).toBeInTheDocument()
+    expect(screen.getByText("MixedCamelCase")).toBeInTheDocument()
+  })
+
+  it("renders JSON stringified values", () => {
+    const extraElements = {
+      card: { name: "agent", version: "1.0.0" },
+    }
+    render(<AgentElements extraElements={extraElements} />)
+    const jsonContent = screen.getByText((content, element) => {
+      return element?.tagName === "PRE" && content.includes('"name": "agent"')
+    })
+    expect(jsonContent).toBeInTheDocument()
+  })
+
+  it("renders multiple extra elements in sorted order", () => {
+    const extraElements = {
+      zebra: { last: true },
+      apple: { first: true },
+      middle: { mid: true },
+    }
+    render(<AgentElements extraElements={extraElements} />)
+
+    const labels = screen.getAllByText((content, element) => {
+      return element?.className?.includes("text-muted-foreground") &&
+             element?.tagName === "P"
+    })
+
+    // Should be alphabetically sorted: apple, middle, zebra
+    expect(labels[0]).toHaveTextContent("Apple")
+    expect(labels[1]).toHaveTextContent("Middle")
+    expect(labels[2]).toHaveTextContent("Zebra")
+  })
+
+  it("handles complex nested objects", () => {
+    const extraElements = {
+      deployment: {
+        namespace: "production",
+        replicas: 3,
+        resources: {
+          limits: { cpu: "500m", memory: "512Mi" },
+          requests: { cpu: "250m", memory: "256Mi" },
+        },
+      },
+    }
+    render(<AgentElements extraElements={extraElements} />)
+    expect(screen.getByText("Deployment")).toBeInTheDocument()
+    const jsonContent = screen.getByText((content, element) => {
+      return element?.tagName === "PRE" && content.includes('"namespace": "production"')
+    })
+    expect(jsonContent).toBeInTheDocument()
+  })
+
+  it("handles primitive values", () => {
+    const extraElements = {
+      simpleString: "test value",
+      simpleNumber: 42,
+      simpleBoolean: true,
+    }
+    render(<AgentElements extraElements={extraElements} />)
+    expect(screen.getByText("SimpleString")).toBeInTheDocument()
+    expect(screen.getByText("SimpleNumber")).toBeInTheDocument()
+    expect(screen.getByText("SimpleBoolean")).toBeInTheDocument()
+  })
+
+  it("renders with proper CSS classes for styling", () => {
+    const extraElements = {
+      card: { test: true },
+    }
+    const { container } = render(<AgentElements extraElements={extraElements} />)
+
+    // Check for section tag
+    const section = container.querySelector("section")
+    expect(section).toBeInTheDocument()
+
+    // Check for pre tag with proper classes
+    const pre = container.querySelector("pre")
+    expect(pre).toHaveClass("bg-muted", "p-3", "rounded-md", "overflow-x-auto")
+  })
+})

--- a/ui/components/agent-detail.tsx
+++ b/ui/components/agent-detail.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react"
 import { AgentResponse } from "@/lib/admin-api"
+import { AgentElements } from "@/components/agent-elements"
 import { Badge } from "@/components/ui/badge"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
@@ -32,6 +33,7 @@ export function AgentDetail({ agent, allVersions: allVersionsProp }: AgentDetail
 
   const { agent: agentData, _meta } = selectedVersion
   const official = _meta?.['io.modelcontextprotocol.registry/official']
+  const extraElements = selectedVersion.extraElements ?? {}
 
   const handleVersionChange = (version: string) => {
     const newVersion = allVersions.find(v => v.agent.version === version)
@@ -50,6 +52,12 @@ export function AgentDetail({ agent, allVersions: allVersionsProp }: AgentDetail
     } catch {
       return dateString
     }
+  }
+
+  const rawDisplayData = {
+    agent: selectedVersion.agent,
+    _meta: selectedVersion._meta,
+    extraElements: selectedVersion.extraElements,
   }
 
   return (
@@ -166,6 +174,8 @@ export function AgentDetail({ agent, allVersions: allVersionsProp }: AgentDetail
               </div>
             </section>
 
+            <AgentElements extraElements={extraElements} />
+
             {agentData.repository?.url && (
               <section>
                 <h3 className="text-sm font-semibold uppercase tracking-wider text-muted-foreground mb-2">Repository</h3>
@@ -243,7 +253,7 @@ export function AgentDetail({ agent, allVersions: allVersionsProp }: AgentDetail
                 Raw JSON
               </h3>
               <pre className="bg-muted p-3 rounded-md overflow-x-auto text-xs leading-relaxed">
-                {JSON.stringify(selectedVersion, null, 2)}
+                {JSON.stringify(rawDisplayData, null, 2)}
               </pre>
             </div>
           </TabsContent>

--- a/ui/components/agent-elements.tsx
+++ b/ui/components/agent-elements.tsx
@@ -1,0 +1,33 @@
+interface AgentElementsProps {
+  extraElements: Record<string, unknown>
+}
+
+function formatElementLabel(elementName: string) {
+  return elementName
+    .replace(/[-_]+/g, ' ')
+    .replace(/\b\w/g, (char) => char.toUpperCase())
+}
+
+export function AgentElements({ extraElements }: AgentElementsProps) {
+  const extraElementEntries = Object.entries(extraElements).sort(([left], [right]) => left.localeCompare(right))
+
+  if (extraElementEntries.length === 0) {
+    return null
+  }
+
+  return (
+    <section>
+      <h3 className="text-sm font-semibold uppercase tracking-wider text-muted-foreground mb-3">Additional Elements</h3>
+      <div className="space-y-4">
+        {extraElementEntries.map(([elementName, elementValue]) => (
+          <div key={elementName}>
+            <p className="text-xs text-muted-foreground mb-2">{formatElementLabel(elementName)}</p>
+            <pre className="bg-muted p-3 rounded-md overflow-x-auto text-xs leading-relaxed">
+              {JSON.stringify(elementValue, null, 2)}
+            </pre>
+          </div>
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/ui/lib/api/types.gen.ts
+++ b/ui/lib/api/types.gen.ts
@@ -60,6 +60,9 @@ export type AgentRegistryExtensions = {
 export type AgentResponse = {
     _meta: AgentResponseMeta;
     agent: AgentJson;
+    extraElements?: {
+        [key: string]: unknown;
+    };
 };
 
 export type AgentResponseMeta = {


### PR DESCRIPTION
…ents

Enable agents to include arbitrary top-level fields in their manifest JSON beyond the standard schema. Additional elements are captured, stored, and returned through the API for forward compatibility and custom metadata.

Backend changes:
- Add custom JSON marshal/unmarshal to AgentJSON to preserve unknown fields
- Store additional elements in AdditionalElements map
- Update API handlers to accept and return extraElements
- Modify database queries to handle additional element storage
- Update OpenAPI spec with extraElements field

Frontend changes:
- Add AgentElements component to display additional fields in UI
- Update agent detail view to render extra elements
- Generate updated API types

Tests:
- Add handler tests for extra element acceptance
- Add model tests for JSON marshal/unmarshal behavior
- Add UI component tests for AgentElements display

Use cases: custom metadata, deployment configs, integration hooks, organizational context, and forward compatibility with schema extensions.

# Description

**Motivation:**
Agents need the ability to include custom metadata and configuration beyond the standard manifest schema. This enables use cases like deployment-specific settings, UI display metadata (e.g., `card` fields), integration hooks, and organizational context without requiring schema changes for each extension.

**What changed:**
- Implemented custom JSON marshaling/unmarshaling in `AgentJSON` to capture and preserve unknown fields in an `AdditionalElements` map
- Extended the database layer to store additional elements alongside standard agent fields
- Modified API handlers to accept arbitrary top-level fields and return them as `extraElements` in responses
- Created `AgentElements` UI component to display additional fields in the agent detail view
- Added comprehensive test coverage for backend and frontend changes
- Documented the extensible manifest feature in AGENTS.md with examples and use cases

**Related issues:**
Related to support for custom agent metadata and forward compatibility requirements.

# Change Type

/kind feature
/kind documentation

# Changelog

```release-note
Agents now support extensible manifests with custom top-level fields. Additional elements are preserved through the API and displayed in the UI, enabling custom metadata, deployment configurations, and forward compatibility.
```

# Additional Notes

**Backward Compatibility:**
Fully backward compatible. Agents without additional elements continue to work unchanged. The `extraElements` field in API responses is optional and only present when additional fields exist.

**Example Usage:**
```json
{
  "name": "my-agent",
  "version": "1.0.0",
  "framework": "langgraph",
  "card": {
    "displayName": "My Custom Agent",
    "category": "productivity"
  },
  "deployment": {
    "namespace": "production"
  }
}
```

The `card` and `deployment` fields above are captured as additional elements and returned in API responses.

**Testing:**
- All existing tests pass
- New tests cover JSON marshal/unmarshal behavior, API endpoint acceptance, and UI rendering
- UI component tests: 8/8 passing
- Backend tests: all passing
