### PR TITLE
cli: avoid printing API token in help output

### DIFF
--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -86,7 +86,8 @@ var rootCmd = &cobra.Command{
 
 func init() {
 	rootCmd.PersistentFlags().StringVar(&registryURL, "registry-url", os.Getenv("ARCTL_API_BASE_URL"), "Registry URL (overrides ARCTL_API_BASE_URL env var; defaults to http://localhost:12121)")
-	rootCmd.PersistentFlags().StringVar(&registryToken, "registry-token", os.Getenv("ARCTL_API_TOKEN"), "Registry bearer token (overrides ARCTL_API_TOKEN)")
+	// Don't use the default value from the env var here as the CLI help text would print it and this is a sensitive credential to access the API
+	rootCmd.PersistentFlags().StringVar(&registryToken, "registry-token", "", "Registry bearer token (defaults to value of ARCTL_API_TOKEN env var)")
 
 	rootCmd.AddCommand(mcp.McpCmd)
 	rootCmd.AddCommand(agent.AgentCmd)


### PR DESCRIPTION
# Description

Avoids printing sensitive API credentials token in the help output. resolveRegistryTarget is already called which reads the token value from the env.

Testing done:
```
$ export ARCTL_API_TOKEN=<token>
$ arctl get agents
NAME        VERSION   FRAMEWORK   LANGUAGE   PROVIDER   MODEL
echoagent   latest    adk         python     gemini     gemini-2.0-flash
```

# Change Type

```
/kind cleanup
```

# Changelog

```release-note
NONE
```