### PR TITLE
cli/declarative: Add support for --output-dir

### DIFF
--- a/internal/cli/declarative/init.go
+++ b/internal/cli/declarative/init.go
@@ -48,6 +48,7 @@ Examples:
   arctl init prompt my-prompt`,
 		SilenceUsage: true,
 	}
+	cmd.PersistentFlags().String("output-dir", "", "Output directory for generated projects. If not provided, projects are created in the current directory under the resource name.")
 	cmd.AddCommand(newInitAgentCmd())
 	cmd.AddCommand(newInitMCPCmd())
 	cmd.AddCommand(newInitSkillCmd())
@@ -112,11 +113,10 @@ Supported languages:  python (for adk)`,
 				image = fmt.Sprintf("%s/%s:latest", registry, name)
 			}
 
-			cwd, err := os.Getwd()
+			projectDir, err := resolveInitProjectPath(cmd, name)
 			if err != nil {
-				return fmt.Errorf("getting working directory: %w", err)
+				return err
 			}
-			projectDir := filepath.Join(cwd, name)
 
 			// Scaffold all code files (Dockerfile, Python source, etc.) using
 			// the existing framework generator. This also writes a flat agent.yaml
@@ -151,7 +151,7 @@ Supported languages:  python (for adk)`,
 
 			fmt.Fprintf(cmd.OutOrStdout(), "✓ Successfully created agent: %s\n", name)
 			fmt.Fprintf(cmd.OutOrStdout(), "\n🚀 Next steps:\n")
-			fmt.Fprintf(cmd.OutOrStdout(), "  1. cd %s\n", name)
+			fmt.Fprintf(cmd.OutOrStdout(), "  1. cd %s\n", projectDir)
 			fmt.Fprintf(cmd.OutOrStdout(), "  2. (Optional) Build and push the image if developing locally:\n")
 			fmt.Fprintf(cmd.OutOrStdout(), "     arctl build . --push\n")
 			fmt.Fprintf(cmd.OutOrStdout(), "  3. Publish the agent to the registry:\n")
@@ -383,11 +383,10 @@ Supported frameworks: fastmcp-python, mcp-go`,
 				image = fmt.Sprintf("%s/%s:latest", registry, dirName)
 			}
 
-			cwd, err := os.Getwd()
+			projectDir, err := resolveInitProjectPath(cmd, dirName)
 			if err != nil {
-				return fmt.Errorf("getting working directory: %w", err)
+				return err
 			}
-			projectDir := filepath.Join(cwd, dirName)
 
 			generator, err := mcpframeworks.GetGenerator(framework)
 			if err != nil {
@@ -410,7 +409,7 @@ Supported frameworks: fastmcp-python, mcp-go`,
 
 			fmt.Fprintf(cmd.OutOrStdout(), "✓ Successfully created MCP server: %s\n", fullName)
 			fmt.Fprintf(cmd.OutOrStdout(), "\n🚀 Next steps:\n")
-			fmt.Fprintf(cmd.OutOrStdout(), "  1. cd %s\n", dirName)
+			fmt.Fprintf(cmd.OutOrStdout(), "  1. cd %s\n", projectDir)
 			fmt.Fprintf(cmd.OutOrStdout(), "  2. (Optional) Build and push the image if developing locally:\n")
 			fmt.Fprintf(cmd.OutOrStdout(), "     arctl build . --push\n")
 			fmt.Fprintf(cmd.OutOrStdout(), "  3. Publish the MCP server to the registry:\n")
@@ -494,11 +493,10 @@ The generated skill.yaml can be applied directly:
 				return fmt.Errorf("invalid skill name: %w", err)
 			}
 
-			cwd, err := os.Getwd()
+			projectDir, err := resolveInitProjectPath(cmd, name)
 			if err != nil {
-				return fmt.Errorf("getting working directory: %w", err)
+				return err
 			}
-			projectDir := filepath.Join(cwd, name)
 
 			if err := skilltemplates.NewGenerator().GenerateProject(skilltemplates.ProjectConfig{
 				ProjectName: name,
@@ -514,7 +512,7 @@ The generated skill.yaml can be applied directly:
 
 			fmt.Fprintf(cmd.OutOrStdout(), "✓ Successfully created skill: %s\n", name)
 			fmt.Fprintf(cmd.OutOrStdout(), "\n🚀 Next steps:\n")
-			fmt.Fprintf(cmd.OutOrStdout(), "  1. cd %s\n", name)
+			fmt.Fprintf(cmd.OutOrStdout(), "  1. cd %s\n", projectDir)
 			fmt.Fprintf(cmd.OutOrStdout(), "  2. (Optional) Build and push the image if developing locally:\n")
 			fmt.Fprintf(cmd.OutOrStdout(), "     arctl build . --push\n")
 			fmt.Fprintf(cmd.OutOrStdout(), "  3. Publish the skill to the registry:\n")
@@ -567,12 +565,12 @@ func newInitPromptCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "prompt NAME",
-		Short: "Create a new declarative <name>.yaml for a prompt",
-		Long: `Create a new <name>.yaml in the current directory using the
-ar.dev/v1alpha1 declarative format. No code scaffolding is generated.
+		Short: "Scaffold a new prompt project with declarative prompt.yaml",
+		Long: `Scaffold a new prompt project. Creates a project directory
+containing a declarative prompt.yaml (ar.dev/v1alpha1).
 
 The generated file can be applied directly:
-  arctl apply -f my-prompt.yaml`,
+  arctl apply -f NAME/prompt.yaml`,
 		Example: `  arctl init prompt my-prompt
   arctl init prompt my-prompt --description "System prompt for summarization"`,
 		Args:         cobra.ExactArgs(1),
@@ -585,12 +583,14 @@ The generated file can be applied directly:
 				return fmt.Errorf("invalid prompt name: %w", err)
 			}
 
-			cwd, err := os.Getwd()
+			projectDir, err := resolveInitProjectPath(cmd, name)
 			if err != nil {
-				return fmt.Errorf("getting working directory: %w", err)
+				return err
 			}
-			// Prompts are just a YAML file — no project directory needed.
-			outPath := filepath.Join(cwd, name+".yaml")
+			if err := os.MkdirAll(projectDir, 0o755); err != nil {
+				return fmt.Errorf("creating prompt project directory: %w", err)
+			}
+			outPath := filepath.Join(projectDir, "prompt.yaml")
 
 			if err := writeDeclarativePromptYAML(outPath, name, initVersion, initDescription, initContent); err != nil {
 				return fmt.Errorf("writing declarative prompt.yaml: %w", err)
@@ -598,9 +598,10 @@ The generated file can be applied directly:
 
 			fmt.Fprintf(cmd.OutOrStdout(), "✓ Successfully created prompt: %s\n", name)
 			fmt.Fprintf(cmd.OutOrStdout(), "\n🚀 Next steps:\n")
-			fmt.Fprintf(cmd.OutOrStdout(), "  1. Edit %s.yaml if needed\n", name)
-			fmt.Fprintf(cmd.OutOrStdout(), "  2. Publish the prompt to the registry:\n")
-			fmt.Fprintf(cmd.OutOrStdout(), "     arctl apply -f %s.yaml\n", name)
+			fmt.Fprintf(cmd.OutOrStdout(), "  1. cd %s\n", projectDir)
+			fmt.Fprintf(cmd.OutOrStdout(), "  2. Edit prompt.yaml if needed\n")
+			fmt.Fprintf(cmd.OutOrStdout(), "  3. Publish the prompt to the registry:\n")
+			fmt.Fprintf(cmd.OutOrStdout(), "     arctl apply -f prompt.yaml\n")
 			return nil
 		},
 	}
@@ -635,4 +636,24 @@ func writeDeclarativePromptYAML(path, name, ver, description, content string) er
 	}
 
 	return os.WriteFile(path, b, 0o644)
+}
+
+func resolveInitProjectPath(cmd *cobra.Command, projectName string) (string, error) {
+	outputDir, err := cmd.Flags().GetString("output-dir")
+	if err != nil {
+		return "", fmt.Errorf("reading output directory flag: %w", err)
+	}
+	if outputDir != "" {
+		base, err := filepath.Abs(outputDir)
+		if err != nil {
+			return "", fmt.Errorf("getting absolute output directory: %w", err)
+		}
+		return filepath.Join(base, projectName), nil
+	}
+
+	projectDir, err := filepath.Abs(projectName)
+	if err != nil {
+		return "", fmt.Errorf("getting absolute project directory: %w", err)
+	}
+	return projectDir, nil
 }

--- a/internal/cli/declarative/init_test.go
+++ b/internal/cli/declarative/init_test.go
@@ -29,6 +29,11 @@ func readAgentYAML(t *testing.T, dir, name string) map[string]any {
 	return readYAMLFile(t, filepath.Join(dir, name, "agent.yaml"))
 }
 
+func readPromptYAML(t *testing.T, dir, name string) map[string]any {
+	t.Helper()
+	return readYAMLFile(t, filepath.Join(dir, name, "prompt.yaml"))
+}
+
 func TestInitAgentCmd_BasicScaffold(t *testing.T) {
 	tmpDir := t.TempDir()
 	origDir, err := os.Getwd()
@@ -283,6 +288,27 @@ func TestInitAgentCmd_DeclarativeYAMLHasCorrectStructure(t *testing.T) {
 	assert.Contains(t, content, "spec:")
 }
 
+func TestInitAgentCmd_OutputDir(t *testing.T) {
+	tmpDir := t.TempDir()
+	origDir, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(tmpDir))
+	defer func() { _ = os.Chdir(origDir) }()
+
+	outputDir := filepath.Join("generated", "agents")
+
+	var buf bytes.Buffer
+	cmd := declarative.NewInitCmd()
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"--output-dir", outputDir, "agent", "adk", "python", "myagent"})
+	require.NoError(t, cmd.Execute())
+
+	projectDir := filepath.Join(tmpDir, outputDir, "myagent")
+	_, err = os.Stat(filepath.Join(projectDir, "agent.yaml"))
+	require.NoError(t, err, "agent.yaml should exist in output directory")
+	assert.Contains(t, buf.String(), "cd "+projectDir)
+}
+
 // ---- mcp init ----
 
 func TestInitMCPCmd_BasicScaffold(t *testing.T) {
@@ -399,6 +425,27 @@ func TestInitMCPCmd_ProjectFilesCreated(t *testing.T) {
 	require.NoError(t, err, "mcp.yaml should exist")
 }
 
+func TestInitMCPCmd_OutputDir(t *testing.T) {
+	tmpDir := t.TempDir()
+	origDir, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(tmpDir))
+	defer func() { _ = os.Chdir(origDir) }()
+
+	outputDir := filepath.Join("generated", "mcps")
+
+	var buf bytes.Buffer
+	cmd := declarative.NewInitCmd()
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"--output-dir", outputDir, "mcp", "fastmcp-python", "myorg/myserver"})
+	require.NoError(t, cmd.Execute())
+
+	projectDir := filepath.Join(tmpDir, outputDir, "myserver")
+	_, err = os.Stat(filepath.Join(projectDir, "mcp.yaml"))
+	require.NoError(t, err, "mcp.yaml should exist in output directory")
+	assert.Contains(t, buf.String(), "cd "+projectDir)
+}
+
 // ---- skill init ----
 
 func TestInitSkillCmd_BasicScaffold(t *testing.T) {
@@ -468,6 +515,27 @@ func TestInitSkillCmd_ProjectFilesCreated(t *testing.T) {
 	require.NoError(t, err, "skill.yaml should exist")
 }
 
+func TestInitSkillCmd_OutputDir(t *testing.T) {
+	tmpDir := t.TempDir()
+	origDir, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(tmpDir))
+	defer func() { _ = os.Chdir(origDir) }()
+
+	outputDir := filepath.Join("generated", "skills")
+
+	var buf bytes.Buffer
+	cmd := declarative.NewInitCmd()
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"--output-dir", outputDir, "skill", "myskill"})
+	require.NoError(t, cmd.Execute())
+
+	projectDir := filepath.Join(tmpDir, outputDir, "myskill")
+	_, err = os.Stat(filepath.Join(projectDir, "skill.yaml"))
+	require.NoError(t, err, "skill.yaml should exist in output directory")
+	assert.Contains(t, buf.String(), "cd "+projectDir)
+}
+
 // ---- prompt init ----
 
 func TestInitPromptCmd_BasicScaffold(t *testing.T) {
@@ -481,8 +549,7 @@ func TestInitPromptCmd_BasicScaffold(t *testing.T) {
 	cmd.SetArgs([]string{"prompt", "myprompt"})
 	require.NoError(t, cmd.Execute())
 
-	// Prompt writes NAME.yaml in cwd, not a subdir
-	m := readYAMLFile(t, filepath.Join(tmpDir, "myprompt.yaml"))
+	m := readPromptYAML(t, tmpDir, "myprompt")
 	assert.Equal(t, "ar.dev/v1alpha1", m["apiVersion"])
 	assert.Equal(t, "Prompt", m["kind"])
 
@@ -511,7 +578,7 @@ func TestInitPromptCmd_CustomContent(t *testing.T) {
 	})
 	require.NoError(t, cmd.Execute())
 
-	m := readYAMLFile(t, filepath.Join(tmpDir, "summarizer.yaml"))
+	m := readPromptYAML(t, tmpDir, "summarizer")
 	metadata := m["metadata"].(map[string]any)
 	assert.Equal(t, "2.0.0", metadata["version"])
 
@@ -520,7 +587,7 @@ func TestInitPromptCmd_CustomContent(t *testing.T) {
 	assert.Equal(t, "You are a text summarizer. Be concise.", spec["content"])
 }
 
-func TestInitPromptCmd_WritesFileNotDirectory(t *testing.T) {
+func TestInitPromptCmd_ProjectFilesCreated(t *testing.T) {
 	tmpDir := t.TempDir()
 	origDir, err := os.Getwd()
 	require.NoError(t, err)
@@ -531,11 +598,31 @@ func TestInitPromptCmd_WritesFileNotDirectory(t *testing.T) {
 	cmd.SetArgs([]string{"prompt", "myprompt"})
 	require.NoError(t, cmd.Execute())
 
-	// Must write myprompt.yaml in cwd, NOT create a directory
-	info, err := os.Stat(filepath.Join(tmpDir, "myprompt.yaml"))
-	require.NoError(t, err, "myprompt.yaml should exist")
-	assert.False(t, info.IsDir(), "myprompt.yaml should be a file, not a directory")
+	info, err := os.Stat(filepath.Join(tmpDir, "myprompt"))
+	require.NoError(t, err, "prompt project directory should exist")
+	assert.True(t, info.IsDir(), "myprompt should be a directory")
 
-	_, err = os.Stat(filepath.Join(tmpDir, "myprompt"))
-	assert.True(t, os.IsNotExist(err), "no directory named myprompt should be created")
+	_, err = os.Stat(filepath.Join(tmpDir, "myprompt", "prompt.yaml"))
+	require.NoError(t, err, "prompt.yaml should exist")
+}
+
+func TestInitPromptCmd_OutputDir(t *testing.T) {
+	tmpDir := t.TempDir()
+	origDir, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(tmpDir))
+	defer func() { _ = os.Chdir(origDir) }()
+
+	outputDir := filepath.Join("generated", "prompts")
+
+	var buf bytes.Buffer
+	cmd := declarative.NewInitCmd()
+	cmd.SetOut(&buf)
+	cmd.SetArgs([]string{"--output-dir", outputDir, "prompt", "myprompt"})
+	require.NoError(t, cmd.Execute())
+
+	projectDir := filepath.Join(tmpDir, outputDir, "myprompt")
+	_, err = os.Stat(filepath.Join(projectDir, "prompt.yaml"))
+	require.NoError(t, err, "prompt.yaml should exist in output directory")
+	assert.Contains(t, buf.String(), "cd "+projectDir)
 }


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don't apply.
-->

# Description

<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

Extend the init declarative CLI command and add support for configuring an output-dir for the scaffolded artifacts. The legacy CLI init commands inconsistently supported this.

Added this as a root flag to the init command. Additionally, refactored the prompt initialization command to follow the other scaffolding logic: the *.yaml files are hardcoded, e.g. agent.yaml, skill.yaml, etc.

Manually tested:

```bash
$ ./bin/arctl init agent adk python myagent --output-dir .playground
$ ll .playground/myagent
total 40
drwxr-xr-x 4 timflannagan timflannagan 4096 Apr 16 02:16 .
drwxrwxr-x 6 timflannagan timflannagan 4096 Apr 16 02:16 ..
-rw-r--r-- 1 timflannagan timflannagan  263 Apr 16 02:16 agent.yaml
...
```

# Change Type

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bump
/kind cleanup
/kind design
/kind deprecation
/kind documentation
/kind feature
/kind fix
/kind flake
/kind install
```
-->

/kind feature

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
NONE
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
