### PR TITLE
Fix resolve for local agent build, it wasn't using auth so failed when an agent had MCP, Prompt, or Skill

### DIFF
--- a/internal/cli/agent/utils/registry_resolver.go
+++ b/internal/cli/agent/utils/registry_resolver.go
@@ -8,12 +8,13 @@ import (
 
 	"github.com/agentregistry-dev/agentregistry/internal/cli/agent/frameworks/common"
 	"github.com/agentregistry-dev/agentregistry/internal/client"
-	"github.com/agentregistry-dev/agentregistry/internal/registry"
 	"github.com/agentregistry-dev/agentregistry/pkg/models"
 	"github.com/modelcontextprotocol/registry/pkg/model"
 )
 
 var defaultRegistryURL = "http://127.0.0.1:12121"
+
+var registryAPIClient *client.Client
 
 // SetDefaultRegistryURL overrides the fallback registry URL used when manifests omit registry_url.
 func SetDefaultRegistryURL(url string) {
@@ -21,6 +22,11 @@ func SetDefaultRegistryURL(url string) {
 		return
 	}
 	defaultRegistryURL = url
+}
+
+// SetRegistryAPIClient stores the authenticated API client for registry resolution.
+func SetRegistryAPIClient(c *client.Client) {
+	registryAPIClient = c
 }
 
 // GetDefaultRegistryURL returns the current default registry URL (without /v0 suffix).
@@ -84,27 +90,42 @@ func resolveRegistryServer(mcpServer models.McpServerType, verbose bool) (*model
 		fmt.Printf("[registry-resolver]   Using specified registry URL: %s\n", registryURL)
 	}
 
-	if verbose {
-		fmt.Printf("[registry-resolver]   Fetching server %q (version=%q) from registry...\n",
-			mcpServer.RegistryServerName, mcpServer.RegistryServerVersion)
+	serverName := mcpServer.RegistryServerName
+	serverVersion := mcpServer.RegistryServerVersion
+	if serverVersion == "" {
+		serverVersion = "latest"
 	}
 
-	client := registry.NewClient()
-	serverEntry, err := client.FetchServer(registryURL, mcpServer.RegistryServerName, mcpServer.RegistryServerVersion)
+	if verbose {
+		fmt.Printf("[registry-resolver]   Fetching server %q (version=%q) from registry...\n",
+			serverName, serverVersion)
+	}
+
+	apiClient := registryAPIClient
+	if apiClient == nil {
+		apiClient = client.NewClient(registryURL, "")
+	}
+
+	serverResp, err := apiClient.GetServerVersion(serverName, serverVersion)
 	if err != nil {
 		if verbose {
 			fmt.Printf("[registry-resolver]   ERROR: Failed to fetch server from registry: %v\n", err)
 		}
-		return nil, fmt.Errorf("failed to fetch server %q from registry: %w", mcpServer.RegistryServerName, err)
+		return nil, fmt.Errorf("failed to fetch server %q from registry: %w", serverName, err)
 	}
+	if serverResp == nil {
+		return nil, fmt.Errorf("server %q (version %q) not found in registry at %s", serverName, serverVersion, registryURL)
+	}
+
+	server := &serverResp.Server
 
 	if verbose {
 		fmt.Printf("[registry-resolver]   Fetched server successfully:\n")
-		fmt.Printf("[registry-resolver]     - Name: %s\n", serverEntry.Server.Name)
-		fmt.Printf("[registry-resolver]     - Version: %s\n", serverEntry.Server.Version)
-		fmt.Printf("[registry-resolver]     - Description: %s\n", serverEntry.Server.Description)
-		fmt.Printf("[registry-resolver]     - Packages count: %d\n", len(serverEntry.Server.Packages))
-		for j, pkg := range serverEntry.Server.Packages {
+		fmt.Printf("[registry-resolver]     - Name: %s\n", server.Name)
+		fmt.Printf("[registry-resolver]     - Version: %s\n", server.Version)
+		fmt.Printf("[registry-resolver]     - Description: %s\n", server.Description)
+		fmt.Printf("[registry-resolver]     - Packages count: %d\n", len(server.Packages))
+		for j, pkg := range server.Packages {
 			fmt.Printf("[registry-resolver]     - Package[%d]: registryType=%q identifier=%q version=%q\n",
 				j, pkg.RegistryType, pkg.Identifier, pkg.Version)
 			if len(pkg.EnvironmentVariables) > 0 {
@@ -114,18 +135,16 @@ func resolveRegistryServer(mcpServer models.McpServerType, verbose bool) (*model
 				}
 			}
 		}
-		if len(serverEntry.Server.Remotes) > 0 {
-			fmt.Printf("[registry-resolver]     - Remotes count: %d\n", len(serverEntry.Server.Remotes))
-			for j, remote := range serverEntry.Server.Remotes {
+		if len(server.Remotes) > 0 {
+			fmt.Printf("[registry-resolver]     - Remotes count: %d\n", len(server.Remotes))
+			for j, remote := range server.Remotes {
 				fmt.Printf("[registry-resolver]     - Remote[%d]: type=%q url=%q\n",
 					j, remote.Type, remote.URL)
 			}
 		}
 	}
 
-	// Collect environment variable overrides from the current environment
-	// This allows users to set required env vars before running
-	envOverrides := collectEnvOverrides(serverEntry.Server.Packages)
+	envOverrides := collectEnvOverrides(server.Packages)
 
 	// Also add user-provided env vars from the manifest (set via TUI or agent.yaml)
 	manifestEnvVars := parseManifestEnvVars(mcpServer.Env)
@@ -156,8 +175,7 @@ func resolveRegistryServer(mcpServer models.McpServerType, verbose bool) (*model
 			mcpServer.RegistryServerPreferRemote)
 	}
 
-	// Translate the registry server spec to a runnable McpServerType
-	translated, err := TranslateRegistryServer(mcpServer.Name, &serverEntry.Server, envOverrides, mcpServer.RegistryServerPreferRemote)
+	translated, err := TranslateRegistryServer(mcpServer.Name, server, envOverrides, mcpServer.RegistryServerPreferRemote)
 	if err != nil {
 		if verbose {
 			fmt.Printf("[registry-resolver]   ERROR: Failed to translate server: %v\n", err)
@@ -212,9 +230,6 @@ func ResolveManifestPrompts(manifest *models.AgentManifest, verbose bool) ([]com
 		fmt.Printf("[prompt-resolver] Processing %d prompts from manifest\n", len(manifest.Prompts))
 	}
 
-	// Cache API clients by registry URL to avoid creating one per prompt.
-	clients := make(map[string]*client.Client)
-
 	var resolved []common.PythonPrompt
 	for i, ref := range manifest.Prompts {
 		registryURL := ref.RegistryURL
@@ -230,10 +245,9 @@ func ResolveManifestPrompts(manifest *models.AgentManifest, verbose bool) ([]com
 				i, ref.Name, promptName, promptVersion, registryURL)
 		}
 
-		apiClient, ok := clients[registryURL]
-		if !ok {
+		apiClient := registryAPIClient
+		if apiClient == nil {
 			apiClient = client.NewClient(registryURL, "")
-			clients[registryURL] = apiClient
 		}
 
 		var promptResp *models.PromptResponse

--- a/internal/cli/agent/utils/registry_translator.go
+++ b/internal/cli/agent/utils/registry_translator.go
@@ -6,39 +6,31 @@ import (
 	"maps"
 
 	platformutils "github.com/agentregistry-dev/agentregistry/internal/registry/platforms/utils"
-	"github.com/agentregistry-dev/agentregistry/internal/registry/types"
 	"github.com/agentregistry-dev/agentregistry/pkg/models"
 	apiv0 "github.com/modelcontextprotocol/registry/pkg/api/v0"
 )
 
-// TranslateRegistryServer converts a registry ServerSpec into a common.McpServerType
+// TranslateRegistryServer converts an API ServerJSON into a McpServerType
 // that can be used by the docker-compose generator.
 func TranslateRegistryServer(
 	name string,
-	serverSpec *types.ServerSpec,
+	server *apiv0.ServerJSON,
 	envOverrides map[string]string,
 	preferRemote bool,
 ) (*models.McpServerType, error) {
-	if len(serverSpec.Remotes) == 0 && len(serverSpec.Packages) == 0 {
-		return nil, fmt.Errorf("server %q has no remotes or packages", serverSpec.Name)
+	if len(server.Remotes) == 0 && len(server.Packages) == 0 {
+		return nil, fmt.Errorf("server %q has no remotes or packages", server.Name)
 	}
 
 	runEnv := make(map[string]string, len(envOverrides))
 	maps.Copy(runEnv, envOverrides)
 
 	translated, err := platformutils.TranslateMCPServer(context.Background(), &platformutils.MCPServerRunRequest{
-		RegistryServer: &apiv0.ServerJSON{
-			Name:        serverSpec.Name,
-			Title:       serverSpec.Title,
-			Description: serverSpec.Description,
-			Version:     serverSpec.Version,
-			Packages:    serverSpec.Packages,
-			Remotes:     serverSpec.Remotes,
-		},
-		PreferRemote: preferRemote,
-		EnvValues:    runEnv,
-		ArgValues:    map[string]string{},
-		HeaderValues: map[string]string{},
+		RegistryServer: server,
+		PreferRemote:   preferRemote,
+		EnvValues:      runEnv,
+		ArgValues:      map[string]string{},
+		HeaderValues:   map[string]string{},
 	})
 	if err != nil {
 		return nil, err
@@ -46,8 +38,8 @@ func TranslateRegistryServer(
 
 	switch translated.MCPServerType {
 	case "remote":
-		if len(serverSpec.Remotes) == 0 || serverSpec.Remotes[0].URL == "" {
-			return nil, fmt.Errorf("server %q remote has no URL", serverSpec.Name)
+		if len(server.Remotes) == 0 || server.Remotes[0].URL == "" {
+			return nil, fmt.Errorf("server %q remote has no URL", server.Name)
 		}
 		headers := make(map[string]string, len(translated.Remote.Headers))
 		for _, header := range translated.Remote.Headers {
@@ -56,16 +48,16 @@ func TranslateRegistryServer(
 		return &models.McpServerType{
 			Type:    "remote",
 			Name:    name,
-			URL:     serverSpec.Remotes[0].URL,
+			URL:     server.Remotes[0].URL,
 			Headers: headers,
 		}, nil
 	case "local":
 		if translated.Local == nil {
-			return nil, fmt.Errorf("server %q local translation missing deployment config", serverSpec.Name)
+			return nil, fmt.Errorf("server %q local translation missing deployment config", server.Name)
 		}
 		buildPath := ""
-		if len(serverSpec.Packages) > 0 {
-			config, _, err := platformutils.GetRegistryConfig(serverSpec.Packages[0], nil)
+		if len(server.Packages) > 0 {
+			config, _, err := platformutils.GetRegistryConfig(server.Packages[0], nil)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -73,6 +73,7 @@ var rootCmd = &cobra.Command{
 		}
 
 		agentutils.SetDefaultRegistryURL(c.BaseURL)
+		agentutils.SetRegistryAPIClient(c)
 		mcp.SetAPIClient(c)
 		agent.SetAPIClient(c)
 		skill.SetAPIClient(c)


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don't apply.
-->

# Description
Resolve https://github.com/agentregistry-dev/agentregistry/issues/439
<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

# Change Type
/kind fix

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bump
/kind cleanup
/kind design
/kind deprecation
/kind documentation
/kind feature
/kind fix
/kind flake
/kind install
```
-->

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
Fix resolve for local agent build, it wasn't using auth so failed when an agent had MCP, Prompt, or Skill
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
