### PR TITLE
fix: deployment delete wiring

### DIFF
--- a/internal/cli/declarative/declarative.go
+++ b/internal/cli/declarative/declarative.go
@@ -2,6 +2,8 @@ package declarative
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"reflect"
 
 	"github.com/agentregistry-dev/agentregistry/internal/cli/scheme"
@@ -9,6 +11,7 @@ import (
 	"github.com/agentregistry-dev/agentregistry/internal/registry/kinds"
 	"github.com/agentregistry-dev/agentregistry/pkg/models"
 	"github.com/agentregistry-dev/agentregistry/pkg/printer"
+	"github.com/agentregistry-dev/agentregistry/pkg/registry/database"
 	v0 "github.com/modelcontextprotocol/registry/pkg/api/v0"
 )
 
@@ -265,6 +268,36 @@ func newCLIRegistry() *kinds.Registry {
 			d := item.(*models.Deployment)
 			return []string{d.ID, d.ServerName, d.Version, d.ResourceType, d.ProviderID, d.Status}
 		},
+		Delete: deploymentDeleteFunc,
 	})
 	return reg
+}
+
+// deploymentDeleteFunc looks up deployments by (name, version) and deletes each match
+// by ID. The same (name, version) can have multiple deployments (one per provider),
+// so all matches are removed.
+func deploymentDeleteFunc(_ context.Context, name, version string) error {
+	all, err := apiClient.GetDeployedServers()
+	if err != nil {
+		return fmt.Errorf("listing deployments: %w", err)
+	}
+	var matches []*models.Deployment
+	for _, d := range all {
+		if d == nil {
+			continue
+		}
+		if d.ServerName == name && (version == "" || d.Version == version) {
+			matches = append(matches, d)
+		}
+	}
+	if len(matches) == 0 {
+		return database.ErrNotFound
+	}
+	var errs []error
+	for _, d := range matches {
+		if err := apiClient.DeleteDeployment(d.ID); err != nil {
+			errs = append(errs, fmt.Errorf("deleting %s (provider %s): %w", d.ID, d.ProviderID, err))
+		}
+	}
+	return errors.Join(errs...)
 }

--- a/internal/cli/declarative/declarative.go
+++ b/internal/cli/declarative/declarative.go
@@ -274,9 +274,14 @@ func newCLIRegistry() *kinds.Registry {
 }
 
 // deploymentDeleteFunc looks up deployments by (name, version) and deletes each match
-// by ID. The same (name, version) can have multiple deployments (one per provider),
-// so all matches are removed.
+// by ID. A non-empty version is required — deployments are identified by
+// (name, version, provider), so omitting version could span multiple versions
+// and cause surprise bulk deletes. The same (name, version) can still map to
+// multiple deployments (one per provider); all of those are removed.
 func deploymentDeleteFunc(_ context.Context, name, version string) error {
+	if version == "" {
+		return fmt.Errorf("%w: --version is required when deleting deployments", database.ErrInvalidInput)
+	}
 	all, err := apiClient.GetDeployedServers()
 	if err != nil {
 		return fmt.Errorf("listing deployments: %w", err)
@@ -286,7 +291,7 @@ func deploymentDeleteFunc(_ context.Context, name, version string) error {
 		if d == nil {
 			continue
 		}
-		if d.ServerName == name && (version == "" || d.Version == version) {
+		if d.ServerName == name && d.Version == version {
 			matches = append(matches, d)
 		}
 	}

--- a/internal/cli/declarative/deployment_delete_test.go
+++ b/internal/cli/declarative/deployment_delete_test.go
@@ -1,0 +1,142 @@
+package declarative_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/agentregistry-dev/agentregistry/internal/cli/declarative"
+	"github.com/agentregistry-dev/agentregistry/internal/client"
+	"github.com/agentregistry-dev/agentregistry/pkg/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// deploymentTestServer builds an httptest.Server routing:
+//   - GET    /v0/deployments       → returns `list`
+//   - DELETE /v0/deployments/{id}  → status 200 unless id is in `failIDs`, then 500
+//
+// Captures every received DELETE id in order for assertions.
+func deploymentTestServer(t *testing.T, list []models.Deployment, failIDs map[string]bool) (*httptest.Server, *[]string) {
+	t.Helper()
+	var mu sync.Mutex
+	deleted := []string{}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v0/deployments", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"deployments": list})
+		default:
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		}
+	})
+	mux.HandleFunc("/v0/deployments/", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		id := strings.TrimPrefix(r.URL.Path, "/v0/deployments/")
+		mu.Lock()
+		deleted = append(deleted, id)
+		mu.Unlock()
+		if failIDs[id] {
+			http.Error(w, fmt.Sprintf(`{"error":"simulated delete failure for %s"}`, id), http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv, &deleted
+}
+
+func setupClientForServer(t *testing.T, srv *httptest.Server) {
+	t.Helper()
+	c := client.NewClient(srv.URL, "")
+	declarative.SetAPIClient(c)
+	t.Cleanup(func() { declarative.SetAPIClient(nil) })
+}
+
+// (1) Versioned delete removes all provider-specific deployments matching (name, version).
+// Deployments on other providers for the same (name, version) get deleted; deployments on
+// other versions are left alone.
+func TestDeploymentDelete_RemovesAllProviderMatchesForVersion(t *testing.T) {
+	deployments := []models.Deployment{
+		{ID: "aws-v1", ServerName: "summarizer", Version: "1.0.0", ProviderID: "my-aws", ResourceType: "agent"},
+		{ID: "gcp-v1", ServerName: "summarizer", Version: "1.0.0", ProviderID: "my-gcp", ResourceType: "agent"},
+		{ID: "aws-v2", ServerName: "summarizer", Version: "2.0.0", ProviderID: "my-aws", ResourceType: "agent"},
+		{ID: "other", ServerName: "unrelated", Version: "1.0.0", ProviderID: "my-aws", ResourceType: "agent"},
+	}
+	srv, deleted := deploymentTestServer(t, deployments, nil)
+	setupClientForServer(t, srv)
+
+	cmd := declarative.NewDeleteCmd()
+	cmd.SetArgs([]string{"deployment", "summarizer", "--version", "1.0.0"})
+	require.NoError(t, cmd.Execute())
+
+	assert.ElementsMatch(t, []string{"aws-v1", "gcp-v1"}, *deleted,
+		"both provider variants of summarizer 1.0.0 should be deleted; nothing else")
+}
+
+// (2) When no deployment matches (name, version), returns a not-found error.
+func TestDeploymentDelete_NotFound(t *testing.T) {
+	deployments := []models.Deployment{
+		{ID: "aws-v2", ServerName: "summarizer", Version: "2.0.0", ProviderID: "my-aws", ResourceType: "agent"},
+	}
+	srv, deleted := deploymentTestServer(t, deployments, nil)
+	setupClientForServer(t, srv)
+
+	cmd := declarative.NewDeleteCmd()
+	cmd.SetArgs([]string{"deployment", "summarizer", "--version", "1.0.0"})
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found",
+		"no match should surface the registry not-found sentinel")
+	assert.Empty(t, *deleted, "no DELETE requests should be issued when nothing matches")
+}
+
+// (3) When the server rejects one of the matching deletes, the error is surfaced and
+// identifies the failing deployment — not silently ignored.
+func TestDeploymentDelete_PartialFailure(t *testing.T) {
+	deployments := []models.Deployment{
+		{ID: "aws-v1", ServerName: "summarizer", Version: "1.0.0", ProviderID: "my-aws", ResourceType: "agent"},
+		{ID: "gcp-v1", ServerName: "summarizer", Version: "1.0.0", ProviderID: "my-gcp", ResourceType: "agent"},
+	}
+	// Fail the GCP delete only.
+	srv, deleted := deploymentTestServer(t, deployments, map[string]bool{"gcp-v1": true})
+	setupClientForServer(t, srv)
+
+	cmd := declarative.NewDeleteCmd()
+	cmd.SetArgs([]string{"deployment", "summarizer", "--version", "1.0.0"})
+	err := cmd.Execute()
+	require.Error(t, err, "partial failure must propagate")
+	assert.Contains(t, err.Error(), "gcp-v1", "error should identify which deployment failed")
+
+	// Both DELETEs should have been attempted — we don't stop on first failure.
+	assert.ElementsMatch(t, []string{"aws-v1", "gcp-v1"}, *deleted,
+		"both matching deployments should be attempted even when one fails")
+}
+
+// (4) Guard against the earlier wildcard bug: empty --version must be rejected before
+// issuing any HTTP call, to prevent accidental bulk deletes across all versions.
+func TestDeploymentDelete_RejectsEmptyVersion(t *testing.T) {
+	deployments := []models.Deployment{
+		{ID: "aws-v1", ServerName: "summarizer", Version: "1.0.0", ProviderID: "my-aws", ResourceType: "agent"},
+		{ID: "aws-v2", ServerName: "summarizer", Version: "2.0.0", ProviderID: "my-aws", ResourceType: "agent"},
+	}
+	srv, deleted := deploymentTestServer(t, deployments, nil)
+	setupClientForServer(t, srv)
+
+	cmd := declarative.NewDeleteCmd()
+	cmd.SetArgs([]string{"deployment", "summarizer"})
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "version",
+		"empty version should error with a version-required message")
+	assert.Empty(t, *deleted, "no DELETE requests should be issued when version is missing")
+}

--- a/internal/registry/api/handlers/v0/providers/handlers.go
+++ b/internal/registry/api/handlers/v0/providers/handlers.go
@@ -62,7 +62,7 @@ func providerWriteHTTPError(action string, err error) error {
 	case providersvc.IsUnsupportedPlatformError(err):
 		return huma.Error400BadRequest(err.Error())
 	case errors.Is(err, database.ErrInvalidInput):
-		return huma.Error400BadRequest("Invalid provider input")
+		return huma.Error400BadRequest(err.Error())
 	case errors.Is(err, database.ErrAlreadyExists):
 		return huma.Error409Conflict("Provider already exists")
 	case errors.Is(err, database.ErrNotFound):

--- a/internal/registry/registry_app.go
+++ b/internal/registry/registry_app.go
@@ -518,11 +518,16 @@ func deploymentApplyFunc(svc deploymentsvc.Registry) kinds.ApplyFunc {
 
 // deploymentDeleteFunc returns the Delete function for the deployment kind.
 // The server-side DELETE /v0/apply batch handler dispatches here when a
-// deployment doc is included. Identity is (name, version) — the same
-// (name, version) can map to multiple deployments (one per provider), so
-// all matches are removed.
+// deployment doc is included. A non-empty version is required — deployments
+// are identified by (name, version, provider), so an empty version could
+// span multiple versions and cause surprise bulk deletes. The same
+// (name, version) can still map to multiple deployments (one per provider);
+// all of those are removed.
 func deploymentDeleteFunc(svc deploymentsvc.Registry) kinds.DeleteFunc {
 	return func(ctx context.Context, name, version string) error {
+		if version == "" {
+			return fmt.Errorf("%w: version is required when deleting deployments", database.ErrInvalidInput)
+		}
 		matches, err := svc.ListDeployments(ctx, &models.DeploymentFilter{ResourceName: &name})
 		if err != nil {
 			return fmt.Errorf("listing deployments: %w", err)
@@ -532,10 +537,7 @@ func deploymentDeleteFunc(svc deploymentsvc.Registry) kinds.DeleteFunc {
 			if d == nil {
 				continue
 			}
-			if d.ServerName != name {
-				continue
-			}
-			if version != "" && d.Version != version {
+			if d.ServerName != name || d.Version != version {
 				continue
 			}
 			toDelete = append(toDelete, d)

--- a/internal/registry/registry_app.go
+++ b/internal/registry/registry_app.go
@@ -301,6 +301,7 @@ func App(ctx context.Context, opts ...types.AppOptions) error {
 		Aliases:  []string{"Deployment"},
 		SpecType: reflect.TypeFor[kinds.DeploymentSpec](),
 		Apply:    deploymentApplyFunc(deploymentService),
+		Delete:   deploymentDeleteFunc(deploymentService),
 		TableColumns: []kinds.Column{
 			{Header: "NAME"}, {Header: "VERSION"}, {Header: "RESOURCE_TYPE"},
 			{Header: "PROVIDER"}, {Header: "STATUS"},
@@ -512,5 +513,42 @@ func deploymentApplyFunc(svc deploymentsvc.Registry) kinds.ApplyFunc {
 			}
 		}
 		return kinds.AppliedResult("deployment", doc), nil
+	}
+}
+
+// deploymentDeleteFunc returns the Delete function for the deployment kind.
+// The server-side DELETE /v0/apply batch handler dispatches here when a
+// deployment doc is included. Identity is (name, version) — the same
+// (name, version) can map to multiple deployments (one per provider), so
+// all matches are removed.
+func deploymentDeleteFunc(svc deploymentsvc.Registry) kinds.DeleteFunc {
+	return func(ctx context.Context, name, version string) error {
+		matches, err := svc.ListDeployments(ctx, &models.DeploymentFilter{ResourceName: &name})
+		if err != nil {
+			return fmt.Errorf("listing deployments: %w", err)
+		}
+		var toDelete []*models.Deployment
+		for _, d := range matches {
+			if d == nil {
+				continue
+			}
+			if d.ServerName != name {
+				continue
+			}
+			if version != "" && d.Version != version {
+				continue
+			}
+			toDelete = append(toDelete, d)
+		}
+		if len(toDelete) == 0 {
+			return database.ErrNotFound
+		}
+		var errs []error
+		for _, d := range toDelete {
+			if err := svc.DeleteDeployment(ctx, d.ID); err != nil {
+				errs = append(errs, fmt.Errorf("deleting %s (provider %s): %w", d.ID, d.ProviderID, err))
+			}
+		}
+		return errors.Join(errs...)
 	}
 }


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don't apply.
-->

# Description
fix: deployment delete wiring 


**Motivation**:
This is a follow up from this PR  https://github.com/agentregistry-dev/agentregistry/pull/434
The `deployment` kind was registered with `Apply` / `List` but no `Delete`, so deleting deployments via the declarative CLI returned `delete not supported  for kind "deployment"` 

<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

# Change Type

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bump
/kind cleanup
/kind design
/kind deprecation
/kind documentation
/kind feature
/kind fix
/kind flake
/kind install
```
-->
/kind fix
# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
fix(declarative): deployment delete wiring 
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
