### PR TITLE
[DX] Use proper naming for CLI token provider method

### DIFF
--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -24,11 +24,11 @@ import (
 )
 
 const (
-	// AnnotationSkipAuthn can be set on a cobra.Command's Annotations map to skip
-	// CLI authentication (OIDC discovery and token resolution) during pre-run setup.
+	// AnnotationSkipTokenResolution can be set on a cobra.Command's Annotations map to skip
+	// CLI token resolution during pre-run setup.
 	// The command will still get an API client, just without an auth token.
 	// Child commands inherit this from their parents.
-	AnnotationSkipAuthn = "skipAuthentication"
+	AnnotationSkipTokenResolution = "skipTokenResolution"
 )
 
 // ClientFactory creates an API client for the given base URL and token.
@@ -38,8 +38,8 @@ type ClientFactory func(ctx context.Context, baseURL, token string) (*client.Cli
 // CLIOptions configures the CLI behavior.
 // Can be extended for more options (e.g. client factory).
 type CLIOptions struct {
-	// AuthnProviderFactory provides CLI-specific authentication.
-	AuthnProviderFactory types.CLIAuthnProviderFactory
+	// TokenProviderFactory allows for extensions to provide tokens to CLI.
+	TokenProviderFactory types.CLITokenProviderFactory
 
 	// OnTokenResolved is called when a token is resolved.
 	// This allows extensions to perform additional actions when a token is resolved (e.g. storing locally).
@@ -131,8 +131,8 @@ func resolveRegistryTarget(getEnv func(string) string) (baseURL, token string) {
 	return base, token
 }
 
-// resolveAuthToken resolves the authentication token from the CLI authentication provider.
-func resolveAuthToken(ctx context.Context, cmd *cobra.Command, factory types.CLIAuthnProviderFactory) (string, error) {
+// resolveAuthToken resolves the authentication token from the CLI token provider.
+func resolveAuthToken(ctx context.Context, cmd *cobra.Command, factory types.CLITokenProviderFactory) (string, error) {
 	provider, err := factory(cmd.Root())
 	if err != nil {
 		if errors.Is(err, types.ErrNoOIDCDefined) {
@@ -144,7 +144,7 @@ func resolveAuthToken(ctx context.Context, cmd *cobra.Command, factory types.CLI
 		return "", nil // non-blocking, user may be running a command that does not require authentication
 	}
 
-	token, err := provider.Authenticate(ctx)
+	token, err := provider.Token(ctx)
 	if err != nil {
 		if errors.Is(err, types.ErrCLINoStoredToken) {
 			return "", nil // non-blocking, user may be running a command that does not require authentication
@@ -207,22 +207,22 @@ func preRunBehavior(cmd *cobra.Command) (skipSetup bool) {
 	return false
 }
 
-// shouldSkipAuthn checks the command and its ancestors for the AnnotationSkipAuthn annotation.
+// shouldSkipTokenResolution checks the command and its ancestors for the AnnotationSkipTokenResolution annotation.
 // The nearest (most specific) annotation wins: a child can override a parent's setting.
-func shouldSkipAuthn(cmd *cobra.Command) bool {
+func shouldSkipTokenResolution(cmd *cobra.Command) bool {
 	for c := cmd; c != nil; c = c.Parent() {
-		if v, ok := c.Annotations[AnnotationSkipAuthn]; ok {
+		if v, ok := c.Annotations[AnnotationSkipTokenResolution]; ok {
 			return v == "true"
 		}
 	}
 	return false
 }
 
-// preRunSetup resolves auth and creates the API client.
+// preRunSetup resolves the API token and creates the API client.
 func preRunSetup(ctx context.Context, cmd *cobra.Command, baseURL, token string) (*client.Client, error) {
 	// Get authentication token if no token override was provided
-	if token == "" && cliOptions.AuthnProviderFactory != nil && !shouldSkipAuthn(cmd) {
-		resolvedToken, err := resolveAuthToken(ctx, cmd, cliOptions.AuthnProviderFactory)
+	if token == "" && cliOptions.TokenProviderFactory != nil && !shouldSkipTokenResolution(cmd) {
+		resolvedToken, err := resolveAuthToken(ctx, cmd, cliOptions.TokenProviderFactory)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/cli/root_test.go
+++ b/pkg/cli/root_test.go
@@ -113,7 +113,7 @@ func TestShouldSkipTokenResolution(t *testing.T) {
 	childOfAnnotated := &cobra.Command{Use: "child"}
 	annotatedCmd.AddCommand(childOfAnnotated)
 
-	// Child explicitly opts back in to authn (overrides parent)
+	// Child explicitly opts back in to resolving token (overrides parent)
 	childOptIn := &cobra.Command{
 		Use:         "secure-child",
 		Annotations: map[string]string{AnnotationSkipTokenResolution: "false"},
@@ -224,7 +224,7 @@ func TestPreRunSetup(t *testing.T) {
 		return client.NewClient(u, tok), nil
 	}
 
-	// Use a dummy command for testing, since some code paths may access cmd.Root() for authn provider
+	// Use a dummy command for testing, since some code paths may access cmd.Root() for token provider
 	mockCmd := &cobra.Command{Use: "test"}
 
 	oldOpts := cliOptions
@@ -243,14 +243,14 @@ func TestPreRunSetup(t *testing.T) {
 		}
 	})
 
-	t.Run("authn_provider_supplies_token", func(t *testing.T) {
-		var mockAuthnTokenFactory = func(_ *cobra.Command) (types.CLITokenProvider, error) {
+	t.Run("token_provider_supplies_token", func(t *testing.T) {
+		var mockTokenProviderFactory = func(_ *cobra.Command) (types.CLITokenProvider, error) {
 			return &mockTokenProvider{token: "authn-token"}, nil
 		}
 
 		var authnToken string
 		Configure(CLIOptions{
-			TokenProviderFactory: mockAuthnTokenFactory,
+			TokenProviderFactory: mockTokenProviderFactory,
 			ClientFactory: func(_ context.Context, u, tok string) (*client.Client, error) {
 				authnToken = tok
 				return dummyClient, nil
@@ -263,20 +263,20 @@ func TestPreRunSetup(t *testing.T) {
 			t.Fatalf("preRunSetup: %v", err)
 		}
 		if authnToken != "authn-token" {
-			t.Errorf("expected token from AuthnProvider, got %q", authnToken)
+			t.Errorf("expected token from TokenProvider, got %q", authnToken)
 		}
 	})
 
-	t.Run("skip_authn_annotation_skips_token_resolution", func(t *testing.T) {
-		authnCalled := false
-		var mockAuthnProviderFactory = func(_ *cobra.Command) (types.CLITokenProvider, error) {
-			authnCalled = true
+	t.Run("skip_token_resolution_annotation_skips_token_resolution", func(t *testing.T) {
+		tokenResolutionCalled := false
+		var mockTokenProviderFactory = func(_ *cobra.Command) (types.CLITokenProvider, error) {
+			tokenResolutionCalled = true
 			return &mockTokenProvider{token: "should-not-be-used"}, nil
 		}
 
 		var clientToken string
 		Configure(CLIOptions{
-			TokenProviderFactory: mockAuthnProviderFactory,
+			TokenProviderFactory: mockTokenProviderFactory,
 			ClientFactory: func(_ context.Context, u, tok string) (*client.Client, error) {
 				clientToken = tok
 				return client.NewClient(u, tok), nil
@@ -296,19 +296,19 @@ func TestPreRunSetup(t *testing.T) {
 		if c == nil {
 			t.Fatal("preRunSetup: expected client")
 		}
-		if authnCalled {
-			t.Error("expected authn provider to NOT be called when SkipAuthn annotation is set")
+		if tokenResolutionCalled {
+			t.Error("expected token provider to NOT be called when SkipTokenResolution annotation is set")
 		}
 		if clientToken != "" {
 			t.Errorf("expected empty token, got %q", clientToken)
 		}
 	})
 
-	t.Run("skip_authn_annotation_still_uses_explicit_token", func(t *testing.T) {
+	t.Run("skip_token_resolution_annotation_still_uses_explicit_token", func(t *testing.T) {
 		var clientToken string
 		Configure(CLIOptions{
 			TokenProviderFactory: func(_ *cobra.Command) (types.CLITokenProvider, error) {
-				t.Fatal("authn provider should not be called when explicit token is provided")
+				t.Fatal("token provider should not be called when explicit token is provided")
 				return nil, nil
 			},
 			ClientFactory: func(_ context.Context, u, tok string) (*client.Client, error) {
@@ -335,23 +335,23 @@ func TestPreRunSetup(t *testing.T) {
 		}
 	})
 
-	t.Run("authn_provider_error", func(t *testing.T) {
-		authnErr := errors.New("auth failed")
-		var mockAuthnProviderFactory = func(_ *cobra.Command) (types.CLITokenProvider, error) {
-			return &mockTokenProvider{err: authnErr}, nil
+	t.Run("token_provider_error", func(t *testing.T) {
+		tokenProviderErr := errors.New("auth failed")
+		var mockTokenProviderFactory = func(_ *cobra.Command) (types.CLITokenProvider, error) {
+			return &mockTokenProvider{err: tokenProviderErr}, nil
 		}
 
 		Configure(CLIOptions{
-			TokenProviderFactory: mockAuthnProviderFactory,
+			TokenProviderFactory: mockTokenProviderFactory,
 			ClientFactory:        clientFactory,
 		})
 		defer func() { Configure(oldOpts) }()
 
 		_, err := preRunSetup(ctx, mockCmd, baseURL, "")
 		if err == nil {
-			t.Fatal("expected error from AuthnProvider")
+			t.Fatal("expected error from TokenProvider")
 		}
-		if !errors.Is(err, authnErr) {
+		if !errors.Is(err, tokenProviderErr) {
 			t.Errorf("expected auth error (wrapped), got %v", err)
 		}
 	})

--- a/pkg/cli/root_test.go
+++ b/pkg/cli/root_test.go
@@ -101,13 +101,13 @@ func TestPreRunBehavior(t *testing.T) {
 	}
 }
 
-func TestShouldSkipAuthn(t *testing.T) {
+func TestShouldSkipTokenResolution(t *testing.T) {
 	root := &cobra.Command{Use: "arctl"}
 
 	// Command with annotation
 	annotatedCmd := &cobra.Command{
 		Use:         "no-auth-cmd",
-		Annotations: map[string]string{AnnotationSkipAuthn: "true"},
+		Annotations: map[string]string{AnnotationSkipTokenResolution: "true"},
 	}
 	// Child inherits from annotated parent
 	childOfAnnotated := &cobra.Command{Use: "child"}
@@ -116,7 +116,7 @@ func TestShouldSkipAuthn(t *testing.T) {
 	// Child explicitly opts back in to authn (overrides parent)
 	childOptIn := &cobra.Command{
 		Use:         "secure-child",
-		Annotations: map[string]string{AnnotationSkipAuthn: "false"},
+		Annotations: map[string]string{AnnotationSkipTokenResolution: "false"},
 	}
 	annotatedCmd.AddCommand(childOptIn)
 
@@ -144,9 +144,9 @@ func TestShouldSkipAuthn(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := shouldSkipAuthn(tt.cmd)
+			got := shouldSkipTokenResolution(tt.cmd)
 			if got != tt.wantSkip {
-				t.Errorf("shouldSkipAuthn() = %v, want %v", got, tt.wantSkip)
+				t.Errorf("shouldSkipTokenResolution() = %v, want %v", got, tt.wantSkip)
 			}
 		})
 	}
@@ -244,13 +244,13 @@ func TestPreRunSetup(t *testing.T) {
 	})
 
 	t.Run("authn_provider_supplies_token", func(t *testing.T) {
-		var mockAuthnProviderFactory = func(_ *cobra.Command) (types.CLIAuthnProvider, error) {
-			return &mockAuthnProvider{token: "authn-token"}, nil
+		var mockAuthnTokenFactory = func(_ *cobra.Command) (types.CLITokenProvider, error) {
+			return &mockTokenProvider{token: "authn-token"}, nil
 		}
 
 		var authnToken string
 		Configure(CLIOptions{
-			AuthnProviderFactory: mockAuthnProviderFactory,
+			TokenProviderFactory: mockAuthnTokenFactory,
 			ClientFactory: func(_ context.Context, u, tok string) (*client.Client, error) {
 				authnToken = tok
 				return dummyClient, nil
@@ -269,14 +269,14 @@ func TestPreRunSetup(t *testing.T) {
 
 	t.Run("skip_authn_annotation_skips_token_resolution", func(t *testing.T) {
 		authnCalled := false
-		var mockAuthnProviderFactory = func(_ *cobra.Command) (types.CLIAuthnProvider, error) {
+		var mockAuthnProviderFactory = func(_ *cobra.Command) (types.CLITokenProvider, error) {
 			authnCalled = true
-			return &mockAuthnProvider{token: "should-not-be-used"}, nil
+			return &mockTokenProvider{token: "should-not-be-used"}, nil
 		}
 
 		var clientToken string
 		Configure(CLIOptions{
-			AuthnProviderFactory: mockAuthnProviderFactory,
+			TokenProviderFactory: mockAuthnProviderFactory,
 			ClientFactory: func(_ context.Context, u, tok string) (*client.Client, error) {
 				clientToken = tok
 				return client.NewClient(u, tok), nil
@@ -286,7 +286,7 @@ func TestPreRunSetup(t *testing.T) {
 
 		annotatedCmd := &cobra.Command{
 			Use:         "skip-auth",
-			Annotations: map[string]string{AnnotationSkipAuthn: "true"},
+			Annotations: map[string]string{AnnotationSkipTokenResolution: "true"},
 		}
 
 		c, err := preRunSetup(ctx, annotatedCmd, baseURL, "")
@@ -307,7 +307,7 @@ func TestPreRunSetup(t *testing.T) {
 	t.Run("skip_authn_annotation_still_uses_explicit_token", func(t *testing.T) {
 		var clientToken string
 		Configure(CLIOptions{
-			AuthnProviderFactory: func(_ *cobra.Command) (types.CLIAuthnProvider, error) {
+			TokenProviderFactory: func(_ *cobra.Command) (types.CLITokenProvider, error) {
 				t.Fatal("authn provider should not be called when explicit token is provided")
 				return nil, nil
 			},
@@ -320,7 +320,7 @@ func TestPreRunSetup(t *testing.T) {
 
 		annotatedCmd := &cobra.Command{
 			Use:         "skip-auth",
-			Annotations: map[string]string{AnnotationSkipAuthn: "true"},
+			Annotations: map[string]string{AnnotationSkipTokenResolution: "true"},
 		}
 
 		c, err := preRunSetup(ctx, annotatedCmd, baseURL, "explicit-token")
@@ -337,12 +337,12 @@ func TestPreRunSetup(t *testing.T) {
 
 	t.Run("authn_provider_error", func(t *testing.T) {
 		authnErr := errors.New("auth failed")
-		var mockAuthnProviderFactory = func(_ *cobra.Command) (types.CLIAuthnProvider, error) {
-			return &mockAuthnProvider{err: authnErr}, nil
+		var mockAuthnProviderFactory = func(_ *cobra.Command) (types.CLITokenProvider, error) {
+			return &mockTokenProvider{err: authnErr}, nil
 		}
 
 		Configure(CLIOptions{
-			AuthnProviderFactory: mockAuthnProviderFactory,
+			TokenProviderFactory: mockAuthnProviderFactory,
 			ClientFactory:        clientFactory,
 		})
 		defer func() { Configure(oldOpts) }()
@@ -427,17 +427,17 @@ func TestPreRunSetup(t *testing.T) {
 	})
 }
 
-// mockAuthnProvider for unit tests.
-type mockAuthnProvider struct {
+// mockTokenProvider for unit tests.
+type mockTokenProvider struct {
 	token string
 	err   error
 }
 
-func (m *mockAuthnProvider) Authenticate(context.Context) (string, error) {
+func (m *mockTokenProvider) Token(context.Context) (string, error) {
 	if m.err != nil {
 		return "", m.err
 	}
 	return m.token, nil
 }
 
-var _ types.CLIAuthnProvider = (*mockAuthnProvider)(nil)
+var _ types.CLITokenProvider = (*mockTokenProvider)(nil)

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -119,16 +119,16 @@ type DaemonManager interface {
 	Purge() error
 }
 
-// CLIAuthnProvider provides authentication for CLI commands.
-// External libraries can implement this to support different auth mechanisms
-type CLIAuthnProvider interface {
-	// Authenticate returns credentials for API calls.
-	Authenticate(ctx context.Context) (token string, err error)
+// CLITokenProvider provides tokens for CLI commands.
+// External libraries can implement this to support fetching tokens from defined sources
+type CLITokenProvider interface {
+	// Token returns token for API calls.
+	Token(ctx context.Context) (token string, err error)
 }
 
-// CLIAuthnProviderFactory is a function type that creates a CLI authentication provider.
+// CLITokenProviderFactory is a function type that creates a CLI token provider.
 // The factory optionally receives the root command, which can be used to access command-specific configuration (e.g. flags).
-type CLIAuthnProviderFactory func(root *cobra.Command) (CLIAuthnProvider, error)
+type CLITokenProviderFactory func(root *cobra.Command) (CLITokenProvider, error)
 
 // HTTPServerFactory is a function type that creates a server implementation that
 // adds new API routes and handlers.


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don't apply.
-->

# Description

The CLI method for resolving a token had a confusing name, so renaming it to better fit its true purpose.

Its previous name implied it handled authentication, _but_ that is handled on the server-side on API calls using the AuthnProvider.

It's new name is true to what it should simply handle -> providing tokens for use in the client.

It is still a skippable path, because getting a token could technically involve things like refreshing and cause failures, so we're staying configurable in case there are some commands that should not be blocked by this.

# Change Type

```
/kind cleanup
```

# Changelog

```release-note
NONE
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
