### PR TITLE
fix(k8s): show actionable error when kagent CRDs are not installed

### DIFF
--- a/internal/registry/platforms/kubernetes/deployment_adapter_kubernetes.go
+++ b/internal/registry/platforms/kubernetes/deployment_adapter_kubernetes.go
@@ -2,6 +2,7 @@ package kubernetes
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"strings"
@@ -14,6 +15,7 @@ import (
 	serversvc "github.com/agentregistry-dev/agentregistry/internal/registry/service/server"
 	"github.com/agentregistry-dev/agentregistry/pkg/models"
 	"github.com/agentregistry-dev/agentregistry/pkg/registry/database"
+	k8smeta "k8s.io/apimachinery/pkg/api/meta"
 )
 
 type kubernetesDeploymentAdapter struct {
@@ -47,6 +49,10 @@ func (a *kubernetesDeploymentAdapter) Deploy(ctx context.Context, req *models.De
 		return nil, err
 	}
 	if err := kubernetesApplyPlatformConfig(ctx, provider, cfg, false); err != nil {
+		if isKagentCRDNotFoundError(err) {
+			// Wrap original to preserve chain for logging; message is user-actionable.
+			return nil, fmt.Errorf("kagent CRD not found in cluster — kagent may not be installed or may be partially installed: install from https://kagent.dev: %w", err)
+		}
 		return nil, fmt.Errorf("apply kubernetes platform config: %w", err)
 	}
 	return &models.DeploymentActionResult{Status: models.DeploymentStatusDeployed}, nil
@@ -151,4 +157,38 @@ func deploymentNamespace(deployment *models.Deployment, provider *models.Provide
 		return namespace
 	}
 	return kubernetesDefaultNamespace()
+}
+
+// isKagentCRDNotFoundError reports whether err indicates that a kagent CRD is not
+// registered in the cluster. It checks two cases:
+//
+//  1. Structured: errors.As reaches a *k8smeta.NoKindMatchError whose Group is
+//     "kagent.dev" and whose Kind is one we actually deploy. This is the expected
+//     path when the REST mapper error propagates unwrapped.
+//
+//  2. Fallback string check: controller-runtime's Apply may wrap the REST mapper
+//     error inside a *k8serrors.StatusError, losing the typed chain. In that case
+//     we inspect the message text. Both substrings must be present to avoid false
+//     positives from unrelated "no matches for kind" errors.
+func isKagentCRDNotFoundError(err error) bool {
+	if err == nil {
+		return false
+	}
+	// kagentKinds is the set of CRD Kinds we deploy via kagent. Checking Kind
+	// prevents false positives from other kagent.dev CRDs absent due to partial
+	// installs with a different remediation path.
+	kagentKinds := map[string]bool{
+		"Agent":     true,
+		"McpServer": true,
+	}
+
+	var noKind *k8smeta.NoKindMatchError
+	if errors.As(err, &noKind) {
+		return noKind.GroupKind.Group == "kagent.dev" && kagentKinds[noKind.GroupKind.Kind]
+	}
+
+	// Fallback: handle the case where controller-runtime wrapped the REST mapper
+	// error as a StatusError, breaking the typed chain.
+	msg := err.Error()
+	return strings.Contains(msg, "no matches for kind") && strings.Contains(msg, "kagent.dev")
 }

--- a/internal/registry/platforms/kubernetes/deployment_adapter_kubernetes.go
+++ b/internal/registry/platforms/kubernetes/deployment_adapter_kubernetes.go
@@ -50,8 +50,12 @@ func (a *kubernetesDeploymentAdapter) Deploy(ctx context.Context, req *models.De
 	}
 	if err := kubernetesApplyPlatformConfig(ctx, provider, cfg, false); err != nil {
 		if isKagentCRDNotFoundError(err) {
-			// Wrap original to preserve chain for logging; message is user-actionable.
-			return nil, fmt.Errorf("kagent CRD not found in cluster — kagent may not be installed or may be partially installed: install from https://kagent.dev: %w", err)
+			// Classify as invalid input/precondition so the API can map it to a 4xx,
+			// while preserving the original cause for logging and diagnostics.
+			return nil, errors.Join(
+				database.ErrInvalidInput,
+				fmt.Errorf("kagent CRD not found in cluster — kagent may not be installed or may be partially installed: install from https://kagent.dev: %w", err),
+			)
 		}
 		return nil, fmt.Errorf("apply kubernetes platform config: %w", err)
 	}

--- a/internal/registry/platforms/kubernetes/deployment_adapter_kubernetes_platform_test.go
+++ b/internal/registry/platforms/kubernetes/deployment_adapter_kubernetes_platform_test.go
@@ -12,7 +12,9 @@ import (
 	v1alpha2 "github.com/kagent-dev/kagent/go/api/v1alpha2"
 	kmcpv1alpha1 "github.com/kagent-dev/kmcp/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
+	k8smeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -719,5 +721,100 @@ func TestKubernetesDeploymentScopedName_TruncatesLongBaseButPreservesSuffix(t *t
 	}
 	if !strings.HasSuffix(got, "-2d6d0c54") {
 		t.Fatalf("expected uuid short suffix to be preserved, got %s", got)
+	}
+}
+
+func TestIsKagentCRDNotFoundError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		// --- Typed path (errors.As reaches NoKindMatchError) ---
+		{
+			name: "typed/Agent CRD missing",
+			err: &k8smeta.NoKindMatchError{
+				GroupKind:        schema.GroupKind{Group: "kagent.dev", Kind: "Agent"},
+				SearchedVersions: []string{"v1alpha2"},
+			},
+			want: true,
+		},
+		{
+			name: "typed/McpServer CRD missing",
+			err: &k8smeta.NoKindMatchError{
+				GroupKind:        schema.GroupKind{Group: "kagent.dev", Kind: "McpServer"},
+				SearchedVersions: []string{"v1alpha2"},
+			},
+			want: true,
+		},
+		{
+			name: "typed/wrapped by kubernetesApplyResource",
+			err: fmt.Errorf("failed to apply Agent myagent-0-1-0: %w", &k8smeta.NoKindMatchError{
+				GroupKind:        schema.GroupKind{Group: "kagent.dev", Kind: "Agent"},
+				SearchedVersions: []string{"v1alpha2"},
+			}),
+			want: true,
+		},
+		{
+			name: "typed/kagent.dev group but unknown Kind - partial install",
+			err: &k8smeta.NoKindMatchError{
+				GroupKind:        schema.GroupKind{Group: "kagent.dev", Kind: "UnknownKind"},
+				SearchedVersions: []string{"v1alpha2"},
+			},
+			want: false,
+		},
+		{
+			name: "typed/different group",
+			err: &k8smeta.NoKindMatchError{
+				GroupKind:        schema.GroupKind{Group: "other.io", Kind: "Agent"},
+				SearchedVersions: []string{"v1"},
+			},
+			want: false,
+		},
+		{
+			name: "typed/group contains kagent.dev as substring but is not equal",
+			err: &k8smeta.NoKindMatchError{
+				GroupKind:        schema.GroupKind{Group: "not-kagent.dev", Kind: "Agent"},
+				SearchedVersions: []string{"v1alpha2"},
+			},
+			want: false,
+		},
+
+		// --- Fallback string path (StatusError wrapping breaks typed chain) ---
+		{
+			name: "fallback/StatusError-style wrapping preserves message text",
+			err:  fmt.Errorf(`no matches for kind "Agent" in version "kagent.dev/v1alpha2"`),
+			want: true,
+		},
+		{
+			name: "fallback/no matches for kind but unrelated group",
+			err:  fmt.Errorf(`no matches for kind "Foo" in version "other.io/v1"`),
+			want: false,
+		},
+		{
+			name: "fallback/contains kagent.dev but not the kind-match phrase",
+			err:  fmt.Errorf("connection refused to kagent.dev endpoint"),
+			want: false,
+		},
+
+		// --- Negative cases ---
+		{
+			name: "unrelated error",
+			err:  fmt.Errorf("context deadline exceeded"),
+			want: false,
+		},
+		{
+			name: "nil error",
+			err:  nil,
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isKagentCRDNotFoundError(tt.err); got != tt.want {
+				t.Errorf("isKagentCRDNotFoundError(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
# Description

**Motivation:** When deploying agents to Kubernetes without kagent installed, users received a cryptic 500 Internal Server Error with a buried no matches for kind "Agent" in version "kagent.dev/v1alpha2" message that gave no actionable guidance.

What changed:
- Added isKagentCRDNotFoundError(err error) bool in deployment_adapter_kubernetes.go that detects the missing CRD condition using two strategies:
  - Primary: errors.As(*k8smeta.NoKindMatchError) with exact Group == "kagent.dev" and Kind scoped to CRDs we actually deploy (Agent, McpServer) — handles the case where the REST mapper error propagates unwrapped
  - Fallback: string-based check for "no matches for kind" + "kagent.dev" — handles the case where controller-runtime wraps the error inside a *StatusError, breaking the typed chain
- Detection happens in Deploy() on the adapter, not in the generic kubernetesApplyResource utility
- Original error is preserved via %w for logging and chain inspection
- 11 table-driven tests covering both detection paths, negative cases, partial installs, and nil

Fixes #318

# Change Type
```
/kind fix
```

# Changelog
```release-note
fix(k8s): show actionable error message when deploying to Kubernetes without kagent installed
```