### PR TITLE
fix: `get deployment` wiring

### DIFF
--- a/internal/cli/declarative/declarative.go
+++ b/internal/cli/declarative/declarative.go
@@ -268,9 +268,28 @@ func newCLIRegistry() *kinds.Registry {
 			d := item.(*models.Deployment)
 			return []string{d.ID, d.ServerName, d.Version, d.ResourceType, d.ProviderID, d.Status}
 		},
+		Get:    deploymentGetFunc,
 		Delete: deploymentDeleteFunc,
 	})
 	return reg
+}
+
+// deploymentGetFunc returns the first deployment matching ServerName == name.
+// Deployments are keyed by ID but users refer to them by name; a single name
+// can map to multiple deployments (different versions/providers). For `get`
+// we surface the first match — callers that need to disambiguate should use
+// `arctl get deployments` for the full list.
+func deploymentGetFunc(_ context.Context, name, _ string) (any, error) {
+	all, err := apiClient.GetDeployedServers()
+	if err != nil {
+		return nil, err
+	}
+	for _, d := range all {
+		if d != nil && d.ServerName == name {
+			return d, nil
+		}
+	}
+	return nil, database.ErrNotFound
 }
 
 // deploymentDeleteFunc looks up deployments by (name, version) and deletes each match

--- a/internal/cli/declarative/declarative.go
+++ b/internal/cli/declarative/declarative.go
@@ -239,6 +239,21 @@ func newCLIRegistry() *kinds.Registry {
 			p := item.(*models.Provider)
 			return []string{p.Name, p.Platform}
 		},
+		ToResourceFunc: func(item any) *kinds.Document {
+			p, ok := item.(*models.Provider)
+			if !ok {
+				return nil
+			}
+			return &kinds.Document{
+				APIVersion: scheme.APIVersion,
+				Kind:       "Provider",
+				Metadata:   kinds.Metadata{Name: p.Name},
+				Spec: kinds.ProviderSpec{
+					Platform: p.Platform,
+					Config:   p.Config,
+				},
+			}
+		},
 		Get: func(_ context.Context, name, _ string) (any, error) {
 			return apiClient.GetProvider(name)
 		},
@@ -267,6 +282,28 @@ func newCLIRegistry() *kinds.Registry {
 		RowFunc: func(item any) []string {
 			d := item.(*models.Deployment)
 			return []string{d.ID, d.ServerName, d.Version, d.ResourceType, d.ProviderID, d.Status}
+		},
+		ToResourceFunc: func(item any) *kinds.Document {
+			d, ok := item.(*models.Deployment)
+			if !ok {
+				return nil
+			}
+			// Render only the declarative DeploymentSpec fields so `-o yaml`
+			// output round-trips through `arctl apply -f`. Server-managed
+			// state (ID, Status, Origin, ProviderMetadata, DeployedAt, etc.)
+			// is intentionally omitted.
+			return &kinds.Document{
+				APIVersion: scheme.APIVersion,
+				Kind:       "Deployment",
+				Metadata:   kinds.Metadata{Name: d.ServerName, Version: d.Version},
+				Spec: kinds.DeploymentSpec{
+					ProviderID:     d.ProviderID,
+					ResourceType:   d.ResourceType,
+					Env:            d.Env,
+					ProviderConfig: d.ProviderConfig,
+					PreferRemote:   d.PreferRemote,
+				},
+			}
 		},
 		Get:    deploymentGetFunc,
 		Delete: deploymentDeleteFunc,

--- a/internal/cli/declarative/deployment_get_test.go
+++ b/internal/cli/declarative/deployment_get_test.go
@@ -96,3 +96,43 @@ func TestDeploymentGet_ListReturnsAll(t *testing.T) {
 	assert.Contains(t, out.String(), "summarizer")
 	assert.Contains(t, out.String(), "other")
 }
+
+// (5) `-o yaml` emits the declarative envelope (apiVersion/kind/metadata/spec)
+// and strips server-managed fields so the output round-trips through apply.
+func TestDeploymentGet_YAMLOutputRoundTrips(t *testing.T) {
+	deployments := []models.Deployment{
+		{
+			ID: "aws-v1", ServerName: "summarizer", Version: "1.0.0",
+			ProviderID: "my-aws", ResourceType: "agent", Status: "deployed",
+			Origin:           "managed",
+			Env:              map[string]string{"GOOGLE_API_KEY": "xxx"},
+			ProviderMetadata: models.JSONObject{"remoteId": "secret-runtime-id"},
+		},
+	}
+	srv, _ := deploymentTestServer(t, deployments, nil)
+	setupClientForServer(t, srv)
+
+	out := &bytes.Buffer{}
+	cmd := declarative.NewGetCmd()
+	cmd.SetOut(out)
+	cmd.SetArgs([]string{"deployment", "summarizer", "-o", "yaml"})
+	require.NoError(t, cmd.Execute())
+
+	got := out.String()
+	// Envelope shape — apply expects these keys at the top.
+	assert.Contains(t, got, "apiVersion: ar.dev/v1alpha1")
+	assert.Contains(t, got, "kind: Deployment")
+	assert.Contains(t, got, "name: summarizer")
+	assert.Contains(t, got, "version: 1.0.0")
+	// Declarative spec fields.
+	assert.Contains(t, got, "providerId: my-aws")
+	assert.Contains(t, got, "resourceType: agent")
+	assert.Contains(t, got, "GOOGLE_API_KEY: xxx")
+	// Server-managed fields must be stripped.
+	assert.NotContains(t, got, "aws-v1", "spec must not leak the server-assigned id")
+	assert.NotContains(t, got, "status:", "spec must not leak the runtime status")
+	assert.NotContains(t, got, "origin:", "spec must not leak the managed/discovered origin")
+	assert.NotContains(t, got, "providerMetadata:", "spec must not leak provider-runtime metadata")
+	assert.NotContains(t, got, "deployedAt", "spec must not leak server timestamps")
+	assert.NotContains(t, got, "updatedAt", "spec must not leak server timestamps")
+}

--- a/internal/cli/declarative/deployment_get_test.go
+++ b/internal/cli/declarative/deployment_get_test.go
@@ -1,0 +1,98 @@
+package declarative_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/agentregistry-dev/agentregistry/internal/cli/declarative"
+	"github.com/agentregistry-dev/agentregistry/pkg/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// (1) Get by name returns the matching deployment when exactly one exists.
+func TestDeploymentGet_ReturnsMatchByName(t *testing.T) {
+	deployments := []models.Deployment{
+		{ID: "aws-v1", ServerName: "summarizer", Version: "1.0.0", ProviderID: "my-aws", ResourceType: "agent", Status: "deployed"},
+		{ID: "other", ServerName: "unrelated", Version: "1.0.0", ProviderID: "my-aws", ResourceType: "agent", Status: "deployed"},
+	}
+	srv, _ := deploymentTestServer(t, deployments, nil)
+	setupClientForServer(t, srv)
+
+	out := &bytes.Buffer{}
+	cmd := declarative.NewGetCmd()
+	cmd.SetOut(out)
+	cmd.SetArgs([]string{"deployment", "summarizer"})
+	require.NoError(t, cmd.Execute())
+
+	assert.Contains(t, out.String(), "summarizer",
+		"get should render the matching deployment's name in the table output")
+	assert.NotContains(t, out.String(), "unrelated",
+		"unrelated deployments must not appear")
+}
+
+// (2) Get returns the first match when multiple deployments share a name.
+// Users needing disambiguation should use `arctl get deployments`.
+func TestDeploymentGet_ReturnsFirstWhenMultipleShareName(t *testing.T) {
+	deployments := []models.Deployment{
+		{ID: "aws-v1", ServerName: "summarizer", Version: "1.0.0", ProviderID: "my-aws", ResourceType: "agent", Status: "deployed"},
+		{ID: "gcp-v1", ServerName: "summarizer", Version: "1.0.0", ProviderID: "my-gcp", ResourceType: "agent", Status: "deployed"},
+		{ID: "aws-v2", ServerName: "summarizer", Version: "2.0.0", ProviderID: "my-aws", ResourceType: "agent", Status: "deployed"},
+	}
+	srv, _ := deploymentTestServer(t, deployments, nil)
+	setupClientForServer(t, srv)
+
+	out := &bytes.Buffer{}
+	cmd := declarative.NewGetCmd()
+	cmd.SetOut(out)
+	cmd.SetArgs([]string{"deployment", "summarizer"})
+	require.NoError(t, cmd.Execute())
+
+	// First match by list order is aws-v1; output should include its ID, not the others.
+	assert.Contains(t, out.String(), "aws-v1",
+		"first deployment for the name should be returned")
+	assert.NotContains(t, out.String(), "gcp-v1",
+		"only the first match is surfaced; subsequent matches are filtered out")
+	assert.NotContains(t, out.String(), "aws-v2",
+		"other versions must not be surfaced when get returns first match")
+}
+
+// (3) Get surfaces the registry's not-found sentinel when no deployment matches.
+// This mirrors other kinds (agent / mcp / skill / prompt) — the CLI wraps the
+// sentinel so tooling can still distinguish "not found" from transport failures.
+func TestDeploymentGet_NotFoundError(t *testing.T) {
+	deployments := []models.Deployment{
+		{ID: "other", ServerName: "unrelated", Version: "1.0.0", ProviderID: "my-aws", ResourceType: "agent", Status: "deployed"},
+	}
+	srv, _ := deploymentTestServer(t, deployments, nil)
+	setupClientForServer(t, srv)
+
+	out := &bytes.Buffer{}
+	cmd := declarative.NewGetCmd()
+	cmd.SetOut(out)
+	cmd.SetArgs([]string{"deployment", "does-not-exist"})
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found",
+		"missing deployment should surface a not-found error")
+}
+
+// (4) List mode (no name arg) returns every deployment — exercises the shared
+// ListFunc path and guards against the Get wiring accidentally short-circuiting list.
+func TestDeploymentGet_ListReturnsAll(t *testing.T) {
+	deployments := []models.Deployment{
+		{ID: "aws-v1", ServerName: "summarizer", Version: "1.0.0", ProviderID: "my-aws", ResourceType: "agent", Status: "deployed"},
+		{ID: "gcp-v1", ServerName: "other", Version: "1.0.0", ProviderID: "my-gcp", ResourceType: "agent", Status: "pending"},
+	}
+	srv, _ := deploymentTestServer(t, deployments, nil)
+	setupClientForServer(t, srv)
+
+	out := &bytes.Buffer{}
+	cmd := declarative.NewGetCmd()
+	cmd.SetOut(out)
+	cmd.SetArgs([]string{"deployments"})
+	require.NoError(t, cmd.Execute())
+
+	assert.Contains(t, out.String(), "summarizer")
+	assert.Contains(t, out.String(), "other")
+}

--- a/internal/cli/declarative/provider_get_test.go
+++ b/internal/cli/declarative/provider_get_test.go
@@ -1,0 +1,102 @@
+package declarative_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/agentregistry-dev/agentregistry/internal/cli/declarative"
+	"github.com/agentregistry-dev/agentregistry/pkg/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// providerTestServer builds an httptest.Server that serves:
+//   - GET /v0/providers/{name} → the provider with matching Name (404 otherwise)
+//
+// Only the routes exercised by `arctl get provider NAME [-o yaml]` are handled.
+func providerTestServer(t *testing.T, providers []models.Provider) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v0/providers/", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		name := strings.TrimPrefix(r.URL.Path, "/v0/providers/")
+		for _, p := range providers {
+			if p.Name == name {
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(p)
+				return
+			}
+		}
+		http.Error(w, `{"error":"not found"}`, http.StatusNotFound)
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// (1) `-o yaml` emits the declarative envelope and strips server-managed fields
+// (id, timestamps) so the output round-trips through `arctl apply -f`.
+func TestProviderGet_YAMLOutputRoundTrips(t *testing.T) {
+	providers := []models.Provider{
+		{
+			ID:       "internal-id-123",
+			Name:     "my-kagent",
+			Platform: "kagent",
+			Config: map[string]any{
+				"kagentUrl": "http://kagent-controller.kagent:8083",
+				"namespace": "kagent",
+			},
+			CreatedAt: time.Now(),
+			UpdatedAt: time.Now(),
+		},
+	}
+	srv := providerTestServer(t, providers)
+	setupClientForServer(t, srv)
+
+	out := &bytes.Buffer{}
+	cmd := declarative.NewGetCmd()
+	cmd.SetOut(out)
+	cmd.SetArgs([]string{"provider", "my-kagent", "-o", "yaml"})
+	require.NoError(t, cmd.Execute())
+
+	got := out.String()
+	// Envelope shape.
+	assert.Contains(t, got, "apiVersion: ar.dev/v1alpha1")
+	assert.Contains(t, got, "kind: Provider")
+	assert.Contains(t, got, "name: my-kagent")
+	// Declarative spec fields.
+	assert.Contains(t, got, "platform: kagent")
+	assert.Contains(t, got, "kagentUrl: http://kagent-controller.kagent:8083")
+	assert.Contains(t, got, "namespace: kagent")
+	// Server-managed fields must be stripped.
+	assert.NotContains(t, got, "internal-id-123", "spec must not leak the server-assigned id")
+	assert.NotContains(t, got, "createdAt", "spec must not leak server timestamps")
+	assert.NotContains(t, got, "updatedAt", "spec must not leak server timestamps")
+}
+
+// (2) Table output (default) still works — regression guard for the YAML-only change.
+func TestProviderGet_TableOutput(t *testing.T) {
+	providers := []models.Provider{
+		{ID: "id-1", Name: "my-kagent", Platform: "kagent"},
+	}
+	srv := providerTestServer(t, providers)
+	setupClientForServer(t, srv)
+
+	out := &bytes.Buffer{}
+	cmd := declarative.NewGetCmd()
+	cmd.SetOut(out)
+	cmd.SetArgs([]string{"provider", "my-kagent"})
+	require.NoError(t, cmd.Execute())
+
+	got := out.String()
+	assert.Contains(t, got, "my-kagent")
+	assert.Contains(t, got, "kagent")
+}

--- a/internal/registry/registry_app.go
+++ b/internal/registry/registry_app.go
@@ -302,6 +302,7 @@ func App(ctx context.Context, opts ...types.AppOptions) error {
 		SpecType: reflect.TypeFor[kinds.DeploymentSpec](),
 		Apply:    deploymentApplyFunc(deploymentService),
 		Delete:   deploymentDeleteFunc(deploymentService),
+		Get:      deploymentGetFunc(deploymentService),
 		TableColumns: []kinds.Column{
 			{Header: "NAME"}, {Header: "VERSION"}, {Header: "RESOURCE_TYPE"},
 			{Header: "PROVIDER"}, {Header: "STATUS"},
@@ -552,5 +553,25 @@ func deploymentDeleteFunc(svc deploymentsvc.Registry) kinds.DeleteFunc {
 			}
 		}
 		return errors.Join(errs...)
+	}
+}
+
+// deploymentGetFunc returns the Get function for the deployment kind. Users
+// reference deployments by name but the canonical key is ID; a single name
+// can map to multiple deployments (different versions/providers). This
+// surfaces the first match and leaves disambiguation to `list` / client-side
+// filtering.
+func deploymentGetFunc(svc deploymentsvc.Registry) kinds.GetFunc {
+	return func(ctx context.Context, name, _ string) (any, error) {
+		matches, err := svc.ListDeployments(ctx, &models.DeploymentFilter{ResourceName: &name})
+		if err != nil {
+			return nil, fmt.Errorf("listing deployments: %w", err)
+		}
+		for _, d := range matches {
+			if d != nil && d.ServerName == name {
+				return d, nil
+			}
+		}
+		return nil, database.ErrNotFound
 	}
 }


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don't apply.
-->

# Description

**Motivation:**
This is a follow up from this PR https://github.com/agentregistry-dev/agentregistry/pull/434
Similar as this PR https://github.com/agentregistry-dev/agentregistry/pull/441

 This PR adds the support for `arctl get deployment <name> `
<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

# Change Type

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bump
/kind cleanup
/kind design
/kind deprecation
/kind documentation
/kind feature
/kind fix
/kind flake
/kind install
```
-->
/kind fix
# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
release(declarative): deployement get wiring 
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
