### PR TITLE
agent: add version to AgentMcpServer to allow name+version ref

### DIFF
--- a/internal/registry/kinds/conversions.go
+++ b/internal/registry/kinds/conversions.go
@@ -33,6 +33,7 @@ func ToAgentJSON(md Metadata, spec *AgentSpec) *models.AgentJSON {
 		aj.McpServers = append(aj.McpServers, models.McpServerType{
 			Type:                       s.Type,
 			Name:                       s.Name,
+			Version:                    s.Version,
 			Image:                      s.Image,
 			Build:                      s.Build,
 			Command:                    s.Command,

--- a/internal/registry/kinds/conversions_test.go
+++ b/internal/registry/kinds/conversions_test.go
@@ -158,6 +158,27 @@ func TestToAgentJSON(t *testing.T) {
 	assert.Equal(t, "http://remote", got.Remotes[0].URL)
 }
 
+func TestToAgentJSON_McpServerVersion(t *testing.T) {
+	md := kinds.Metadata{Name: "agent-with-mcp-ver", Version: "1.0.0"}
+	spec := &kinds.AgentSpec{
+		Description: "agent with new-format mcp server",
+		McpServers: []kinds.AgentMcpServer{
+			{
+				Name:    "local/test-mcp",
+				Version: "2.3.0",
+			},
+		},
+	}
+
+	got := kinds.ToAgentJSON(md, spec)
+
+	require.NotNil(t, got)
+	require.Len(t, got.McpServers, 1)
+	assert.Equal(t, "local/test-mcp", got.McpServers[0].Name)
+	assert.Equal(t, "2.3.0", got.McpServers[0].Version)
+	assert.Empty(t, got.McpServers[0].Type, "new-format entry should have no Type")
+}
+
 func TestToAgentJSON_NilRepository(t *testing.T) {
 	md := kinds.Metadata{Name: "agent-no-repo", Version: "0.1.0"}
 	spec := &kinds.AgentSpec{Description: "no repo"}

--- a/internal/registry/kinds/spectypes.go
+++ b/internal/registry/kinds/spectypes.go
@@ -36,8 +36,9 @@ type AgentSpec struct {
 
 // AgentMcpServer mirrors models.McpServerType.
 type AgentMcpServer struct {
-	Type                       string            `yaml:"type" json:"type"`
 	Name                       string            `yaml:"name" json:"name"`
+	Version                    string            `yaml:"version,omitempty" json:"version,omitempty"`
+	Type                       string            `yaml:"type,omitempty" json:"type,omitempty"`
 	Image                      string            `yaml:"image,omitempty" json:"image,omitempty"`
 	Build                      string            `yaml:"build,omitempty" json:"build,omitempty"`
 	Command                    string            `yaml:"command,omitempty" json:"command,omitempty"`


### PR DESCRIPTION
# Description
A recent change regressed the previous behavior that allowed name+version refers in `mcpServers`. This fixes it.

# Change Type

```
/kind bug_fix
```

# Changelog

```release-note
NONE
```
