### PR TITLE
v1alpha1: Add server-managed UID to ObjectMeta

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2050,6 +2050,8 @@ components:
                     type: string
                 namespace:
                     type: string
+                uid:
+                    type: string
                 updatedAt:
                     type: string
                     format: date-time

--- a/pkg/api/v1alpha1/object.go
+++ b/pkg/api/v1alpha1/object.go
@@ -21,8 +21,8 @@ const DefaultNamespace = "default"
 // ObjectMeta is the metadata block common to every resource.
 //
 // Namespace, Name, Version, Labels, and Annotations are user-settable.
-// CreatedAt, UpdatedAt, and DeletionTimestamp are server-managed: the API
-// ignores them on apply and overwrites them on response.
+// UID, CreatedAt, UpdatedAt, and DeletionTimestamp are server-managed:
+// the API ignores them on apply and overwrites them on response.
 //
 // Generation is an internal coordination primitive — it drives
 // reconciler convergence (paired with Status.ObservedGeneration). It's
@@ -36,6 +36,15 @@ const DefaultNamespace = "default"
 // Namespace is an internal detail today — it defaults to "default" on
 // apply and is stripped from responses when it equals "default" so the
 // multi-tenant surface stays hidden until we deliberately enable it.
+//
+// UID is a server-assigned UUID stamped at row creation and never
+// mutated afterwards — same contract as Kubernetes' metadata.uid.
+// (Namespace, Name, Version) is reusable across delete + recreate
+// cycles; UID is not, so it disambiguates "the row I observed earlier"
+// from "a fresh row at the same identity". The apply pipeline strips
+// any caller-supplied value before the store sees it; Postgres assigns
+// the value via a column default, so even direct-SQL inserts get a
+// valid UID.
 //
 // Labels vs Annotations (Kubernetes convention):
 //   - Labels are queryable: short key/value pairs, GIN-indexed, used for
@@ -54,6 +63,7 @@ type ObjectMeta struct {
 	Namespace   string            `json:"namespace,omitempty" yaml:"namespace,omitempty"`
 	Name        string            `json:"name" yaml:"name"`
 	Version     string            `json:"version,omitempty" yaml:"version,omitempty"`
+	UID         string            `json:"uid,omitempty" yaml:"uid,omitempty"`
 	Labels      map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
 	Annotations map[string]string `json:"annotations,omitempty" yaml:"annotations,omitempty"`
 

--- a/pkg/registry/resource/apply.go
+++ b/pkg/registry/resource/apply.go
@@ -243,6 +243,10 @@ func resolveBatchTarget(cfg ApplyConfig, obj v1alpha1.Object, verb string) (*v1a
 	// Default namespace before authorize/applyCore see it. The handler.go
 	// PUT path stamps namespace from the URL; the batch path has only the
 	// YAML body to look at, so default explicitly here.
+	//
+	// metadata.uid is stripped centrally inside applyCore so the single
+	// PUT path benefits from the same sanitization — no need to repeat it
+	// here.
 	if meta.Namespace == "" {
 		meta.Namespace = v1alpha1.DefaultNamespace
 		obj.SetMetadata(*meta)

--- a/pkg/registry/resource/core.go
+++ b/pkg/registry/resource/core.go
@@ -80,6 +80,19 @@ func applyCore(
 	meta := obj.GetMetadata()
 	kind := obj.GetKind()
 
+	// Strip caller-supplied metadata.uid before any downstream stage
+	// observes it. UID is server-managed (Postgres assigns it via the
+	// column default on first insert and preserves it across re-applies),
+	// and Authorize/PostUpsert hooks must not be able to see — let alone
+	// branch on — a forged UID. Centralizing the strip here covers every
+	// applyCore caller: the single-resource PUT handler and the multi-doc
+	// batch endpoint alike. Mirrors Kubernetes' read-only metadata.uid.
+	mutated := false
+	if meta.UID != "" {
+		meta.UID = ""
+		mutated = true
+	}
+
 	// Stamp default metadata.version for kinds that opt out of the
 	// version-required validator (Provider, Deployment) — see
 	// v1alpha1.MetadataVersionDefaulter. Without this, a YAML manifest
@@ -92,9 +105,12 @@ func applyCore(
 		if defaulter, ok := obj.(v1alpha1.MetadataVersionDefaulter); ok {
 			if def := defaulter.DefaultMetadataVersion(); def != "" {
 				meta.Version = def
-				obj.SetMetadata(*meta)
+				mutated = true
 			}
 		}
+	}
+	if mutated {
+		obj.SetMetadata(*meta)
 	}
 
 	if opts.Authorize != nil {

--- a/pkg/registry/v1alpha1store/embeddings.go
+++ b/pkg/registry/v1alpha1store/embeddings.go
@@ -193,7 +193,7 @@ func (s *Store) SemanticList(ctx context.Context, opts SemanticListOpts) ([]sema
 
 	args = append(args, limit)
 	query := fmt.Sprintf(`
-		SELECT namespace, name, version, generation, labels, annotations, spec, status,
+		SELECT namespace, name, version, uid::text, generation, labels, annotations, spec, status,
 		       deletion_timestamp, finalizers, created_at, updated_at,
 		       semantic_embedding <=> $1::vector AS score
 		FROM %s
@@ -223,6 +223,7 @@ func (s *Store) SemanticList(ctx context.Context, opts SemanticListOpts) ([]sema
 func scanSemanticRow(rows pgx.Rows) (*v1alpha1.RawObject, float32, error) {
 	var (
 		namespace, name, version string
+		uid                      string
 		generation               int64
 		labelsJSON               []byte
 		annotationsJSON          []byte
@@ -235,7 +236,7 @@ func scanSemanticRow(rows pgx.Rows) (*v1alpha1.RawObject, float32, error) {
 		score                    float32
 	)
 	if err := rows.Scan(
-		&namespace, &name, &version, &generation,
+		&namespace, &name, &version, &uid, &generation,
 		&labelsJSON, &annotationsJSON, &specJSON, &statusJSON,
 		&deletionTimestamp, &finalizersJSON,
 		&createdAt, &updatedAt,
@@ -245,7 +246,7 @@ func scanSemanticRow(rows pgx.Rows) (*v1alpha1.RawObject, float32, error) {
 	}
 
 	obj, err := decodeRow(
-		namespace, name, version, generation,
+		namespace, name, version, uid, generation,
 		labelsJSON, annotationsJSON, specJSON, statusJSON,
 		deletionTimestamp, finalizersJSON, createdAt, updatedAt,
 	)

--- a/pkg/registry/v1alpha1store/helpers.go
+++ b/pkg/registry/v1alpha1store/helpers.go
@@ -26,13 +26,18 @@ type rowScanner interface {
 //
 // Column order must match:
 //
-//	namespace, name, version, generation, labels, annotations, spec, status,
+//	namespace, name, version, uid, generation, labels, annotations, spec, status,
 //	deletion_timestamp, finalizers, created_at, updated_at
+//
+// `uid` is selected as `uid::text` so it scans into a Go string without
+// requiring a pgtype UUID codec — keeps the column types in this scan
+// path uniformly textual / numeric / timestamptz.
 func scanRow(row rowScanner) (*v1alpha1.RawObject, error) {
 	var (
 		namespace         string
 		name              string
 		version           string
+		uid               string
 		generation        int64
 		labelsJSON        []byte
 		annotationsJSON   []byte
@@ -44,7 +49,7 @@ func scanRow(row rowScanner) (*v1alpha1.RawObject, error) {
 		updatedAt         time.Time
 	)
 	if err := row.Scan(
-		&namespace, &name, &version, &generation,
+		&namespace, &name, &version, &uid, &generation,
 		&labelsJSON, &annotationsJSON, &specJSON, &statusJSON,
 		&deletionTimestamp, &finalizersJSON,
 		&createdAt, &updatedAt,
@@ -56,7 +61,7 @@ func scanRow(row rowScanner) (*v1alpha1.RawObject, error) {
 	}
 
 	return decodeRow(
-		namespace, name, version, generation,
+		namespace, name, version, uid, generation,
 		labelsJSON, annotationsJSON, specJSON, statusJSON,
 		deletionTimestamp, finalizersJSON, createdAt, updatedAt,
 	)
@@ -67,7 +72,7 @@ func scanRow(row rowScanner) (*v1alpha1.RawObject, error) {
 // distance score) can reuse the deserialization without repeating its
 // logic.
 func decodeRow(
-	namespace, name, version string,
+	namespace, name, version, uid string,
 	generation int64,
 	labelsJSON, annotationsJSON, specJSON, statusJSON []byte,
 	deletionTimestamp *time.Time,
@@ -99,6 +104,7 @@ func decodeRow(
 			Namespace:         namespace,
 			Name:              name,
 			Version:           version,
+			UID:               uid,
 			Labels:            labels,
 			Annotations:       annotations,
 			Generation:        generation,

--- a/pkg/registry/v1alpha1store/migrations/001_v1alpha1_schema.sql
+++ b/pkg/registry/v1alpha1store/migrations/001_v1alpha1_schema.sql
@@ -73,6 +73,7 @@ $$ LANGUAGE plpgsql;
 --
 -- Columns:
 --   namespace, name, version      — composite identity (PK)
+--   uid                           — server-assigned UUID, immutable after create
 --   generation                    — server-managed, bumps on spec mutation
 --   labels                        — user-set key/value, GIN-indexed
 --   spec                          — JSONB per pkg/api/v1alpha1 typed Spec
@@ -81,12 +82,20 @@ $$ LANGUAGE plpgsql;
 --   deletion_timestamp            — server-managed soft-delete marker
 --   finalizers                    — reconciler-owned tokens; empty+terminating → GC
 --   created_at, updated_at        — timestamps (trigger-maintained)
+--
+-- The `uid` column carries a DEFAULT of gen_random_uuid() so it is the sole
+-- UID issuer: the Go store omits it from the INSERT column list on Upsert
+-- (the default fires on create) and keeps it out of the ON CONFLICT DO UPDATE
+-- SET list (so it is preserved across re-applies — Kubernetes-style read-only
+-- metadata.uid). Direct-SQL inserts (the providers seed below, manual psql)
+-- get a valid UID without code changes.
 -- -----------------------------------------------------------------------------
 
 CREATE TABLE IF NOT EXISTS v1alpha1.agents (
     namespace          VARCHAR(255) NOT NULL,
     name               VARCHAR(255) NOT NULL,
     version            VARCHAR(255) NOT NULL,
+    uid                UUID         NOT NULL DEFAULT gen_random_uuid(),
     generation         BIGINT       NOT NULL DEFAULT 1,
     labels             JSONB        NOT NULL DEFAULT '{}'::jsonb,
     annotations        JSONB        NOT NULL DEFAULT '{}'::jsonb,
@@ -112,6 +121,7 @@ CREATE TABLE IF NOT EXISTS v1alpha1.mcp_servers (
     namespace          VARCHAR(255) NOT NULL,
     name               VARCHAR(255) NOT NULL,
     version            VARCHAR(255) NOT NULL,
+    uid                UUID         NOT NULL DEFAULT gen_random_uuid(),
     generation         BIGINT       NOT NULL DEFAULT 1,
     labels             JSONB        NOT NULL DEFAULT '{}'::jsonb,
     annotations        JSONB        NOT NULL DEFAULT '{}'::jsonb,
@@ -136,6 +146,7 @@ CREATE TABLE IF NOT EXISTS v1alpha1.skills (
     namespace          VARCHAR(255) NOT NULL,
     name               VARCHAR(255) NOT NULL,
     version            VARCHAR(255) NOT NULL,
+    uid                UUID         NOT NULL DEFAULT gen_random_uuid(),
     generation         BIGINT       NOT NULL DEFAULT 1,
     labels             JSONB        NOT NULL DEFAULT '{}'::jsonb,
     annotations        JSONB        NOT NULL DEFAULT '{}'::jsonb,
@@ -160,6 +171,7 @@ CREATE TABLE IF NOT EXISTS v1alpha1.prompts (
     namespace          VARCHAR(255) NOT NULL,
     name               VARCHAR(255) NOT NULL,
     version            VARCHAR(255) NOT NULL,
+    uid                UUID         NOT NULL DEFAULT gen_random_uuid(),
     generation         BIGINT       NOT NULL DEFAULT 1,
     labels             JSONB        NOT NULL DEFAULT '{}'::jsonb,
     annotations        JSONB        NOT NULL DEFAULT '{}'::jsonb,
@@ -184,6 +196,7 @@ CREATE TABLE IF NOT EXISTS v1alpha1.providers (
     namespace          VARCHAR(255) NOT NULL,
     name               VARCHAR(255) NOT NULL,
     version            VARCHAR(255) NOT NULL,
+    uid                UUID         NOT NULL DEFAULT gen_random_uuid(),
     generation         BIGINT       NOT NULL DEFAULT 1,
     labels             JSONB        NOT NULL DEFAULT '{}'::jsonb,
     annotations        JSONB        NOT NULL DEFAULT '{}'::jsonb,
@@ -208,6 +221,7 @@ CREATE TABLE IF NOT EXISTS v1alpha1.deployments (
     namespace          VARCHAR(255) NOT NULL,
     name               VARCHAR(255) NOT NULL,
     version            VARCHAR(255) NOT NULL,
+    uid                UUID         NOT NULL DEFAULT gen_random_uuid(),
     generation         BIGINT       NOT NULL DEFAULT 1,
     labels             JSONB        NOT NULL DEFAULT '{}'::jsonb,
     annotations        JSONB        NOT NULL DEFAULT '{}'::jsonb,

--- a/pkg/registry/v1alpha1store/migrations/005_remote_resources.sql
+++ b/pkg/registry/v1alpha1store/migrations/005_remote_resources.sql
@@ -17,6 +17,7 @@ CREATE TABLE IF NOT EXISTS v1alpha1.remote_mcp_servers (
     namespace          VARCHAR(255) NOT NULL,
     name               VARCHAR(255) NOT NULL,
     version            VARCHAR(255) NOT NULL,
+    uid                UUID         NOT NULL DEFAULT gen_random_uuid(),
     generation         BIGINT       NOT NULL DEFAULT 1,
     labels             JSONB        NOT NULL DEFAULT '{}'::jsonb,
     annotations        JSONB        NOT NULL DEFAULT '{}'::jsonb,

--- a/pkg/registry/v1alpha1store/store.go
+++ b/pkg/registry/v1alpha1store/store.go
@@ -54,11 +54,16 @@ func NewStore(pool *pgxpool.Pool, table string) *Store {
 
 // UpsertResult describes what happened on Upsert. SpecChanged is true when
 // the incoming spec bytes differ from the existing row's spec (or when the
-// row didn't exist). Generation reflects the final stored value.
+// row didn't exist). Generation reflects the final stored value. UID is the
+// row's metadata.uid as observed after the write — Postgres assigns it via
+// a column default on first insert and preserves it across re-applies, so
+// callers can treat this as the authoritative server-side identity even on
+// the no-op update path.
 type UpsertResult struct {
 	Created     bool
 	SpecChanged bool
 	Generation  int64
+	UID         string
 }
 
 // ErrInvalidCursor reports that a list pagination cursor could not be parsed.
@@ -258,7 +263,14 @@ func (s *Store) Upsert(ctx context.Context, namespace, name, version string, spe
 			annotationsJSON = a
 		}
 
-		_, err = tx.Exec(ctx,
+		// `uid` is intentionally absent from both the INSERT column list
+		// and the ON CONFLICT DO UPDATE SET list: the column default
+		// (gen_random_uuid()) fires on create, and conflict-update
+		// preserves the existing value — Kubernetes-style read-only
+		// metadata.uid. RETURNING uid::text feeds back whichever path
+		// won so UpsertResult always carries the authoritative value.
+		var uid string
+		err = tx.QueryRow(ctx,
 			fmt.Sprintf(`
 				INSERT INTO %s (namespace, name, version, generation, labels, annotations, spec, finalizers)
 				VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
@@ -268,11 +280,13 @@ func (s *Store) Upsert(ctx context.Context, namespace, name, version string, spe
 				    annotations = EXCLUDED.annotations,
 				    spec        = EXCLUDED.spec,
 				    finalizers  = EXCLUDED.finalizers
+				RETURNING uid::text
 			`, s.table),
-			namespace, name, version, newGen, labelsJSON, annotationsJSON, []byte(specJSON), finalizersJSON)
+			namespace, name, version, newGen, labelsJSON, annotationsJSON, []byte(specJSON), finalizersJSON).Scan(&uid)
 		if err != nil {
 			return fmt.Errorf("upsert row: %w", err)
 		}
+		res.UID = uid
 
 		if err := s.recomputeLatest(ctx, tx, namespace, name); err != nil {
 			return fmt.Errorf("recompute latest: %w", err)
@@ -463,7 +477,7 @@ func (s *Store) PatchAnnotations(ctx context.Context, namespace, name, version s
 func (s *Store) Get(ctx context.Context, namespace, name, version string) (*v1alpha1.RawObject, error) {
 	row := s.pool.QueryRow(ctx,
 		fmt.Sprintf(`
-			SELECT namespace, name, version, generation, labels, annotations, spec, status,
+			SELECT namespace, name, version, uid::text, generation, labels, annotations, spec, status,
 			       deletion_timestamp, finalizers, created_at, updated_at
 			FROM %s
 			WHERE namespace=$1 AND name=$2 AND version=$3`, s.table),
@@ -477,7 +491,7 @@ func (s *Store) Get(ctx context.Context, namespace, name, version string) (*v1al
 func (s *Store) GetLatest(ctx context.Context, namespace, name string) (*v1alpha1.RawObject, error) {
 	row := s.pool.QueryRow(ctx,
 		fmt.Sprintf(`
-			SELECT namespace, name, version, generation, labels, annotations, spec, status,
+			SELECT namespace, name, version, uid::text, generation, labels, annotations, spec, status,
 			       deletion_timestamp, finalizers, created_at, updated_at
 			FROM %s
 			WHERE namespace=$1 AND name=$2 AND is_latest_version`, s.table),
@@ -650,7 +664,7 @@ func (s *Store) List(ctx context.Context, opts ListOpts) ([]*v1alpha1.RawObject,
 	}
 
 	query := fmt.Sprintf(`
-		SELECT namespace, name, version, generation, labels, annotations, spec, status,
+		SELECT namespace, name, version, uid::text, generation, labels, annotations, spec, status,
 		       deletion_timestamp, finalizers, created_at, updated_at
 		FROM %s`, s.table)
 	if len(where) > 0 {
@@ -823,7 +837,7 @@ type FindReferrersOpts struct {
 func (s *Store) FindReferrers(ctx context.Context, pathJSON json.RawMessage, opts FindReferrersOpts) ([]*v1alpha1.RawObject, error) {
 	args := []any{[]byte(pathJSON)}
 	query := fmt.Sprintf(`
-		SELECT namespace, name, version, generation, labels, annotations, spec, status,
+		SELECT namespace, name, version, uid::text, generation, labels, annotations, spec, status,
 		       deletion_timestamp, finalizers, created_at, updated_at
 		FROM %s
 		WHERE spec @> $1::jsonb`, s.table)

--- a/pkg/registry/v1alpha1store/store_test.go
+++ b/pkg/registry/v1alpha1store/store_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"regexp"
 	"testing"
 	"time"
 
@@ -14,6 +15,11 @@ import (
 	"github.com/agentregistry-dev/agentregistry/pkg/api/v1alpha1"
 	pkgdb "github.com/agentregistry-dev/agentregistry/pkg/registry/database"
 )
+
+// uuidPattern matches the canonical 8-4-4-4-12 textual UUID Postgres
+// emits for `uid::text`. Sufficient for assertion: the column type is
+// already UUID, so we only need to confirm the wire shape.
+var uuidPattern = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
 
 const testTable = "v1alpha1.agents"
 const testNS = "default"
@@ -712,4 +718,81 @@ func TestStore_LatestVersionTieBreakDeterministic(t *testing.T) {
 	}
 	// `version DESC` tie-break → snapshot-b comes out on top.
 	require.Equal(t, "snapshot-b", winners[0], "version DESC tie-break should prefer 'snapshot-b'")
+}
+
+// TestStore_UpsertAssignsUID pins the create-side of the metadata.uid
+// contract: Postgres' column default fires on first insert, the RETURNING
+// clause surfaces the assigned value to the caller, and a follow-up Get
+// reads back the same UID.
+func TestStore_UpsertAssignsUID(t *testing.T) {
+	pool := NewTestPool(t)
+	store := NewStore(pool, testTable)
+	ctx := context.Background()
+
+	res, err := store.Upsert(ctx, testNS, "uid-create", "v1", mustSpec(t, v1alpha1.AgentSpec{Title: "first"}), UpsertOpts{})
+	require.NoError(t, err)
+	require.True(t, res.Created)
+	require.Regexp(t, uuidPattern, res.UID, "UpsertResult.UID must be a canonical UUID")
+
+	obj, err := store.Get(ctx, testNS, "uid-create", "v1")
+	require.NoError(t, err)
+	require.Equal(t, res.UID, obj.Metadata.UID, "Get must surface the same UID Upsert returned")
+}
+
+// TestStore_UpsertPreservesUIDAcrossUpdates pins the immutability half:
+// the UID column lives outside the ON CONFLICT SET list, so neither a
+// no-op re-apply (same spec) nor a spec-changing re-apply may rotate it.
+// This is the Kubernetes-style read-only metadata.uid behavior — once
+// observed by a controller, the UID stays stable for the row's lifetime.
+func TestStore_UpsertPreservesUIDAcrossUpdates(t *testing.T) {
+	pool := NewTestPool(t)
+	store := NewStore(pool, testTable)
+	ctx := context.Background()
+
+	first, err := store.Upsert(ctx, testNS, "uid-stable", "v1", mustSpec(t, v1alpha1.AgentSpec{Title: "first"}), UpsertOpts{})
+	require.NoError(t, err)
+	require.NotEmpty(t, first.UID)
+
+	// No-op re-apply — generation stays at 1, UID must not change.
+	noop, err := store.Upsert(ctx, testNS, "uid-stable", "v1", mustSpec(t, v1alpha1.AgentSpec{Title: "first"}), UpsertOpts{})
+	require.NoError(t, err)
+	require.False(t, noop.SpecChanged)
+	require.Equal(t, first.UID, noop.UID, "no-op upsert must preserve UID")
+
+	// Spec-changing re-apply — generation bumps, UID still must not change.
+	bumped, err := store.Upsert(ctx, testNS, "uid-stable", "v1", mustSpec(t, v1alpha1.AgentSpec{Title: "second"}), UpsertOpts{})
+	require.NoError(t, err)
+	require.True(t, bumped.SpecChanged)
+	require.EqualValues(t, 2, bumped.Generation)
+	require.Equal(t, first.UID, bumped.UID, "spec-changing upsert must preserve UID")
+
+	obj, err := store.Get(ctx, testNS, "uid-stable", "v1")
+	require.NoError(t, err)
+	require.Equal(t, first.UID, obj.Metadata.UID, "Get must keep returning the original UID")
+}
+
+// TestStore_UpsertGeneratesFreshUIDAfterRecreate is the whole reason UID
+// exists: (namespace, name, version) is reusable across delete +
+// recreate, so without UID, a controller that observed the original row
+// can't tell when it has been replaced. The recreated row must carry a
+// new UID so observers can detect the boundary.
+func TestStore_UpsertGeneratesFreshUIDAfterRecreate(t *testing.T) {
+	pool := NewTestPool(t)
+	store := NewStore(pool, testTable)
+	ctx := context.Background()
+
+	first, err := store.Upsert(ctx, testNS, "uid-recreate", "v1", mustSpec(t, v1alpha1.AgentSpec{Title: "v1-first"}), UpsertOpts{})
+	require.NoError(t, err)
+	require.NotEmpty(t, first.UID)
+
+	// Finalizer-free hard-delete (matches the fast path Delete now takes
+	// for kinds without finalizers — see TestStore_DeleteFinalizerFreeHardDeletes).
+	require.NoError(t, store.Delete(ctx, testNS, "uid-recreate", "v1"))
+
+	second, err := store.Upsert(ctx, testNS, "uid-recreate", "v1", mustSpec(t, v1alpha1.AgentSpec{Title: "v1-second"}), UpsertOpts{})
+	require.NoError(t, err)
+	require.True(t, second.Created, "post-delete upsert is a fresh create")
+	require.NotEmpty(t, second.UID)
+	require.NotEqual(t, first.UID, second.UID,
+		"recreated row must carry a new UID so observers can distinguish it from the deleted predecessor")
 }

--- a/ui/lib/api/types.gen.ts
+++ b/ui/lib/api/types.gen.ts
@@ -253,6 +253,7 @@ export type ObjectMeta = {
     };
     name: string;
     namespace?: string;
+    uid?: string;
     updatedAt?: string;
     version?: string;
 };


### PR DESCRIPTION
# Description

Adds an immutable UUID `metadata.uid` to every v1alpha1 resource, mirroring Kubernetes' `metadata.uid` so clients can disambiguate a row from a re-created row at the same (namespace, name, version).

- `pkg/api/v1alpha1/object.go`: new `ObjectMeta.UID string` with `uid,omitempty` JSON/YAML tags; documented as server-managed and read-only.
- `pkg/registry/v1alpha1store/migrations/001_v1alpha1_schema.sql`, `005_remote_resources.sql`: new `uid UUID NOT NULL DEFAULT gen_random_uuid()` column on every per-kind table. Postgres is the sole UID issuer; the existing migration files are edited rather than bumped because the schema is pre-release.
- `pkg/registry/v1alpha1store/store.go`: `Upsert` keeps `uid` out of both the INSERT column list and the `ON CONFLICT DO UPDATE` SET list (default fires on create, value preserved on update) and reads the authoritative value back via `RETURNING uid::text`. `UpsertResult` gains a `UID` field. All read SELECTs (Get/GetLatest/List/FindReferrers/SemanticList) now select `uid::text`.
- `pkg/registry/v1alpha1store/helpers.go`, `pkg/registry/v1alpha1store/embeddings.go`: `scanRow` / `decodeRow` / `scanSemanticRow` propagate the new column into `RawObject.Metadata.UID`.
- `pkg/registry/resource/apply.go`: `resolveBatchTarget` strips any caller-supplied `metadata.uid` so YAML cannot forge it; the store's create path remains the only issuer.

# Change Type

/kind cleanup

# Changelog

```release-note
Added a server-managed `metadata.uid` (UUID) to every v1alpha1 resource. The field is assigned by Postgres on creation, immutable across re-applies, and stripped from caller input.
```

# Additional Notes

Existing v1alpha1 databases will break until the new column is present (Get/List/Upsert all reference `uid`). Pre-release recovery: drop the v1alpha1 schema and clear schema_migrations rows 201-299, then restart so migrations rerun.

Run the following commands against the DB to add the new UID column:
```
  ALTER TABLE v1alpha1.agents              ADD COLUMN uid UUID NOT NULL DEFAULT gen_random_uuid();
  ALTER TABLE v1alpha1.mcp_servers         ADD COLUMN uid UUID NOT NULL DEFAULT gen_random_uuid();
  ALTER TABLE v1alpha1.skills              ADD COLUMN uid UUID NOT NULL DEFAULT gen_random_uuid();
  ALTER TABLE v1alpha1.prompts             ADD COLUMN uid UUID NOT NULL DEFAULT gen_random_uuid();
  ALTER TABLE v1alpha1.providers           ADD COLUMN uid UUID NOT NULL DEFAULT gen_random_uuid();
  ALTER TABLE v1alpha1.deployments         ADD COLUMN uid UUID NOT NULL DEFAULT gen_random_uuid();
  ALTER TABLE v1alpha1.remote_mcp_servers  ADD COLUMN uid UUID NOT NULL DEFAULT gen_random_uuid();
```