### PR TITLE
relax URL validation to allow http

### DIFF
--- a/pkg/api/v1alpha1/remotemcpserver_test.go
+++ b/pkg/api/v1alpha1/remotemcpserver_test.go
@@ -75,17 +75,6 @@ func TestRemoteMCPServer_Validate(t *testing.T) {
 			wantSub: "spec.remote.url",
 		},
 		{
-			name: "non-https rejected",
-			obj: RemoteMCPServer{
-				Metadata: ObjectMeta{Namespace: "default", Name: "weather", Version: "1"},
-				Spec: RemoteMCPServerSpec{
-					Remote: MCPTransport{Type: "streamable-http", URL: "http://example.test/mcp"},
-				},
-			},
-			wantErr: true,
-			wantSub: "spec.remote.url",
-		},
-		{
 			name: "empty remote",
 			obj: RemoteMCPServer{
 				Metadata: ObjectMeta{Namespace: "default", Name: "weather", Version: "1"},

--- a/pkg/api/v1alpha1/validation.go
+++ b/pkg/api/v1alpha1/validation.go
@@ -200,9 +200,6 @@ func validateWebsiteURL(u string) error {
 	if err != nil {
 		return fmt.Errorf("%w: %v", ErrInvalidURL, err)
 	}
-	if parsed.Scheme != "https" {
-		return fmt.Errorf("%w: scheme must be https, got %q", ErrInvalidURL, parsed.Scheme)
-	}
 	if parsed.Host == "" {
 		return fmt.Errorf("%w: host is empty", ErrInvalidURL)
 	}
@@ -220,7 +217,7 @@ func validateTitle(title string) error {
 	return nil
 }
 
-// validateRepository: optional; when set, URL must parse as https.
+// validateRepository validates the Repository object
 func validateRepository(r *Repository) FieldErrors {
 	var errs FieldErrors
 	if r == nil {


### PR DESCRIPTION
# Description
Requiring `https` for MCP servers limits
testing local MCP servers.

# Change Type

```
/kind cleanup
```

# Changelog

```release-note
NONE
```