### PR TITLE
resource: allow always listing terminating resources

### DIFF
--- a/pkg/registry/resource/handler.go
+++ b/pkg/registry/resource/handler.go
@@ -141,6 +141,17 @@ type Config struct {
 	// the placeholder + parameterization rules there before wiring a
 	// new caller.
 	ListFilter func(ctx context.Context, in AuthorizeInput) (extraWhere string, extraArgs []any, err error)
+
+	// IncludeTerminatingByDefault, when true, makes the list handler
+	// surface rows with deletion_timestamp set even if the caller
+	// hasn't passed ?includeTerminating=true. Used by kinds whose
+	// teardown is operator-observable so `arctl get` can
+	// show phase=Terminating during in-flight cleanup; the row drops
+	// from the list once the reconciler hard-deletes it. The user's
+	// ?includeTerminating query value is OR-ed with this flag, so the
+	// caller can still force inclusion but never exclusion when the
+	// kind has opted in.
+	IncludeTerminatingByDefault bool
 }
 
 // AuthorizeInput is the context passed to Config.Authorize on every handler
@@ -530,7 +541,7 @@ func runList[T v1alpha1.Object](
 		Limit:              p.Limit,
 		Cursor:             p.Cursor,
 		LatestOnly:         p.LatestOnly,
-		IncludeTerminating: p.IncludeTerminating,
+		IncludeTerminating: p.IncludeTerminating || cfg.IncludeTerminatingByDefault,
 	}
 	if p.Labels != "" {
 		selector, err := parseLabelSelector(p.Labels)

--- a/pkg/registry/resource/handler_test.go
+++ b/pkg/registry/resource/handler_test.go
@@ -538,3 +538,61 @@ func TestResourceRegister_PostUpsertFailureLeavesPersistedRow(t *testing.T) {
 		"once the platform-adapter clears, identical-spec re-apply succeeds without a spec bump")
 	require.Equal(t, 1, hookCalls)
 }
+
+// TestResourceRegister_IncludeTerminatingByDefault pins the opt-in
+// behavior: a kind registered with IncludeTerminatingByDefault=true
+// surfaces terminating rows on plain LIST (no ?includeTerminating=true
+// needed), and the OR-ing with ?latestOnly=true still returns terminating
+// rows even though recomputeLatest has cleared is_latest_version on them.
+func TestResourceRegister_IncludeTerminatingByDefault(t *testing.T) {
+	pool := v1alpha1store.NewTestPool(t)
+	store := v1alpha1store.NewStore(pool, "v1alpha1.agents")
+
+	_, api := humatest.New(t)
+	resource.Register[*v1alpha1.Agent](api, resource.Config{
+		Kind:                        v1alpha1.KindAgent,
+		BasePrefix:                  "/v0",
+		Store:                       store,
+		IncludeTerminatingByDefault: true,
+	}, func() *v1alpha1.Agent { return &v1alpha1.Agent{} })
+
+	// Seed a row, attach a finalizer, then soft-delete so the row goes
+	// terminating (deletion_timestamp set) and recomputeLatest clears
+	// its is_latest_version flag.
+	body := v1alpha1.Agent{
+		TypeMeta: v1alpha1.TypeMeta{APIVersion: v1alpha1.GroupVersion, Kind: v1alpha1.KindAgent},
+		Metadata: v1alpha1.ObjectMeta{Namespace: "default", Name: "draining", Version: "v1"},
+		Spec:     v1alpha1.AgentSpec{Title: "Draining"},
+	}
+	resp := api.Put("/v0/agents/draining/v1", body)
+	require.Equal(t, http.StatusOK, resp.Code, resp.Body.String())
+
+	require.NoError(t, store.PatchFinalizers(t.Context(), "default", "draining", "v1",
+		func([]string) []string { return []string{"finalizer.example.com"} }))
+	require.NoError(t, store.Delete(t.Context(), "default", "draining", "v1"))
+
+	var list struct {
+		Items      []v1alpha1.Agent `json:"items"`
+		NextCursor string           `json:"nextCursor,omitempty"`
+	}
+
+	// Plain LIST with no ?includeTerminating still returns the terminating
+	// row because the kind opted in via IncludeTerminatingByDefault.
+	resp = api.Get("/v0/agents")
+	require.Equal(t, http.StatusOK, resp.Code, resp.Body.String())
+	require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &list))
+	require.Len(t, list.Items, 1)
+	require.Equal(t, "draining", list.Items[0].Metadata.Name)
+	require.NotNil(t, list.Items[0].Metadata.DeletionTimestamp,
+		"opt-in default must surface the deletionTimestamp so operators see in-flight teardown")
+
+	// LatestOnly OR-ed with the default-on flag: store widens the
+	// predicate to "(is_latest_version OR deletion_timestamp IS NOT NULL)"
+	// so the terminating row still appears even though its
+	// is_latest_version was cleared by recomputeLatest.
+	resp = api.Get("/v0/agents?latestOnly=true")
+	require.Equal(t, http.StatusOK, resp.Code, resp.Body.String())
+	require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &list))
+	require.Len(t, list.Items, 1)
+	require.Equal(t, "draining", list.Items[0].Metadata.Name)
+}

--- a/pkg/registry/v1alpha1store/store.go
+++ b/pkg/registry/v1alpha1store/store.go
@@ -100,7 +100,11 @@ type ListOpts struct {
 	// Cursor is an opaque pagination token. Empty starts from the beginning.
 	Cursor string
 	// LatestOnly restricts to rows where is_latest_version=true (one per
-	// (namespace, name)).
+	// (namespace, name)). When combined with IncludeTerminating=true, the
+	// predicate widens to "latest live row OR any terminating row" because
+	// recomputeLatest clears is_latest_version on terminating rows; in that
+	// mode the one-per-(namespace, name) guarantee no longer holds — multiple
+	// concurrently-terminating versions of the same name can all surface.
 	LatestOnly bool
 	// IncludeTerminating includes rows with deletion_timestamp set. Default
 	// false — callers asking for "alive" rows shouldn't see terminating ones.
@@ -605,7 +609,10 @@ func (s *Store) PurgeFinalized(ctx context.Context) (int64, error) {
 // List returns rows filtered by opts, ordered by updated_at DESC with
 // stable identity tie-breakers. A pagination cursor is returned when
 // more rows are available; pass it back via ListOpts.Cursor to continue.
-// Terminating rows are excluded unless IncludeTerminating is true.
+// Terminating rows are excluded unless IncludeTerminating is true. When
+// LatestOnly and IncludeTerminating are both true, results contain the
+// live latest row plus any terminating rows for each (namespace, name)
+// — see ListOpts.LatestOnly for the rationale.
 func (s *Store) List(ctx context.Context, opts ListOpts) ([]*v1alpha1.RawObject, string, error) {
 	limit := opts.Limit
 	if limit <= 0 {
@@ -620,7 +627,17 @@ func (s *Store) List(ctx context.Context, opts ListOpts) ([]*v1alpha1.RawObject,
 		where = append(where, fmt.Sprintf("namespace = $%d", len(args)))
 	}
 	if opts.LatestOnly {
-		where = append(where, "is_latest_version")
+		if opts.IncludeTerminating {
+			// recomputeLatest clears is_latest_version on terminating
+			// rows, so a strict "is_latest_version" filter would hide
+			// them even with IncludeTerminating=true. Widen the predicate
+			// to "the live latest row OR any terminating row" so kinds
+			// whose teardown is operator-observable can
+			// surface in-flight teardown alongside healthy rows.
+			where = append(where, "(is_latest_version OR deletion_timestamp IS NOT NULL)")
+		} else {
+			where = append(where, "is_latest_version")
+		}
 	}
 	if !opts.IncludeTerminating {
 		where = append(where, "deletion_timestamp IS NULL")

--- a/pkg/registry/v1alpha1store/store_test.go
+++ b/pkg/registry/v1alpha1store/store_test.go
@@ -383,6 +383,36 @@ func TestStore_List(t *testing.T) {
 	require.Len(t, withTerm, 3)
 }
 
+func TestStore_ListLatestOnlyIncludeTerminating(t *testing.T) {
+	pool := NewTestPool(t)
+	store := NewStore(pool, testTable)
+	ctx := context.Background()
+
+	_, err := store.Upsert(ctx, testNS, "foo", "v1.0.0", mustSpec(t, v1alpha1.AgentSpec{Title: "v1"}), UpsertOpts{})
+	require.NoError(t, err)
+	_, err = store.Upsert(ctx, testNS, "foo", "v2.0.0", mustSpec(t, v1alpha1.AgentSpec{Title: "v2"}), UpsertOpts{})
+	require.NoError(t, err)
+
+	// Soft-delete the older version via the finalizer path so it goes
+	// terminating and recomputeLatest clears is_latest_version on it.
+	require.NoError(t, store.PatchFinalizers(ctx, testNS, "foo", "v1.0.0",
+		func([]string) []string { return []string{"finalizer.example.com"} }))
+	require.NoError(t, store.Delete(ctx, testNS, "foo", "v1.0.0"))
+
+	// LatestOnly without IncludeTerminating: only the live latest (v2).
+	live, _, err := store.List(ctx, ListOpts{LatestOnly: true})
+	require.NoError(t, err)
+	require.Len(t, live, 1)
+	require.Equal(t, "v2.0.0", live[0].Metadata.Version)
+
+	// LatestOnly + IncludeTerminating: live latest plus the terminating row.
+	combined, _, err := store.List(ctx, ListOpts{LatestOnly: true, IncludeTerminating: true})
+	require.NoError(t, err)
+	require.Len(t, combined, 2)
+	versions := []string{combined[0].Metadata.Version, combined[1].Metadata.Version}
+	require.ElementsMatch(t, []string{"v1.0.0", "v2.0.0"}, versions)
+}
+
 func TestStore_ListExtraWhereRebasesPlaceholders(t *testing.T) {
 	pool := NewTestPool(t)
 	store := NewStore(pool, testTable)


### PR DESCRIPTION
# Description

Allows always listing terminating resources that need to be operator visible.

# Change Type

```
/kind cleanup
```

# Changelog

```release-note
NONE
```