### PR TITLE
resource: support seeding initial finalizers on Upsert

### DIFF
--- a/internal/registry/api/handlers/v0/crud/crud.go
+++ b/internal/registry/api/handlers/v0/crud/crud.go
@@ -46,6 +46,11 @@ type PerKindHooks struct {
 	// PostDeletes run after a successful DELETE; see
 	// resource.Config.PostDelete. Mirrors PostUpserts above.
 	PostDeletes map[string]func(ctx context.Context, obj v1alpha1.Object) error
+	// InitialFinalizers seed finalizers atomically with row creation;
+	// see resource.Config.InitialFinalizers. Used by kinds whose
+	// teardown is owned by a reconciler driving external
+	// infrastructure.
+	InitialFinalizers map[string]func(obj v1alpha1.Object) []string
 }
 
 // Register wires the namespace-scoped + cross-namespace list endpoints
@@ -83,6 +88,7 @@ func Register(
 			ListFilter:        perKind.ListFilters[kind],
 			PostUpsert:        perKind.PostUpserts[kind],
 			PostDelete:        perKind.PostDeletes[kind],
+			InitialFinalizers: perKind.InitialFinalizers[kind],
 		}, true
 	}
 

--- a/internal/registry/api/router/v0.go
+++ b/internal/registry/api/router/v0.go
@@ -209,5 +209,6 @@ func registerKindRoutes(api huma.API, basePrefix string, stores Stores, coord *d
 		Authorizers:       perKind.Authorizers,
 		PostUpserts:       perKind.PostUpserts,
 		PostDeletes:       perKind.PostDeletes,
+		InitialFinalizers: perKind.InitialFinalizers,
 	})
 }

--- a/internal/registry/registry_app.go
+++ b/internal/registry/registry_app.go
@@ -296,6 +296,12 @@ func crudPerKindHooks(options types.AppOptions) crud.PerKindHooks {
 			hooks.PostDeletes[kind] = fn
 		}
 	}
+	if len(options.InitialFinalizers) > 0 {
+		hooks.InitialFinalizers = make(map[string]func(obj v1alpha1.Object) []string, len(options.InitialFinalizers))
+		for kind, fn := range options.InitialFinalizers {
+			hooks.InitialFinalizers[kind] = fn
+		}
+	}
 	// ProviderPlatforms map dispatches the KindProvider PostUpsert /
 	// PostDelete by Spec.Platform → adapter. A Provider whose platform
 	// has no registered adapter is a no-op (matches the OSS default

--- a/pkg/registry/resource/apply.go
+++ b/pkg/registry/resource/apply.go
@@ -58,6 +58,15 @@ type ApplyConfig struct {
 	// soft-deletes the row but never tears down the platform adapter
 	// state.
 	PostDeletes map[string]func(ctx context.Context, obj v1alpha1.Object) error
+
+	// InitialFinalizers mirrors resource.Config.InitialFinalizers per
+	// kind. Without it, /v0/apply on a kind whose teardown is
+	// reconciler-owned creates rows with finalizers=[] and a concurrent
+	// DELETE between Upsert commit and any post-upsert finalizer write
+	// hits Store.Delete's "finalizers empty → hard-delete fast path",
+	// orphaning whatever the reconciler was going to clean up. Missing
+	// keys leave the row's finalizers empty (today's behavior).
+	InitialFinalizers map[string]func(obj v1alpha1.Object) []string
 }
 
 // applyInput receives a raw multi-doc YAML stream. RawBody keeps bytes
@@ -165,6 +174,7 @@ func applyOne(ctx context.Context, cfg ApplyConfig, obj v1alpha1.Object, dryRun 
 		Resolver:          cfg.Resolver,
 		RegistryValidator: cfg.RegistryValidator,
 		PostUpsert:        cfg.PostUpserts[obj.GetKind()],
+		InitialFinalizers: cfg.InitialFinalizers[obj.GetKind()],
 	}, dryRun)
 	if ae != nil {
 		return failResult(res, ae)

--- a/pkg/registry/resource/core.go
+++ b/pkg/registry/resource/core.go
@@ -19,6 +19,21 @@ type applyOpts struct {
 	Resolver          v1alpha1.ResolverFunc
 	RegistryValidator v1alpha1.RegistryValidatorFunc
 	PostUpsert        func(ctx context.Context, obj v1alpha1.Object) error
+	// InitialFinalizers, when non-nil, is called on every apply to
+	// compute the finalizer slice handed to Upsert. The store uses the
+	// result only on create — updates preserve existing finalizers — so
+	// callers should keep the implementation cheap and side-effect-free.
+	// Computing eagerly here (rather than deferring to a thunk inside
+	// Upsert) keeps the apply pipeline straight-line; the alternative
+	// would force the create-vs-update detection out of the FOR UPDATE
+	// transaction.
+	//
+	// Used by kinds whose teardown is owned by a reconciler — without
+	// atomic seeding, a concurrent DELETE arriving between Upsert
+	// commit and a subsequent PatchFinalizers call hits Store.Delete's
+	// "finalizers empty → hard-delete fast path" and orphans whatever
+	// the reconciler was going to clean up.
+	InitialFinalizers func(obj v1alpha1.Object) []string
 }
 
 // upsertResult is the outcome of a successful applyCore call.
@@ -145,6 +160,9 @@ func applyCore(
 	upsertOpts := v1alpha1store.UpsertOpts{Labels: meta.Labels}
 	if meta.Annotations != nil {
 		upsertOpts.Annotations = meta.Annotations
+	}
+	if opts.InitialFinalizers != nil {
+		upsertOpts.InitialFinalizers = opts.InitialFinalizers(obj)
 	}
 	up, err := store.Upsert(ctx, meta.Namespace, meta.Name, meta.Version, specJSON, upsertOpts)
 	if err != nil {

--- a/pkg/registry/resource/handler.go
+++ b/pkg/registry/resource/handler.go
@@ -152,6 +152,28 @@ type Config struct {
 	// caller can still force inclusion but never exclusion when the
 	// kind has opted in.
 	IncludeTerminatingByDefault bool
+
+	// InitialFinalizers, when non-nil, is invoked on every apply (PUT
+	// + /v0/apply batch) to compute the finalizer set passed to Upsert.
+	// Returning nil/empty leaves the row with finalizers=[] — today's
+	// behavior. Returning a non-empty slice makes Store.Delete take the
+	// soft-delete path on the next DELETE, keeping the row visible to
+	// the kind's reconciler until it finishes platform-side teardown.
+	//
+	// The store applies the result only on create; updates preserve
+	// existing finalizers as before. Calling on every apply (rather
+	// than guarding with a create-detection load round-trip) keeps the
+	// pipeline straight-line — implementations should be cheap and
+	// side-effect-free. Reapply scenarios where a row already exists
+	// with the wrong finalizer set must use PatchFinalizers from a
+	// PostUpsert hook.
+	//
+	// Required for kinds whose teardown owns external infrastructure
+	// the reconciler is responsible for cleaning up. Without it, a
+	// concurrent DELETE between Upsert commit and any post-upsert
+	// finalizer write hits the hard-delete fast-path and orphans
+	// whatever the reconciler would have torn down.
+	InitialFinalizers func(obj v1alpha1.Object) []string
 }
 
 // AuthorizeInput is the context passed to Config.Authorize on every handler
@@ -411,6 +433,7 @@ func Register[T v1alpha1.Object](api huma.API, cfg Config, newObj func() T) {
 			Resolver:          cfg.Resolver,
 			RegistryValidator: cfg.RegistryValidator,
 			PostUpsert:        cfg.PostUpsert,
+			InitialFinalizers: cfg.InitialFinalizers,
 		}, false); ae != nil {
 			return nil, mapApplyErrorToHuma(ae, kind, ns, name, version)
 		}

--- a/pkg/registry/v1alpha1store/store.go
+++ b/pkg/registry/v1alpha1store/store.go
@@ -160,9 +160,21 @@ type listCursor struct {
 // row post-apply; nil means "leave existing annotations unchanged",
 // while an explicit empty map means "clear all annotations". Used by
 // controllers that add annotations out-of-band with user applies.
+//
+// InitialFinalizers is applied only on the create path (when no row
+// exists yet at the supplied (namespace, name, version)). On update,
+// existing finalizers are preserved as before — InitialFinalizers is
+// ignored. This is the atomic seam for kinds whose teardown is owned
+// by a reconciler driving external infrastructure: the finalizer must
+// exist from the moment the row is visible to a concurrent DELETE,
+// otherwise Delete's "finalizers empty → hard-delete fast path" can
+// drop the row before the reconciler ever sees it and orphan whatever
+// the reconciler was responsible for cleaning up. Mutating finalizers
+// on existing rows still goes through PatchFinalizers.
 type UpsertOpts struct {
-	Labels      map[string]string
-	Annotations map[string]string
+	Labels            map[string]string
+	Annotations       map[string]string
+	InitialFinalizers []string
 }
 
 // Upsert writes the given object under its (namespace, name, version). On
@@ -243,14 +255,21 @@ func (s *Store) Upsert(ctx context.Context, namespace, name, version string, spe
 		}
 		res.Generation = newGen
 
-		// Finalizers preserved verbatim from the existing row (or `[]`
-		// for new rows). The public Upsert API has no `Finalizers`
-		// option anymore — the column is retained for the future
-		// orphan-reconciler hook only. PatchFinalizers (still exported)
-		// is the sole way to mutate it.
+		// Finalizers preserved verbatim from the existing row on
+		// update; on create, opts.InitialFinalizers seeds the column
+		// (defaulting to `[]` when unset). PatchFinalizers remains the
+		// sole way to mutate finalizers on an existing row.
 		finalizersJSON := oldFinalizersRaw
 		if !found {
-			finalizersJSON = []byte("[]")
+			if len(opts.InitialFinalizers) > 0 {
+				b, err := json.Marshal(opts.InitialFinalizers)
+				if err != nil {
+					return fmt.Errorf("marshal initial finalizers: %w", err)
+				}
+				finalizersJSON = b
+			} else {
+				finalizersJSON = []byte("[]")
+			}
 		}
 
 		// Annotation handling: nil preserves existing,

--- a/pkg/registry/v1alpha1store/store_test.go
+++ b/pkg/registry/v1alpha1store/store_test.go
@@ -250,6 +250,83 @@ func TestStore_DeleteWithFinalizersSoftDeletes(t *testing.T) {
 	require.True(t, res.Created)
 }
 
+// readFinalizers reads the current finalizers slice for a row through
+// PatchFinalizers's identity mutator. RawObject doesn't expose the
+// finalizers column directly (there's no public Get accessor), and
+// PatchFinalizers is the only typed read path that doesn't require a
+// raw SQL query.
+func readFinalizers(t *testing.T, ctx context.Context, store *Store, ns, name, version string) []string {
+	t.Helper()
+	var got []string
+	require.NoError(t, store.PatchFinalizers(ctx, ns, name, version, func(current []string) []string {
+		got = append([]string(nil), current...)
+		return current
+	}))
+	return got
+}
+
+// TestStore_UpsertSeedsInitialFinalizers pins the atomic seam used by
+// kinds whose teardown is owned by a reconciler: passing
+// InitialFinalizers on the create path of Upsert writes the row with
+// the finalizer in the same transaction as the spec, so a concurrent
+// DELETE arriving before any out-of-band PatchFinalizers can't take
+// the hard-delete fast path and skip the reconciler's cleanup.
+func TestStore_UpsertSeedsInitialFinalizers(t *testing.T) {
+	pool := NewTestPool(t)
+	store := NewStore(pool, testTable)
+	ctx := context.Background()
+
+	const finalizer = "finalizer.example.com/teardown"
+	res, err := store.Upsert(ctx, testNS, "foo", "v1", mustSpec(t, v1alpha1.AgentSpec{}), UpsertOpts{
+		InitialFinalizers: []string{finalizer},
+	})
+	require.NoError(t, err)
+	require.True(t, res.Created)
+
+	// The freshly-written row carries the seeded finalizer.
+	require.Equal(t, []string{finalizer}, readFinalizers(t, ctx, store, testNS, "foo", "v1"))
+
+	// Delete now takes the soft-delete branch (because the row is
+	// already finalized) — without InitialFinalizers it would hard-
+	// delete and orphan whatever the reconciler was supposed to clean
+	// up.
+	require.NoError(t, store.Delete(ctx, testNS, "foo", "v1"))
+	row, err := store.Get(ctx, testNS, "foo", "v1")
+	require.NoError(t, err)
+	require.NotNil(t, row.Metadata.DeletionTimestamp, "finalizer-seeded row must soft-delete, not hard-delete")
+}
+
+// TestStore_UpsertInitialFinalizersIgnoredOnUpdate pins the contract:
+// InitialFinalizers seeds the row only on the create path. A subsequent
+// Upsert against the same identity must not overwrite finalizers that
+// were attached out-of-band (or seeded earlier), since updates are not
+// the authoritative finalizer-mutation seam — PatchFinalizers is.
+func TestStore_UpsertInitialFinalizersIgnoredOnUpdate(t *testing.T) {
+	pool := NewTestPool(t)
+	store := NewStore(pool, testTable)
+	ctx := context.Background()
+
+	const seeded = "finalizer.example.com/teardown"
+	_, err := store.Upsert(ctx, testNS, "foo", "v1", mustSpec(t, v1alpha1.AgentSpec{}), UpsertOpts{
+		InitialFinalizers: []string{seeded},
+	})
+	require.NoError(t, err)
+
+	// Re-apply with a different InitialFinalizers slice + a spec change
+	// to force the update branch. Existing finalizers must be preserved
+	// untouched.
+	res, err := store.Upsert(ctx, testNS, "foo", "v1", mustSpec(t, v1alpha1.AgentSpec{Title: "updated"}), UpsertOpts{
+		InitialFinalizers: []string{"different.example.com/never-applied"},
+	})
+	require.NoError(t, err)
+	require.False(t, res.Created)
+	require.True(t, res.SpecChanged)
+
+	require.Equal(t, []string{seeded},
+		readFinalizers(t, ctx, store, testNS, "foo", "v1"),
+		"update path must not overwrite finalizers; PatchFinalizers is the only mutation seam")
+}
+
 // TestStore_UpsertRejectsTerminatingRow guards the Kubernetes-style
 // invariant: once a row is soft-deleted, it cannot be mutated in place via
 // Upsert. Pre-fix behavior was a silent partial-update (ON CONFLICT bumped

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -66,6 +66,20 @@ type PostUpsert func(ctx context.Context, obj v1alpha1.Object) error
 // batch's per-doc delete hook.
 type PostDelete func(ctx context.Context, obj v1alpha1.Object) error
 
+// InitialFinalizers computes the finalizer slice seeded onto a row at
+// create time. Returning nil/empty leaves finalizers=[] (today's
+// default; no soft-delete protection). Returning a non-empty slice
+// blocks Store.Delete's hard-delete fast-path so the kind's reconciler
+// can own teardown.
+//
+// The callback is invoked on every apply because the apply pipeline
+// can't know "create vs update" without an extra round-trip — the
+// distinction happens inside Upsert under FOR UPDATE. The returned
+// slice is used only on create; updates preserve existing finalizers
+// regardless. Implementations should be cheap (a type assertion + a
+// field read) and side-effect-free.
+type InitialFinalizers func(obj v1alpha1.Object) []string
+
 // AppOptions contains configuration for the registry app.
 // All fields are optional and allow external developers to extend
 // functionality.
@@ -128,6 +142,15 @@ type AppOptions struct {
 
 	// PostDeletes mirror PostUpserts on the delete path.
 	PostDeletes map[string]PostDelete
+
+	// InitialFinalizers seeds finalizers atomically with row creation,
+	// per kind. Used by kinds whose teardown is owned by a reconciler
+	// driving external infrastructure: blocks Store.Delete's
+	// finalizer-empty hard-delete fast-path so the reconciler can drive
+	// cleanup before the row is purged. Missing keys leave new rows
+	// with finalizers=[] (today's behavior); existing rows preserve
+	// their finalizers across re-apply regardless.
+	InitialFinalizers map[string]InitialFinalizers
 
 	// V1Alpha1StoreTables registers additional v1alpha1 kinds with their
 	// backing PostgreSQL tables. Downstream builds that add their own


### PR DESCRIPTION
# Description

Add an InitialFinalizers hook to the per-kind resource and apply configurations so resource kinds can seed finalizers atomically with row creation. Without this, kinds whose teardown is owned by a reconciler driving external infrastructure are exposed to a race: a DELETE arriving between the create commit and any post-upsert finalizer write hits the hard-delete fast path and orphans whatever the reconciler was responsible for cleaning up.

The hook is invoked only on the create branch; updates preserve existing finalizers as before. Threaded through both the per-kind PUT path and the multi-doc apply batch so all entry points seed identically.

# Change Type

```
/kind cleanup
```

# Changelog

```release-note
NONE
```
