### PR TITLE
fix: default apply tags before authz

### DIFF
--- a/pkg/registry/resource/apply_test.go
+++ b/pkg/registry/resource/apply_test.go
@@ -162,8 +162,17 @@ spec:
 	require.Len(t, out.Results, 2)
 	require.Equal(t, v1alpha1.KindRuntime, out.Results[0].Kind)
 	require.Equal(t, arv0.ApplyStatusCreated, out.Results[0].Status)
+	require.Empty(t, out.Results[0].Tag)
 	require.Equal(t, v1alpha1.KindDeployment, out.Results[1].Kind)
 	require.Equal(t, arv0.ApplyStatusCreated, out.Results[1].Status)
+	require.Empty(t, out.Results[1].Tag)
+
+	runtimeRow, err := runtimes.Get(t.Context(), "default", "local-test-runtime", "")
+	require.NoError(t, err)
+	require.Empty(t, runtimeRow.Metadata.Tag)
+	deploymentRow, err := deployments.Get(t.Context(), "default", "summarizer", "")
+	require.NoError(t, err)
+	require.Empty(t, deploymentRow.Metadata.Tag)
 }
 
 func TestRegisterDeleteApply_OmittedTagDeletesAllTags(t *testing.T) {
@@ -255,6 +264,63 @@ metadata:
 	latest, err := agents.Get(t.Context(), "default", "alice", v1alpha1store.DefaultTag())
 	require.NoError(t, err)
 	require.Equal(t, v1alpha1store.DefaultTag(), latest.Metadata.Tag)
+}
+
+func TestRegisterApply_DefaultsRemoteMCPServerTagBeforeAuthorize(t *testing.T) {
+	pool := v1alpha1store.NewTestPool(t)
+	remoteMCPServers := v1alpha1store.NewStore(pool, "v1alpha1.remote_mcp_servers")
+
+	_, err := remoteMCPServers.Upsert(t.Context(), &v1alpha1.RemoteMCPServer{
+		Metadata: v1alpha1.ObjectMeta{Namespace: "default", Name: "test-mcp-server"},
+		Spec: v1alpha1.RemoteMCPServerSpec{
+			Title:  "Test MCP Server",
+			Remote: v1alpha1.MCPTransport{Type: "streamable-http", URL: "https://example.test/mcp"},
+		},
+	})
+	require.NoError(t, err)
+
+	var seen resource.AuthorizeInput
+	_, api := humatest.New(t)
+	resource.RegisterApply(api, resource.ApplyConfig{
+		BasePrefix: "/v0",
+		Stores: map[string]*v1alpha1store.Store{
+			v1alpha1.KindRemoteMCPServer: remoteMCPServers,
+		},
+		Authorizers: map[string]func(context.Context, resource.AuthorizeInput) error{
+			v1alpha1.KindRemoteMCPServer: func(ctx context.Context, in resource.AuthorizeInput) error {
+				seen = in
+				_, err := remoteMCPServers.Get(ctx, in.Namespace, in.Name, in.Tag)
+				return err
+			},
+		},
+	})
+
+	yaml := []byte(`apiVersion: ar.dev/v1alpha1
+kind: RemoteMCPServer
+metadata:
+  namespace: default
+  name: test-mcp-server
+spec:
+  title: Test MCP Server
+  remote:
+    type: streamable-http
+    url: https://example.test/mcp
+`)
+	resp := api.Post("/v0/apply", "Content-Type: application/yaml", strings.NewReader(string(yaml)))
+	require.Equal(t, http.StatusOK, resp.Code, resp.Body.String())
+
+	var out struct {
+		Results []arv0.ApplyResult `json:"results"`
+	}
+	require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &out))
+	require.Len(t, out.Results, 1)
+	require.Equal(t, arv0.ApplyStatusUnchanged, out.Results[0].Status)
+	require.Equal(t, v1alpha1store.DefaultTag(), out.Results[0].Tag)
+	require.Equal(t, "apply", seen.Verb)
+	require.Equal(t, v1alpha1.KindRemoteMCPServer, seen.Kind)
+	require.Equal(t, "default", seen.Namespace)
+	require.Equal(t, "test-mcp-server", seen.Name)
+	require.Equal(t, v1alpha1store.DefaultTag(), seen.Tag)
 }
 
 // TestRegisterApply_DeniesKindWithNoAuthorizer pins the apply-side

--- a/pkg/registry/resource/core.go
+++ b/pkg/registry/resource/core.go
@@ -71,8 +71,8 @@ func (e *applyError) Error() string {
 // applyCore runs the shared upsert pipeline on a single
 // already-decoded, metadata-stamped object:
 //
-//	authorize → validate → resolve refs → validate registries →
-//	marshal spec → Store.Upsert → PostUpsert
+//	canonicalize metadata → authorize → validate → resolve refs →
+//	validate registries → marshal spec → Store.Upsert → PostUpsert
 //
 // dryRun=true skips Upsert + PostUpsert; everything else still runs so
 // clients get the same 400-class error surface they would on a real
@@ -89,6 +89,11 @@ func applyCore(
 
 	if meta.UID != "" {
 		meta.UID = ""
+		obj.SetMetadata(*meta)
+	}
+
+	if v1alpha1.IsTaggedArtifactKind(kind) && meta.Tag == "" {
+		meta.Tag = v1alpha1store.DefaultTag()
 		obj.SetMetadata(*meta)
 	}
 
@@ -110,11 +115,6 @@ func applyCore(
 	}
 	if err := v1alpha1.ValidateObjectRegistries(ctx, obj, opts.RegistryValidator); err != nil {
 		return upsertResult{}, &applyError{Stage: stageRegistries, Err: err}
-	}
-
-	if v1alpha1.IsTaggedArtifactKind(kind) && meta.Tag == "" {
-		meta.Tag = v1alpha1store.DefaultTag()
-		obj.SetMetadata(*meta)
 	}
 
 	if dryRun {


### PR DESCRIPTION
# Description

Defaults omitted `metadata.tag` values to the literal `latest` tag before batch apply authorization runs. This fixes `/v0/apply` for tagged resources such as `RemoteMCPServer` when authz or staging hooks use `AuthorizeInput.Tag` before upsert.

The default remains restricted to tagged artifact kinds, so mutable objects still do not expose a synthetic public tag.

# Change Type

/kind fix

# Changelog

```release-note
Fix `/v0/apply` for tagged v1alpha1 resources that omit `metadata.tag` when authorization hooks are enabled.
```

# Additional Notes

Verification:
- `go test -tags=integration -v ./pkg/registry/resource -run TestRegisterApply_DefaultsRemoteMCPServerTagBeforeAuthorize -count=1` reproduced the pre-fix failure with `forbidden: v1alpha1 store: tag is required`.
- `go test -tags=integration ./pkg/registry/resource -count=1`
- `go test ./pkg/...`
