### PR TITLE
feat(v1alpha1): add Branch and Commit to Repository

### DIFF
--- a/internal/cli/common/gitutil/gitutil.go
+++ b/internal/cli/common/gitutil/gitutil.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"regexp"
 	"strings"
 )
 
@@ -61,10 +60,23 @@ func ParseGitHubURL(rawURL string) (cloneURL, branch, subPath string, err error)
 
 // CloneAndCopy clones a GitHub repository URL and copies its contents to targetDir.
 // It handles parsing the URL, shallow cloning, navigating to subpaths, and cleanup.
-func CloneAndCopy(repoURL, targetDir string, verbose bool) error {
-	cloneURL, branch, subPath, err := ParseGitHubURL(repoURL)
+//
+// branch, commit, and subPath are explicit overrides. When branch and subPath
+// are empty, the values parsed from the URL (e.g.
+// https://github.com/o/r/tree/<branch>/<sub>) are used. The URL-derived ref is
+// always treated as a branch; callers wanting to pin a commit SHA must set the
+// commit argument explicitly. branch is passed to `git clone --branch`; commit
+// triggers a fetch + checkout after the clone.
+func CloneAndCopy(repoURL, branch, commit, subPath, targetDir string, verbose bool) error {
+	cloneURL, urlBranch, urlSubPath, err := ParseGitHubURL(repoURL)
 	if err != nil {
 		return fmt.Errorf("parse GitHub URL: %w", err)
+	}
+	if branch == "" {
+		branch = urlBranch
+	}
+	if subPath == "" {
+		subPath = urlSubPath
 	}
 
 	tempDir, err := os.MkdirTemp("", "arctl-git-clone-*")
@@ -73,12 +85,8 @@ func CloneAndCopy(repoURL, targetDir string, verbose bool) error {
 	}
 	defer func() { _ = os.RemoveAll(tempDir) }()
 
-	// git clone --branch works for branches and tags but not commit SHAs.
-	// For SHAs, clone the default branch then checkout the specific commit.
-	isSHA := isCommitSHA(branch)
-
 	cloneArgs := []string{"clone", "--depth", "1"}
-	if branch != "" && !isSHA {
+	if branch != "" {
 		cloneArgs = append(cloneArgs, "--branch", branch)
 	}
 	cloneArgs = append(cloneArgs, cloneURL, tempDir)
@@ -92,15 +100,14 @@ func CloneAndCopy(repoURL, targetDir string, verbose bool) error {
 		return fmt.Errorf("clone repository: %w", err)
 	}
 
-	// For commit SHAs, fetch the specific commit and check it out.
-	if isSHA {
-		fetchCmd := exec.Command("git", "-C", tempDir, "fetch", "--depth", "1", "origin", branch)
+	if commit != "" {
+		fetchCmd := exec.Command("git", "-C", tempDir, "fetch", "--depth", "1", "origin", commit)
 		if verbose {
 			fetchCmd.Stdout = os.Stdout
 			fetchCmd.Stderr = os.Stderr
 		}
 		if err := fetchCmd.Run(); err != nil {
-			return fmt.Errorf("fetch commit %s: %w", branch, err)
+			return fmt.Errorf("fetch commit %s: %w", commit, err)
 		}
 
 		checkoutCmd := exec.Command("git", "-C", tempDir, "checkout", "FETCH_HEAD")
@@ -109,7 +116,7 @@ func CloneAndCopy(repoURL, targetDir string, verbose bool) error {
 			checkoutCmd.Stderr = os.Stderr
 		}
 		if err := checkoutCmd.Run(); err != nil {
-			return fmt.Errorf("checkout commit %s: %w", branch, err)
+			return fmt.Errorf("checkout commit %s: %w", commit, err)
 		}
 	}
 
@@ -266,14 +273,4 @@ func RepoNameFromCloneURL(cloneURL string) string {
 		return ""
 	}
 	return strings.TrimSuffix(cloneURL[idx+1:], ".git")
-}
-
-// commitSHAPattern matches full (40-char) and abbreviated (7-40 char)
-// hexadecimal commit SHAs.
-var commitSHAPattern = regexp.MustCompile(`^[0-9a-fA-F]{7,40}$`)
-
-// isCommitSHA returns true if ref looks like a Git commit SHA rather than a
-// branch or tag name. This is a heuristic: a 7-40 character hex string.
-func isCommitSHA(ref string) bool {
-	return commitSHAPattern.MatchString(ref)
 }

--- a/internal/cli/declarative/init.go
+++ b/internal/cli/declarative/init.go
@@ -144,6 +144,8 @@ func newInitAgentCmd() *cobra.Command {
 		initLanguage      string
 		initImage         string
 		initGit           string
+		initGitBranch     string
+		initGitCommit     string
 		initMCPs          []string
 		initLocalMCPs     []string
 	)
@@ -296,7 +298,7 @@ init and add an MCP_SERVERS_CONFIG entry, e.g.:
 			// agent.yaml carries only canonical AgentSpec fields.
 			if err := writeDeclarativeAgentYAML(projectDir, name, image,
 				provider, modelName,
-				initDescription, initGit, initMCPs); err != nil {
+				initDescription, initGit, initGitBranch, initGitCommit, initMCPs); err != nil {
 				return fmt.Errorf("write agent.yaml: %w", err)
 			}
 
@@ -321,6 +323,8 @@ init and add an MCP_SERVERS_CONFIG entry, e.g.:
 	cmd.Flags().StringVar(&initModelName, "model-name", "", "Model name")
 	cmd.Flags().StringVar(&initImage, "image", "", "Image tag override")
 	cmd.Flags().StringVar(&initGit, "git", "", "Git repository URL")
+	cmd.Flags().StringVar(&initGitBranch, "git-branch", "", "Git branch to record on the agent's source repository")
+	cmd.Flags().StringVar(&initGitCommit, "git-commit", "", "Git commit SHA to pin the agent's source repository to")
 	cmd.Flags().StringSliceVar(&initMCPs, "mcp", nil, "Registry MCP server ref (name@version). Repeatable.")
 	cmd.Flags().StringSliceVar(&initLocalMCPs, "local-mcp", nil, "Path to a sibling MCP project; wires it into .env so the local agent can reach it. Repeatable.")
 	return cmd
@@ -495,7 +499,7 @@ func parseNameVersion(s string) (string, string) {
 // metadata.tag is intentionally omitted — tagging is a publish-time concern.
 // The server stores untagged applies as the literal "latest"; users who want
 // a deterministic tag set it on the YAML by hand before `arctl apply`.
-func writeDeclarativeAgentYAML(projectDir, name, image, modelProvider, modelName, description, gitURL string, mcps []string) error {
+func writeDeclarativeAgentYAML(projectDir, name, image, modelProvider, modelName, description, gitURL, gitBranch, gitCommit string, mcps []string) error {
 	desc := description
 	if desc == "" {
 		desc = fmt.Sprintf("%s agent", name)
@@ -521,7 +525,9 @@ func writeDeclarativeAgentYAML(projectDir, name, image, modelProvider, modelName
 
 	if gitURL != "" {
 		agent.Spec.Source.Repository = &v1alpha1.Repository{
-			URL: gitURL,
+			URL:    gitURL,
+			Branch: gitBranch,
+			Commit: gitCommit,
 		}
 	}
 

--- a/internal/cli/declarative/pull.go
+++ b/internal/cli/declarative/pull.go
@@ -64,7 +64,7 @@ func pullResource(ctx context.Context, typ, name, tag, outDir string) error {
 		return fmt.Errorf("API client not initialized")
 	}
 
-	var repoURL, subfolder string
+	var repo *v1alpha1.Repository
 	switch typ {
 	case "agent":
 		obj, err := client.GetTyped(ctx, apiClient, v1alpha1.KindAgent, v1alpha1.DefaultNamespace, name, tag,
@@ -75,8 +75,7 @@ func pullResource(ctx context.Context, typ, name, tag, outDir string) error {
 		if obj.Spec.Source == nil || obj.Spec.Source.Repository == nil || obj.Spec.Source.Repository.URL == "" {
 			return fmt.Errorf("agent %q has no source repository URL set", name)
 		}
-		repoURL = obj.Spec.Source.Repository.URL
-		subfolder = obj.Spec.Source.Repository.Subfolder
+		repo = obj.Spec.Source.Repository
 	case "mcp":
 		obj, err := client.GetTyped(ctx, apiClient, v1alpha1.KindMCPServer, v1alpha1.DefaultNamespace, name, tag,
 			func() *v1alpha1.MCPServer { return &v1alpha1.MCPServer{} })
@@ -86,8 +85,7 @@ func pullResource(ctx context.Context, typ, name, tag, outDir string) error {
 		if obj.Spec.Source == nil || obj.Spec.Source.Repository == nil || obj.Spec.Source.Repository.URL == "" {
 			return fmt.Errorf("mcp %q has no source repository URL set", name)
 		}
-		repoURL = obj.Spec.Source.Repository.URL
-		subfolder = obj.Spec.Source.Repository.Subfolder
+		repo = obj.Spec.Source.Repository
 	case "skill":
 		obj, err := client.GetTyped(ctx, apiClient, v1alpha1.KindSkill, v1alpha1.DefaultNamespace, name, tag,
 			func() *v1alpha1.Skill { return &v1alpha1.Skill{} })
@@ -97,19 +95,25 @@ func pullResource(ctx context.Context, typ, name, tag, outDir string) error {
 		if obj.Spec.Source == nil || obj.Spec.Source.Repository == nil || obj.Spec.Source.Repository.URL == "" {
 			return fmt.Errorf("skill %q has no source repository URL set", name)
 		}
-		repoURL = obj.Spec.Source.Repository.URL
-		subfolder = obj.Spec.Source.Repository.Subfolder
+		repo = obj.Spec.Source.Repository
 	}
 
 	if err := os.MkdirAll(outDir, 0755); err != nil {
 		return err
 	}
-	fmt.Printf("Cloning %s into %s\n", repoURL, outDir)
-	if err := gitutil.CloneAndCopy(repoURL, outDir, false); err != nil {
+	switch {
+	case repo.Commit != "":
+		fmt.Printf("Cloning %s @ %s into %s\n", repo.URL, repo.Commit, outDir)
+	case repo.Branch != "":
+		fmt.Printf("Cloning %s (branch %s) into %s\n", repo.URL, repo.Branch, outDir)
+	default:
+		fmt.Printf("Cloning %s into %s\n", repo.URL, outDir)
+	}
+	if err := gitutil.CloneAndCopy(repo.URL, repo.Branch, repo.Commit, repo.Subfolder, outDir, false); err != nil {
 		return err
 	}
-	if subfolder != "" {
-		fmt.Printf("(subfolder hint: %s)\n", subfolder)
+	if repo.Subfolder != "" {
+		fmt.Printf("(subfolder hint: %s)\n", repo.Subfolder)
 	}
 	fmt.Printf("Pulled %s\n", name)
 	return nil

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -599,6 +599,10 @@ components:
     Repository:
       additionalProperties: false
       properties:
+        branch:
+          type: string
+        commit:
+          type: string
         subfolder:
           type: string
         url:

--- a/pkg/api/v1alpha1/common.go
+++ b/pkg/api/v1alpha1/common.go
@@ -1,7 +1,14 @@
 package v1alpha1
 
 // Repository is a source-code location shared by several resource kinds.
+//
+// Branch and Commit are optional pinning hints for consumers that need to
+// fetch source (deploys, importers, scanners). When both are empty,
+// consumers should fall back to the repository's default branch (i.e.
+// `git clone` without `--branch`), not a hardcoded branch name.
 type Repository struct {
 	URL       string `json:"url,omitempty" yaml:"url,omitempty"`
+	Branch    string `json:"branch,omitempty" yaml:"branch,omitempty"`
+	Commit    string `json:"commit,omitempty" yaml:"commit,omitempty"`
 	Subfolder string `json:"subfolder,omitempty" yaml:"subfolder,omitempty"`
 }

--- a/pkg/api/v1alpha1/validation.go
+++ b/pkg/api/v1alpha1/validation.go
@@ -193,6 +193,13 @@ func validateRepository(r *Repository) FieldErrors {
 		if err := validateWebsiteURL(r.URL); err != nil {
 			errs.Append("repository.url", err)
 		}
+	} else {
+		if r.Branch != "" {
+			errs.Append("repository.branch", fmt.Errorf("%w: branch requires repository.url", ErrInvalidFormat))
+		}
+		if r.Commit != "" {
+			errs.Append("repository.commit", fmt.Errorf("%w: commit requires repository.url", ErrInvalidFormat))
+		}
 	}
 	return errs
 }

--- a/pkg/api/v1alpha1/validation_test.go
+++ b/pkg/api/v1alpha1/validation_test.go
@@ -111,6 +111,45 @@ func TestAgentValidate_AccumulatesErrors(t *testing.T) {
 	require.Contains(t, paths, "spec.title")
 }
 
+func TestAgentValidate_AcceptsRepositoryWithBranchAndCommit(t *testing.T) {
+	a := &Agent{
+		Metadata: ObjectMeta{Namespace: "default", Name: "a"},
+		Spec: AgentSpec{
+			Source: &AgentSource{
+				Repository: &Repository{
+					URL:    "https://github.com/example/repo",
+					Branch: "feature/x",
+					Commit: "abc1234def",
+				},
+			},
+		},
+	}
+	require.NoError(t, a.Validate())
+}
+
+func TestAgentValidate_RejectsBranchOrCommitWithoutURL(t *testing.T) {
+	cases := []struct {
+		name string
+		repo Repository
+		want string
+	}{
+		{"branch without url", Repository{Branch: "feature/x"}, "spec.source.repository.branch"},
+		{"commit without url", Repository{Commit: "abc1234"}, "spec.source.repository.commit"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			a := &Agent{
+				Metadata: ObjectMeta{Namespace: "default", Name: "a"},
+				Spec: AgentSpec{
+					Source: &AgentSource{Repository: &tc.repo},
+				},
+			}
+			paths := failedFields(t, a.Validate())
+			require.Contains(t, paths, tc.want)
+		})
+	}
+}
+
 func TestAgentResolveRefs_OK(t *testing.T) {
 	resolver := func(ctx context.Context, ref ResourceRef) error { return nil }
 	a := &Agent{

--- a/ui/lib/api/types.gen.ts
+++ b/ui/lib/api/types.gen.ts
@@ -289,6 +289,8 @@ export type RemoteMcpServerSpec = {
 };
 
 export type Repository = {
+    branch?: string;
+    commit?: string;
     subfolder?: string;
     url?: string;
 };


### PR DESCRIPTION
# Description

**Motivation:** today an Agent / MCPServer / Skill manifest can name a source repository URL but not a branch or commit. Consumers that need to fetch source (deploys, importers, `arctl pull`) either accept the repo's default branch or hardcode their own fallback — neither of which lets the registered resource declare its canonical ref.

This change adds the missing schema so resources can pin a branch or commit alongside the URL, and updates the in-tree consumers (`arctl pull`, `arctl init agent`) to thread the fields through.

**What changed:**
- `Repository` gains optional `branch` and `commit` fields.
- Validation rejects `branch` or `commit` set without `url`.
- `gitutil.CloneAndCopy` takes explicit `branch`/`commit`/`subPath` overrides.
- `arctl pull` passes `Repository.Branch`/`Commit`/`Subfolder` through.
- `arctl init agent` gains `--git-branch` and `--git-commit` flags.
- `openapi.yaml` regenerated.

**Breaking:** `gitutil.CloneAndCopy` previously parsed `https://github.com/o/r/tree/<ref>/...` URLs and treated `<ref>` as a commit if it looked like a 7–40 char hex SHA. With explicit `branch` and `commit` fields, that branch-vs-commit heuristic is gone — URL-derived refs are always treated as branches. To pin a commit, set `commit` explicitly. The only in-tree caller passing such URLs was `arctl pull`, which now uses the explicit fields instead.

# Change Type

/kind feature
/kind breaking_change

# Changelog

```release-note
Repository now accepts optional `branch` and `commit` fields, validated to require `url` when set. `arctl pull` and `arctl init agent` honor them. BREAKING: `gitutil.CloneAndCopy` no longer auto-detects commit SHAs from URL `/tree/<ref>/` paths — set the commit field explicitly to pin a SHA.
```
