### PR TITLE
Stop loading env files in registry config

### DIFF
--- a/internal/registry/config/config.go
+++ b/internal/registry/config/config.go
@@ -7,7 +7,6 @@ import (
 	"os"
 
 	env "github.com/caarlos0/env/v11"
-	"github.com/joho/godotenv"
 )
 
 // Config holds the application configuration
@@ -54,12 +53,8 @@ type EmbeddingsConfig struct {
 
 // NewConfig creates a new configuration with default values
 func NewConfig() *Config {
-	err := godotenv.Load()
-	if err != nil {
-		slog.Info("no .env file found or error loading .env file", "error", err)
-	}
 	var cfg Config
-	err = env.ParseWithOptions(&cfg, env.Options{
+	err := env.ParseWithOptions(&cfg, env.Options{
 		Prefix: "AGENT_REGISTRY_",
 	})
 	if err != nil {


### PR DESCRIPTION
# Description

This PR removes implicit `.env` loading from the registry server configuration
constructor. `internal/registry/config.NewConfig()` now reads only the process
environment supplied by the caller through `caarlos0/env`.

Local tools can still load `.env` before invoking the server, and Docker or
Kubernetes deployments continue to pass environment variables through their
runtime configuration. The server binary no longer mutates its own environment
based on a working-directory-local `.env` file.

# Change Type

/kind cleanup

# Changelog

```release-note
NONE
```

# Additional Notes

`github.com/joho/godotenv` remains a direct dependency because the declarative
CLI env parser still uses `godotenv.Parse` to read project `.env` files. This
change only removes the registry server config path's implicit load.
