### PR TITLE
feat(cli): list every tag by default; add --tag and --latest filters

### DIFF
--- a/internal/cli/declarative/declarative.go
+++ b/internal/cli/declarative/declarative.go
@@ -88,8 +88,8 @@ func init() {
 		Get: func(ctx context.Context, name, _ string) (any, error) {
 			return client.GetTyped(ctx, apiClient, v1alpha1.KindRuntime, v1alpha1.DefaultNamespace, name, "", func() *v1alpha1.Runtime { return &v1alpha1.Runtime{} })
 		},
-		ListFunc: func(ctx context.Context) ([]any, error) {
-			return listLatestAny(ctx, v1alpha1.KindRuntime, func() *v1alpha1.Runtime { return &v1alpha1.Runtime{} })
+		ListFunc: func(ctx context.Context, opts scheme.ListOpts) ([]any, error) {
+			return listAny(ctx, v1alpha1.KindRuntime, opts, func() *v1alpha1.Runtime { return &v1alpha1.Runtime{} })
 		},
 		Delete: func(ctx context.Context, name, tag string, force bool) error {
 			return deleteAny(ctx, v1alpha1.KindRuntime, name, tag, force, func() *v1alpha1.Runtime { return &v1alpha1.Runtime{} })
@@ -113,7 +113,7 @@ func init() {
 		Delete: func(_ context.Context, name, tag string, force bool) error {
 			return deleteDeploymentByTarget(context.Background(), name, tag, force)
 		},
-		ListFunc: func(_ context.Context) ([]any, error) {
+		ListFunc: func(_ context.Context, _ scheme.ListOpts) ([]any, error) {
 			return listDeploymentAny(context.Background())
 		},
 		RowFunc: func(item any) []string {
@@ -168,8 +168,8 @@ func typedKind[T v1alpha1.Object](
 		Get: func(ctx context.Context, name, tag string) (any, error) {
 			return client.GetTyped(ctx, apiClient, canonicalKind, v1alpha1.DefaultNamespace, name, tag, newObj)
 		},
-		ListFunc: func(ctx context.Context) ([]any, error) {
-			return listLatestAny(ctx, canonicalKind, newObj)
+		ListFunc: func(ctx context.Context, opts scheme.ListOpts) ([]any, error) {
+			return listAny(ctx, canonicalKind, opts, newObj)
 		},
 		Delete: func(ctx context.Context, name, tag string, force bool) error {
 			return deleteAny(ctx, canonicalKind, name, tag, force, newObj)

--- a/internal/cli/declarative/extension.go
+++ b/internal/cli/declarative/extension.go
@@ -58,8 +58,8 @@ func RegisterExtensionKind(k ExtensionKind) {
 		Get: func(ctx context.Context, name, _ string) (any, error) {
 			return client.GetTyped(ctx, apiClient, k.CanonicalKind, v1alpha1.DefaultNamespace, name, "", k.NewObject)
 		},
-		ListFunc: func(ctx context.Context) ([]any, error) {
-			return listLatestAny(ctx, k.CanonicalKind, k.NewObject)
+		ListFunc: func(ctx context.Context, opts scheme.ListOpts) ([]any, error) {
+			return listAny(ctx, k.CanonicalKind, opts, k.NewObject)
 		},
 		Delete: func(ctx context.Context, name, tag string, force bool) error {
 			return deleteAny(ctx, k.CanonicalKind, name, tag, force, k.NewObject)

--- a/internal/cli/declarative/get.go
+++ b/internal/cli/declarative/get.go
@@ -34,6 +34,8 @@ Supported types: agents, mcps, skills, prompts, runtimes, deployments
 Examples:
   arctl get all
   arctl get agents
+  arctl get agents --tag stable          # list rows with a specific tag
+  arctl get agents --latest              # list rows pinned to the "latest" tag
   arctl get mcps
   arctl get agent acme/summarizer
   arctl get agent acme/summarizer -o yaml
@@ -45,7 +47,8 @@ Examples:
 		RunE:         runGet,
 	}
 	cmd.Flags().StringP("output", "o", "table", "Output format: table, yaml, json")
-	cmd.Flags().String("tag", "", "Specific tag to fetch (defaults to latest; tagged content kinds only; not allowed with --all-tags)")
+	cmd.Flags().String("tag", "", "Tagged kinds only. With NAME: fetch one tag (defaults to latest). Without NAME: filter the list to this tag.")
+	cmd.Flags().Bool("latest", false, "List mode only: restrict to rows pinned to the literal 'latest' tag (equivalent to --tag latest).")
 	cmd.Flags().Bool("all-tags", false, "List every tag of NAME (tagged content kinds only)")
 	return cmd
 }
@@ -53,12 +56,20 @@ Examples:
 func runGet(cmd *cobra.Command, args []string) error {
 	outputFormat, _ := cmd.Flags().GetString("output")
 	allTags, _ := cmd.Flags().GetBool("all-tags")
+	latest, _ := cmd.Flags().GetBool("latest")
 	tag, _ := cmd.Flags().GetString("tag")
 	allTagsFlag := "--all-tags"
 	tagFlag := "--tag"
+	latestFlag := "--latest"
 
 	if allTags && tag != "" {
 		return fmt.Errorf("%s and %s are mutually exclusive", tagFlag, allTagsFlag)
+	}
+	if allTags && latest {
+		return fmt.Errorf("%s and %s are mutually exclusive", latestFlag, allTagsFlag)
+	}
+	if latest && tag != "" {
+		return fmt.Errorf("%s and %s are mutually exclusive", tagFlag, latestFlag)
 	}
 
 	if args[0] == "all" {
@@ -67,6 +78,9 @@ func runGet(cmd *cobra.Command, args []string) error {
 		}
 		if tag != "" {
 			return fmt.Errorf("%s cannot be used with `get all`", tagFlag)
+		}
+		if latest {
+			return fmt.Errorf("%s cannot be used with `get all`", latestFlag)
 		}
 		return runGetAll(cmd, outputFormat)
 	}
@@ -98,16 +112,14 @@ func runGet(cmd *cobra.Command, args []string) error {
 		return printItems(cmd, k, items, outputFormat)
 	}
 
-	// --tag is only meaningful for tagged content-registry kinds.
-	// ListTags is set exclusively on those kinds via typedKind, so
-	// it's a stable proxy without coupling get.go to v1alpha1's kind table.
-	if tag != "" {
-		if len(args) != 2 {
-			return fmt.Errorf("%s requires NAME", tagFlag)
-		}
-		if k.ListTags == nil {
-			return fmt.Errorf("%s not supported for kind %q (resource is not tagged)", tagFlag, k.Kind)
-		}
+	// --tag / --latest are only meaningful for tagged content-registry kinds.
+	// ListTags is set exclusively on those kinds via typedKind, so it's a
+	// stable proxy without coupling get.go to v1alpha1's kind table.
+	if tag != "" && k.ListTags == nil {
+		return fmt.Errorf("%s not supported for kind %q (resource is not tagged)", tagFlag, k.Kind)
+	}
+	if latest && k.ListTags == nil {
+		return fmt.Errorf("%s not supported for kind %q (resource is not tagged)", latestFlag, k.Kind)
 	}
 
 	if len(args) == 2 {
@@ -123,7 +135,8 @@ func runGet(cmd *cobra.Command, args []string) error {
 		return printItem(cmd, k, item, outputFormat)
 	}
 
-	items, err := listItems(k)
+	listOpts := scheme.ListOpts{Tag: tag, LatestOnly: latest}
+	items, err := listItems(k, listOpts)
 	if err != nil {
 		return fmt.Errorf("listing %s: %w", kindPlural(k), err)
 	}
@@ -142,7 +155,7 @@ func runGetAll(cmd *cobra.Command, outputFormat string) error {
 	allKinds := scheme.All()
 	first := true
 	for _, k := range allKinds {
-		items, err := listItems(k)
+		items, err := listItems(k, scheme.ListOpts{})
 		if errors.Is(err, errNotListable) {
 			continue
 		}

--- a/internal/cli/declarative/get_test.go
+++ b/internal/cli/declarative/get_test.go
@@ -236,16 +236,123 @@ func TestGet_Tag_NotSupportedForDeployment(t *testing.T) {
 	assert.Contains(t, err.Error(), "deployment")
 }
 
-// TestGet_Tag_RequiresName pins that --tag errors when NAME is omitted.
-func TestGet_Tag_RequiresName(t *testing.T) {
+// TestGet_Tag_ListModeFiltersByTag verifies that `arctl get agents --tag X`
+// (no NAME) forwards `?tag=X` to the list endpoint. Earlier the CLI rejected
+// the no-NAME form with "--tag requires NAME"; that constraint is gone now
+// because the default list returns every tag, so --tag is the canonical way
+// to scope a list to one tag value.
+func TestGet_Tag_ListModeFiltersByTag(t *testing.T) {
+	var (
+		mu       sync.Mutex
+		captured []string
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		captured = append(captured, r.URL.RawQuery)
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"items":[]}`))
+	}))
+	t.Cleanup(srv.Close)
+	setupClientForServer(t, srv)
+
+	cmd := declarative.NewGetCmd()
+	cmd.SetArgs([]string{"agents", "--tag", "0.1.0"})
+	require.NoError(t, cmd.Execute())
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.NotEmpty(t, captured, "expected at least one server call")
+	assert.Contains(t, captured[0], "tag=0.1.0",
+		"expected ?tag=0.1.0 to flow through to the list query, got %q", captured[0])
+}
+
+// TestGet_Latest_ListModeFiltersByLatestOnly verifies `--latest` (no NAME)
+// flips `?latestOnly=true` on the list query. This is the explicit re-opt
+// into the old "default list filter" behavior that used to be implicit.
+func TestGet_Latest_ListModeFiltersByLatestOnly(t *testing.T) {
+	var (
+		mu       sync.Mutex
+		captured []string
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		captured = append(captured, r.URL.RawQuery)
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"items":[]}`))
+	}))
+	t.Cleanup(srv.Close)
+	setupClientForServer(t, srv)
+
+	cmd := declarative.NewGetCmd()
+	cmd.SetArgs([]string{"agents", "--latest"})
+	require.NoError(t, cmd.Execute())
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.NotEmpty(t, captured, "expected at least one server call")
+	assert.Contains(t, captured[0], "latestOnly=true",
+		"expected ?latestOnly=true to flow through, got %q", captured[0])
+}
+
+// TestGet_ListModeDefault_NoTagFilter verifies the new default: a plain
+// `arctl get agents` does NOT send tag= or latestOnly=, so the server
+// returns every row. This is the contract that fixes the empty-list bug
+// for resources published with explicit version tags.
+func TestGet_ListModeDefault_NoTagFilter(t *testing.T) {
+	var (
+		mu       sync.Mutex
+		captured []string
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		captured = append(captured, r.URL.RawQuery)
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"items":[]}`))
+	}))
+	t.Cleanup(srv.Close)
+	setupClientForServer(t, srv)
+
+	cmd := declarative.NewGetCmd()
+	cmd.SetArgs([]string{"agents"})
+	require.NoError(t, cmd.Execute())
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.NotEmpty(t, captured, "expected at least one server call")
+	assert.NotContains(t, captured[0], "tag=",
+		"default list should not pass a tag filter, got %q", captured[0])
+	assert.NotContains(t, captured[0], "latestOnly=true",
+		"default list should not pass latestOnly, got %q", captured[0])
+}
+
+// TestGet_TagAndLatest_MutuallyExclusive pins the flag-validation guard.
+func TestGet_TagAndLatest_MutuallyExclusive(t *testing.T) {
 	declarative.SetAPIClient(client.NewClient("http://127.0.0.1:1", ""))
 	t.Cleanup(func() { declarative.SetAPIClient(nil) })
 
 	cmd := declarative.NewGetCmd()
-	cmd.SetArgs([]string{"agents", "--tag", "1"})
+	cmd.SetArgs([]string{"agents", "--tag", "1", "--latest"})
 	err := cmd.Execute()
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "--tag requires NAME")
+	assert.Contains(t, err.Error(), "mutually exclusive")
+}
+
+// TestGet_Latest_NotSupportedForProvider mirrors the --tag guard: --latest
+// is also a tag-shaped filter and should be rejected for mutable kinds
+// before any dispatch.
+func TestGet_Latest_NotSupportedForProvider(t *testing.T) {
+	declarative.SetAPIClient(client.NewClient("http://127.0.0.1:1", ""))
+	t.Cleanup(func() { declarative.SetAPIClient(nil) })
+
+	cmd := declarative.NewGetCmd()
+	cmd.SetArgs([]string{"runtime", "--latest"})
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--latest not supported")
+	assert.Contains(t, err.Error(), "runtime")
 }
 
 // TestGet_Tag_RejectsGetAll pins that --tag is rejected for
@@ -256,4 +363,14 @@ func TestGet_Tag_RejectsGetAll(t *testing.T) {
 	err := cmd.Execute()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "--tag cannot be used with `get all`")
+}
+
+// TestGet_Latest_RejectsGetAll is the symmetric guard for --latest on
+// cross-kind list.
+func TestGet_Latest_RejectsGetAll(t *testing.T) {
+	cmd := declarative.NewGetCmd()
+	cmd.SetArgs([]string{"all", "--latest"})
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--latest cannot be used with `get all`")
 }

--- a/internal/cli/declarative/kinds_dispatch.go
+++ b/internal/cli/declarative/kinds_dispatch.go
@@ -18,12 +18,13 @@ import (
 // than treating it as an error.
 var errNotListable = errors.New("list not supported for this kind")
 
-// listItems fetches all items for the given kind using its registered ListFunc.
-func listItems(k *scheme.Kind) ([]any, error) {
+// listItems fetches items for the given kind using its registered ListFunc.
+// opts may be the zero value to list every row.
+func listItems(k *scheme.Kind, opts scheme.ListOpts) ([]any, error) {
 	if k.ListFunc == nil {
 		return nil, fmt.Errorf("%w: %q", errNotListable, k.Kind)
 	}
-	return k.ListFunc(context.Background())
+	return k.ListFunc(context.Background(), opts)
 }
 
 // getItem fetches a single item by name for the given kind. Empty tag resolves

--- a/internal/cli/declarative/resources.go
+++ b/internal/cli/declarative/resources.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	cliCommon "github.com/agentregistry-dev/agentregistry/internal/cli/common"
+	"github.com/agentregistry-dev/agentregistry/internal/cli/scheme"
 	"github.com/agentregistry-dev/agentregistry/internal/client"
 	"github.com/agentregistry-dev/agentregistry/pkg/api/v1alpha1"
 	"github.com/agentregistry-dev/agentregistry/pkg/printer"
@@ -27,14 +28,25 @@ type deploymentStatus struct {
 	UpdatedAt       time.Time      `json:"updatedAt,omitempty" yaml:"updatedAt,omitempty"`
 }
 
-func listLatestAny[T v1alpha1.Object](ctx context.Context, kind string, newObj func() T) ([]any, error) {
+// listAny lists rows of the given kind. The zero scheme.ListOpts returns
+// every (namespace, name, tag) row of the kind — same shape as a raw
+// GET /v0/{plural}. Callers pass Tag or LatestOnly to filter; the CLI
+// `get` command surfaces those as `--tag` / `--latest`.
+//
+// Earlier this helper hardcoded `LatestOnly: true`, which translated
+// server-side to a literal `tag = "latest"` predicate. That returned
+// nothing for resources published with explicit version tags, even
+// though they existed in the registry. List now matches the natural
+// "show me what's there" expectation.
+func listAny[T v1alpha1.Object](ctx context.Context, kind string, opts scheme.ListOpts, newObj func() T) ([]any, error) {
 	items, err := client.ListAllTyped(
 		ctx,
 		apiClient,
 		kind,
 		client.ListOpts{
 			Namespace:  v1alpha1.DefaultNamespace,
-			LatestOnly: true,
+			Tag:        opts.Tag,
+			LatestOnly: opts.LatestOnly,
 			Limit:      200,
 		},
 		newObj,

--- a/internal/cli/scheme/registry.go
+++ b/internal/cli/scheme/registry.go
@@ -21,7 +21,19 @@ type Column struct {
 	Header string
 }
 
-type ListFunc func(context.Context) ([]any, error)
+// ListOpts are CLI-facing filters forwarded to the per-kind ListFunc.
+// Empty fields mean "no filter" — the default `arctl get <plural>` lists
+// every row of the kind.
+type ListOpts struct {
+	// Tag, when set, restricts the list to rows with this tag value
+	// (tagged content kinds only). Mutually exclusive with LatestOnly.
+	Tag string
+	// LatestOnly restricts the list to the literal "latest" tag (tagged
+	// content kinds) or the latest mutable-object row.
+	LatestOnly bool
+}
+
+type ListFunc func(context.Context, ListOpts) ([]any, error)
 type RowFunc func(any) []string
 type ToYAMLFunc func(any) any
 type GetFunc func(ctx context.Context, name, tag string) (any, error)

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -182,10 +182,15 @@ func (c *Client) GetVersion() (*VersionBody, error) {
 // scopes to the default namespace; "all" widens to every namespace.
 // Any other value scopes to that exact namespace.
 type ListOpts struct {
-	Namespace          string
-	Labels             string
-	Limit              int
-	Cursor             string
+	Namespace string
+	Labels    string
+	Limit     int
+	Cursor    string
+	// Tag, when set, restricts results to one tag value on tagged-artifact
+	// kinds. Empty means "every tag of every name".
+	Tag string
+	// LatestOnly is equivalent to Tag = "latest" for tagged kinds and also
+	// covers the mutable-object latest-row case.
 	LatestOnly         bool
 	IncludeTerminating bool
 }
@@ -280,6 +285,9 @@ func (c *Client) List(ctx context.Context, kind string, opts ListOpts) ([]v1alph
 	}
 	if opts.Labels != "" {
 		q.Set("labels", opts.Labels)
+	}
+	if opts.Tag != "" {
+		q.Set("tag", opts.Tag)
 	}
 	if opts.LatestOnly {
 		q.Set("latestOnly", "true")

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -763,12 +763,23 @@ paths:
         schema:
           description: 'Label selector: key=value,key2=value2.'
           type: string
-      - description: Only return the literal latest tag per (namespace, name).
+      - description: Restrict the result set to one tag value (tagged artifact kinds
+          only).
+        explode: false
+        in: query
+        name: tag
+        schema:
+          description: Restrict the result set to one tag value (tagged artifact kinds
+            only).
+          type: string
+      - description: Only return the literal latest tag per (namespace, name). Equivalent
+          to tag=latest for tagged kinds.
         explode: false
         in: query
         name: latestOnly
         schema:
-          description: Only return the literal latest tag per (namespace, name).
+          description: Only return the literal latest tag per (namespace, name). Equivalent
+            to tag=latest for tagged kinds.
           type: boolean
       - description: Include rows with a deletionTimestamp.
         explode: false
@@ -1029,12 +1040,23 @@ paths:
         schema:
           description: 'Label selector: key=value,key2=value2.'
           type: string
-      - description: Only return the literal latest tag per (namespace, name).
+      - description: Restrict the result set to one tag value (tagged artifact kinds
+          only).
+        explode: false
+        in: query
+        name: tag
+        schema:
+          description: Restrict the result set to one tag value (tagged artifact kinds
+            only).
+          type: string
+      - description: Only return the literal latest tag per (namespace, name). Equivalent
+          to tag=latest for tagged kinds.
         explode: false
         in: query
         name: latestOnly
         schema:
-          description: Only return the literal latest tag per (namespace, name).
+          description: Only return the literal latest tag per (namespace, name). Equivalent
+            to tag=latest for tagged kinds.
           type: boolean
       - description: Include rows with a deletionTimestamp.
         explode: false
@@ -1210,12 +1232,23 @@ paths:
         schema:
           description: 'Label selector: key=value,key2=value2.'
           type: string
-      - description: Only return the literal latest tag per (namespace, name).
+      - description: Restrict the result set to one tag value (tagged artifact kinds
+          only).
+        explode: false
+        in: query
+        name: tag
+        schema:
+          description: Restrict the result set to one tag value (tagged artifact kinds
+            only).
+          type: string
+      - description: Only return the literal latest tag per (namespace, name). Equivalent
+          to tag=latest for tagged kinds.
         explode: false
         in: query
         name: latestOnly
         schema:
-          description: Only return the literal latest tag per (namespace, name).
+          description: Only return the literal latest tag per (namespace, name). Equivalent
+            to tag=latest for tagged kinds.
           type: boolean
       - description: Include rows with a deletionTimestamp.
         explode: false
@@ -1427,12 +1460,23 @@ paths:
         schema:
           description: 'Label selector: key=value,key2=value2.'
           type: string
-      - description: Only return the literal latest tag per (namespace, name).
+      - description: Restrict the result set to one tag value (tagged artifact kinds
+          only).
+        explode: false
+        in: query
+        name: tag
+        schema:
+          description: Restrict the result set to one tag value (tagged artifact kinds
+            only).
+          type: string
+      - description: Only return the literal latest tag per (namespace, name). Equivalent
+          to tag=latest for tagged kinds.
         explode: false
         in: query
         name: latestOnly
         schema:
-          description: Only return the literal latest tag per (namespace, name).
+          description: Only return the literal latest tag per (namespace, name). Equivalent
+            to tag=latest for tagged kinds.
           type: boolean
       - description: Include rows with a deletionTimestamp.
         explode: false
@@ -1624,12 +1668,23 @@ paths:
         schema:
           description: 'Label selector: key=value,key2=value2.'
           type: string
-      - description: Only return the literal latest tag per (namespace, name).
+      - description: Restrict the result set to one tag value (tagged artifact kinds
+          only).
+        explode: false
+        in: query
+        name: tag
+        schema:
+          description: Restrict the result set to one tag value (tagged artifact kinds
+            only).
+          type: string
+      - description: Only return the literal latest tag per (namespace, name). Equivalent
+          to tag=latest for tagged kinds.
         explode: false
         in: query
         name: latestOnly
         schema:
-          description: Only return the literal latest tag per (namespace, name).
+          description: Only return the literal latest tag per (namespace, name). Equivalent
+            to tag=latest for tagged kinds.
           type: boolean
       - description: Include rows with a deletionTimestamp.
         explode: false
@@ -1821,12 +1876,23 @@ paths:
         schema:
           description: 'Label selector: key=value,key2=value2.'
           type: string
-      - description: Only return the literal latest tag per (namespace, name).
+      - description: Restrict the result set to one tag value (tagged artifact kinds
+          only).
+        explode: false
+        in: query
+        name: tag
+        schema:
+          description: Restrict the result set to one tag value (tagged artifact kinds
+            only).
+          type: string
+      - description: Only return the literal latest tag per (namespace, name). Equivalent
+          to tag=latest for tagged kinds.
         explode: false
         in: query
         name: latestOnly
         schema:
-          description: Only return the literal latest tag per (namespace, name).
+          description: Only return the literal latest tag per (namespace, name). Equivalent
+            to tag=latest for tagged kinds.
           type: boolean
       - description: Include rows with a deletionTimestamp.
         explode: false
@@ -1982,12 +2048,23 @@ paths:
         schema:
           description: 'Label selector: key=value,key2=value2.'
           type: string
-      - description: Only return the literal latest tag per (namespace, name).
+      - description: Restrict the result set to one tag value (tagged artifact kinds
+          only).
+        explode: false
+        in: query
+        name: tag
+        schema:
+          description: Restrict the result set to one tag value (tagged artifact kinds
+            only).
+          type: string
+      - description: Only return the literal latest tag per (namespace, name). Equivalent
+          to tag=latest for tagged kinds.
         explode: false
         in: query
         name: latestOnly
         schema:
-          description: Only return the literal latest tag per (namespace, name).
+          description: Only return the literal latest tag per (namespace, name). Equivalent
+            to tag=latest for tagged kinds.
           type: boolean
       - description: Include rows with a deletionTimestamp.
         explode: false

--- a/pkg/registry/resource/handler.go
+++ b/pkg/registry/resource/handler.go
@@ -257,7 +257,8 @@ type listInput struct {
 	Limit      int    `query:"limit" doc:"Max items to return (default 50)." default:"50"`
 	Cursor     string `query:"cursor" doc:"Opaque pagination cursor."`
 	Labels     string `query:"labels" doc:"Label selector: key=value,key2=value2."`
-	LatestOnly bool   `query:"latestOnly" doc:"Only return the literal latest tag per (namespace, name)."`
+	Tag        string `query:"tag" doc:"Restrict the result set to one tag value (tagged artifact kinds only)."`
+	LatestOnly bool   `query:"latestOnly" doc:"Only return the literal latest tag per (namespace, name). Equivalent to tag=latest for tagged kinds."`
 	// IncludeTerminating surfaces soft-deleted rows (deletionTimestamp != nil)
 	// which are hidden by default.
 	IncludeTerminating bool `query:"includeTerminating" doc:"Include rows with a deletionTimestamp."`
@@ -318,6 +319,7 @@ func Register[T v1alpha1.Object](api huma.API, cfg Config, newObj func() T) {
 			Labels:             in.Labels,
 			Limit:              in.Limit,
 			Cursor:             in.Cursor,
+			Tag:                in.Tag,
 			LatestOnly:         in.LatestOnly,
 			IncludeTerminating: in.IncludeTerminating,
 		})
@@ -639,6 +641,7 @@ type listParams struct {
 	Labels             string
 	Limit              int
 	Cursor             string
+	Tag                string
 	LatestOnly         bool
 	IncludeTerminating bool
 }
@@ -652,6 +655,7 @@ func runList[T v1alpha1.Object](
 		Namespace:          p.Namespace,
 		Limit:              p.Limit,
 		Cursor:             p.Cursor,
+		Tag:                p.Tag,
 		LatestOnly:         p.LatestOnly,
 		IncludeTerminating: p.IncludeTerminating || cfg.IncludeTerminatingByDefault,
 	}

--- a/pkg/registry/v1alpha1store/store.go
+++ b/pkg/registry/v1alpha1store/store.go
@@ -180,8 +180,18 @@ type ListOpts struct {
 	Limit int
 	// Cursor is an opaque pagination token. Empty starts from the beginning.
 	Cursor string
+	// Tag restricts the result set to a single tag value on tagged-artifact
+	// stores. Empty means "no tag filter" — every tag of every name is
+	// returned. Ignored on mutable-object stores (they have no tag column).
+	// Mutually exclusive with LatestOnly (validated at the caller level;
+	// the store treats LatestOnly as the literal `Tag = "latest"` filter
+	// when both are set, but new callers should pick one).
+	Tag string
 	// LatestOnly restricts to the literal "latest" tag per (namespace, name),
-	// or the private latest row for mutable-object stores.
+	// or the private latest row for mutable-object stores. Equivalent to
+	// `Tag = "latest"` on tagged stores; kept as a separate field because
+	// it also covers the mutable-object latest-row case (where there's no
+	// user-facing tag column).
 	LatestOnly bool
 	// IncludeTerminating includes rows with deletion_timestamp set. Default
 	// false — callers asking for "alive" rows shouldn't see terminating ones.
@@ -965,8 +975,14 @@ func (s *Store) List(ctx context.Context, opts ListOpts) ([]*v1alpha1.RawObject,
 		args = append(args, opts.Namespace)
 		where = append(where, fmt.Sprintf("namespace = $%d", len(args)))
 	}
-	if opts.LatestOnly {
-		if s.behavior == TaggedArtifactStore {
+	if s.behavior == TaggedArtifactStore {
+		// Tag wins when set; otherwise LatestOnly falls back to the literal
+		// "latest" filter for callers that pre-date the Tag field.
+		switch {
+		case opts.Tag != "":
+			args = append(args, opts.Tag)
+			where = append(where, fmt.Sprintf("tag = $%d", len(args)))
+		case opts.LatestOnly:
 			args = append(args, DefaultTag())
 			where = append(where, fmt.Sprintf("tag = $%d", len(args)))
 		}

--- a/ui/lib/api/types.gen.ts
+++ b/ui/lib/api/types.gen.ts
@@ -376,7 +376,11 @@ export type ListAgentsData = {
          */
         labels?: string;
         /**
-         * Only return the literal latest tag per (namespace, name).
+         * Restrict the result set to one tag value (tagged artifact kinds only).
+         */
+        tag?: string;
+        /**
+         * Only return the literal latest tag per (namespace, name). Equivalent to tag=latest for tagged kinds.
          */
         latestOnly?: boolean;
         /**
@@ -620,7 +624,11 @@ export type ListDeploymentsData = {
          */
         labels?: string;
         /**
-         * Only return the literal latest tag per (namespace, name).
+         * Restrict the result set to one tag value (tagged artifact kinds only).
+         */
+        tag?: string;
+        /**
+         * Only return the literal latest tag per (namespace, name). Equivalent to tag=latest for tagged kinds.
          */
         latestOnly?: boolean;
         /**
@@ -795,7 +803,11 @@ export type ListMcpserversData = {
          */
         labels?: string;
         /**
-         * Only return the literal latest tag per (namespace, name).
+         * Restrict the result set to one tag value (tagged artifact kinds only).
+         */
+        tag?: string;
+        /**
+         * Only return the literal latest tag per (namespace, name). Equivalent to tag=latest for tagged kinds.
          */
         latestOnly?: boolean;
         /**
@@ -1004,7 +1016,11 @@ export type ListPromptsData = {
          */
         labels?: string;
         /**
-         * Only return the literal latest tag per (namespace, name).
+         * Restrict the result set to one tag value (tagged artifact kinds only).
+         */
+        tag?: string;
+        /**
+         * Only return the literal latest tag per (namespace, name). Equivalent to tag=latest for tagged kinds.
          */
         latestOnly?: boolean;
         /**
@@ -1188,7 +1204,11 @@ export type ListRemotemcpserversData = {
          */
         labels?: string;
         /**
-         * Only return the literal latest tag per (namespace, name).
+         * Restrict the result set to one tag value (tagged artifact kinds only).
+         */
+        tag?: string;
+        /**
+         * Only return the literal latest tag per (namespace, name). Equivalent to tag=latest for tagged kinds.
          */
         latestOnly?: boolean;
         /**
@@ -1372,7 +1392,11 @@ export type ListRuntimesData = {
          */
         labels?: string;
         /**
-         * Only return the literal latest tag per (namespace, name).
+         * Restrict the result set to one tag value (tagged artifact kinds only).
+         */
+        tag?: string;
+        /**
+         * Only return the literal latest tag per (namespace, name). Equivalent to tag=latest for tagged kinds.
          */
         latestOnly?: boolean;
         /**
@@ -1522,7 +1546,11 @@ export type ListSkillsData = {
          */
         labels?: string;
         /**
-         * Only return the literal latest tag per (namespace, name).
+         * Restrict the result set to one tag value (tagged artifact kinds only).
+         */
+        tag?: string;
+        /**
+         * Only return the literal latest tag per (namespace, name). Equivalent to tag=latest for tagged kinds.
          */
         latestOnly?: boolean;
         /**


### PR DESCRIPTION
# Description

**Motivation:** `arctl get <plural>` set `LatestOnly=true` on every list call, which the store translated into a literal `tag = "latest"` SQL predicate on tagged-artifact kinds. Resources published with explicit version tags (e.g. `metadata.tag: "0.1.0"`) never matched, so the list came back empty even when the artifacts existed in the registry. `arctl get agents` and `arctl get mcps` would say "No agents found" right after a successful publish — the row was in the database, but the filter hid it.

**What changed:** list means "list" by default; the old filter is now an opt-in flag.

```
arctl get <plural>              → every (namespace, name, tag) row
arctl get <plural> --tag X      → only rows where tag = X
arctl get <plural> --latest     → only rows pinned to literal "latest"
```

`--tag` / `--latest` / `--all-tags` are mutually exclusive. `--tag` and `--latest` are rejected for mutable kinds (Runtime, Deployment) and for `arctl get all`.

**Wiring map:**
- `pkg/registry/v1alpha1store/store.go` — `ListOpts.Tag` is new; store filters by `tag = $N` when set, falling back to `LatestOnly` for legacy callers.
- `pkg/registry/resource/handler.go` — `Tag` flows through `listInput` → `listParams` → `runList`.
- `internal/client/client.go` — `ListOpts.Tag` round-trips as `?tag=` on the list path.
- `internal/cli/scheme/registry.go` — `ListFunc` gains a `scheme.ListOpts` argument so per-kind closures can propagate filters.
- `internal/cli/declarative/` — `listLatestAny` → `listAny`; the hardcoded `LatestOnly: true` is gone. `get.go` surfaces `--tag` / `--latest` and validates the flag matrix.

`LatestOnly` stays on the client and server `ListOpts` for back-compat; new callers should prefer `Tag`.

# Change Type

/kind feature
/kind fix

# Changelog

```release-note
`arctl get <plural>` now lists every tag of the kind by default. Use `--tag X` to restrict to one tag or `--latest` to keep the old "literal latest" behavior. Prior versions silently filtered to `tag="latest"`, which hid resources published with explicit version tags.
```

# Additional Notes

- The `listLatestAny` → `listAny` rename and the `scheme.ListFunc` signature change are internal; no external API breaks.
- Tests updated: retired `TestGet_Tag_RequiresName` (contract no longer holds); added `TestGet_ListModeDefault_NoTagFilter`, `TestGet_Tag_ListModeFiltersByTag`, `TestGet_Latest_ListModeFiltersByLatestOnly`, `TestGet_TagAndLatest_MutuallyExclusive`, `TestGet_Latest_NotSupportedForProvider`, `TestGet_Latest_RejectsGetAll`.