### PR TITLE
fix(cli): arctl help offline

### DIFF
--- a/internal/cli/frameworks/builtin/adk-python/templates/docker-compose.yaml.tmpl
+++ b/internal/cli/frameworks/builtin/adk-python/templates/docker-compose.yaml.tmpl
@@ -4,9 +4,16 @@
 services:
   otel-collector:
     image: otel/opentelemetry-collector:latest
+    # Host-side ports are bumped to 14317/14318 so they don't collide with
+    # other OTLP collectors that conventionally bind 4317/4318 on the host
+    # (e.g. a kagent helm install exposes its telemetry gateway on those
+    # ports; a native otel-collector binary; an active `kubectl port-forward`).
+    # The container still listens on 4317/4318 internally and the agent
+    # reaches it via the compose network at `otel-collector:4318` — unchanged.
+    # Only the host's visibility into the collector moves.
     ports:
-      - "4317:4317"  # OTLP gRPC
-      - "4318:4318"  # OTLP HTTP
+      - "14317:4317"  # OTLP gRPC  (host 14317 -> container 4317)
+      - "14318:4318"  # OTLP HTTP  (host 14318 -> container 4318)
     volumes:
       - ./otel-collector-config.yaml:/etc/otelcol/config.yaml
     command: ["--config", "/etc/otelcol/config.yaml"]

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -203,6 +203,7 @@ var preRunSkipCommands = map[string]map[string]bool{
 		"configure":  true,
 		"init":       true,
 		"build":      true,
+		"help":       true,
 	},
 	"mcp": {
 		"add-tool": true,

--- a/pkg/cli/root_test.go
+++ b/pkg/cli/root_test.go
@@ -68,7 +68,11 @@ func TestPreRunBehavior(t *testing.T) {
 	zshCompletionCmd := &cobra.Command{Use: "zsh"}
 	completionCmd.AddCommand(zshCompletionCmd)
 	versionCmd := &cobra.Command{Use: "version"}
-	root.AddCommand(initCmd, buildCmd, agentCmd, mcpCmd, skillCmd, configureCmd, completionCmd, versionCmd)
+	// Cobra auto-generates a "help" subcommand on the root. `arctl help`,
+	// `arctl help <cmd>`, and `arctl help <cmd> <subcmd>` all dispatch to this
+	// single command (cmd.Name()=="help", cmd.Parent()==root).
+	helpCmd := &cobra.Command{Use: "help"}
+	root.AddCommand(initCmd, buildCmd, agentCmd, mcpCmd, skillCmd, configureCmd, completionCmd, versionCmd, helpCmd)
 
 	tests := []struct {
 		name     string
@@ -85,6 +89,8 @@ func TestPreRunBehavior(t *testing.T) {
 		{"configure", configureCmd, true},
 		{"completion", completionCmd, true},
 		{"completion zsh", zshCompletionCmd, true},
+		// help is offline; must not trigger registry setup.
+		{"help", helpCmd, true},
 		// version goes through pre-run using AnnotationOptionalRegistry to have an optional registry connection
 		{"version", versionCmd, false},
 		// Run/pull/etc. need the API client.


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don't apply.
-->

# Description
- **`arctl help` works offline** — cobra's auto-generated `help` subcommand
    was going through the root `PersistentPreRunE`, which calls `preRunSetup`
    and pings the registry. With no registry running, `arctl help` and
    `arctl help <command>` failed with `registry unreachable`, while
    `arctl --help` worked (cobra handles the flag before run hooks). Added
    `help` to `preRunSkipCommands["arctl"]`, matching the existing pattern
    for `configure` / `completion` / `init` / `build`. All three help paths
    are now offline.
 - **adk-python compose OTLP host ports** — bump the otel-collector host-side
    mappings to `14317`/`14318` so `arctl init agent` doesn't generate a
    compose file that collides with other OTLP collectors that conventionally
    bind `4317`/`4318` on the host
<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

# Change Type

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bump
/kind cleanup
/kind design
/kind deprecation
/kind documentation
/kind feature
/kind fix
/kind flake
/kind install
```
-->
/kind fix
# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
NONE
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
