### PR TITLE
Rename arctl deployment resource columns: id to name, name to target

### DIFF
--- a/internal/cli/declarative/declarative.go
+++ b/internal/cli/declarative/declarative.go
@@ -121,7 +121,7 @@ func init() {
 			return deploymentToDocument(deployment)
 		},
 		TableColumns: []scheme.Column{
-			{Header: "ID"}, {Header: "NAME"}, {Header: "VERSION"},
+			{Header: "NAME"}, {Header: "TARGET"}, {Header: "VERSION"},
 			{Header: "TYPE"}, {Header: "RUNTIME"}, {Header: "STATUS"},
 		},
 	})


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don't apply.
-->

# Description
The arctl get deployments command currently uses misleading column headers. The ID column actually contains the resource's name (namespace/name), while the NAME column contains the deployment target. This is confusing for users since "Name" typically refers to the resource's own name.

This PR renames ID column to NAME, and NAME column to TARGET.

<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

# Change Type
/kind fix

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bump
/kind cleanup
/kind design
/kind deprecation
/kind documentation
/kind feature
/kind fix
/kind flake
/kind install
```
-->

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
NONE
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
