### PR TITLE
cli: add status.raw and surface conditions and raw in yaml output

### DIFF
--- a/internal/cli/common/deployments.go
+++ b/internal/cli/common/deployments.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"maps"
 	"strings"
@@ -32,6 +33,14 @@ type DeploymentRecord struct {
 	CreatedAt         time.Time         `json:"deployedAt,omitempty"`
 	UpdatedAt         time.Time         `json:"updatedAt,omitempty"`
 	DeletionTimestamp *time.Time        `json:"deletionTimestamp,omitempty"`
+
+	// Conditions is the raw v1alpha1.Status.Conditions list as reported by
+	// reconcilers. Surfaced alongside the derived Status phase so YAML/JSON
+	// consumers can see fine-grained state without losing the compact view.
+	Conditions []v1alpha1.Condition `json:"conditions,omitempty"`
+
+	// Raw is the opaque adapter-owned status map (see v1alpha1.Status.Raw).
+	Raw json.RawMessage `json:"raw,omitempty"`
 }
 
 // ListDeployments returns every Deployment row visible from the default namespace.
@@ -103,7 +112,27 @@ func DeploymentRecordFromObject(dep *v1alpha1.Deployment) *DeploymentRecord {
 		CreatedAt:         dep.Metadata.CreatedAt,
 		UpdatedAt:         dep.Metadata.UpdatedAt,
 		DeletionTimestamp: dep.Metadata.DeletionTimestamp,
+		Conditions:        cloneConditions(dep.Status.Conditions),
+		Raw:               cloneRaw(dep.Status.Raw),
 	}
+}
+
+func cloneConditions(in []v1alpha1.Condition) []v1alpha1.Condition {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]v1alpha1.Condition, len(in))
+	copy(out, in)
+	return out
+}
+
+func cloneRaw(in json.RawMessage) json.RawMessage {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(json.RawMessage, len(in))
+	copy(out, in)
+	return out
 }
 
 // DeploymentID is the display identity used by imperative deployment commands.

--- a/internal/cli/declarative/resources.go
+++ b/internal/cli/declarative/resources.go
@@ -2,6 +2,7 @@ package declarative
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"time"
@@ -19,13 +20,15 @@ import (
 // v1alpha1.Status conditions block so imperative users keep the compact fields
 // they already consume while apply decode still ignores incoming status.
 type deploymentStatus struct {
-	ID              string         `json:"id,omitempty" yaml:"id,omitempty"`
-	Phase           string         `json:"phase,omitempty" yaml:"phase,omitempty"`
-	Origin          string         `json:"origin,omitempty" yaml:"origin,omitempty"`
-	Error           string         `json:"error,omitempty" yaml:"error,omitempty"`
-	RuntimeMetadata map[string]any `json:"runtimeMetadata,omitempty" yaml:"runtimeMetadata,omitempty"`
-	DeployedAt      time.Time      `json:"deployedAt,omitempty" yaml:"deployedAt,omitempty"`
-	UpdatedAt       time.Time      `json:"updatedAt,omitempty" yaml:"updatedAt,omitempty"`
+	ID              string               `json:"id,omitempty" yaml:"id,omitempty"`
+	Phase           string               `json:"phase,omitempty" yaml:"phase,omitempty"`
+	Origin          string               `json:"origin,omitempty" yaml:"origin,omitempty"`
+	Error           string               `json:"error,omitempty" yaml:"error,omitempty"`
+	RuntimeMetadata map[string]any       `json:"runtimeMetadata,omitempty" yaml:"runtimeMetadata,omitempty"`
+	DeployedAt      time.Time            `json:"deployedAt,omitempty" yaml:"deployedAt,omitempty"`
+	UpdatedAt       time.Time            `json:"updatedAt,omitempty" yaml:"updatedAt,omitempty"`
+	Conditions      []v1alpha1.Condition `json:"conditions,omitempty" yaml:"conditions,omitempty"`
+	Raw             json.RawMessage      `json:"raw,omitempty" yaml:"raw,omitempty"`
 }
 
 // listAny lists rows of the given kind. The zero scheme.ListOpts returns
@@ -221,6 +224,8 @@ func deploymentToDocument(dep *cliCommon.DeploymentRecord) any {
 			RuntimeMetadata: dep.RuntimeMetadata,
 			DeployedAt:      dep.CreatedAt,
 			UpdatedAt:       dep.UpdatedAt,
+			Conditions:      dep.Conditions,
+			Raw:             dep.Raw,
 		},
 	}
 }

--- a/internal/registry/service/deployment/coordinator.go
+++ b/internal/registry/service/deployment/coordinator.go
@@ -281,10 +281,17 @@ func (c *Coordinator) persistApplyResult(ctx context.Context, deployment *v1alph
 		return err
 	}
 	patch := v1alpha1store.PatchOpts{}
-	if len(result.Conditions) > 0 {
+	if len(result.Conditions) > 0 || len(result.Raw) > 0 {
 		patch.Status = v1alpha1.StatusPatcher(func(s *v1alpha1.Status) {
 			for _, cond := range result.Conditions {
 				s.SetCondition(cond)
+			}
+			for key, encoded := range result.Raw {
+				// Best-effort: a malformed Raw value should not block the
+				// rest of the status patch. Adapter authors are responsible
+				// for handling valid JSON; a returned error here just means
+				// that one key is skipped.
+				_ = s.SetRawKeyJSON(key, encoded)
 			}
 		})
 	}

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -672,6 +672,7 @@ components:
           type:
           - array
           - "null"
+        raw: {}
       type: object
     VersionBody:
       additionalProperties: false

--- a/pkg/api/v1alpha1/status.go
+++ b/pkg/api/v1alpha1/status.go
@@ -2,6 +2,8 @@ package v1alpha1
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
 	"time"
 )
 
@@ -44,6 +46,106 @@ type Condition struct {
 type Status struct {
 	ObservedGeneration int64       `json:"-" yaml:"-"`
 	Conditions         []Condition `json:"conditions,omitempty" yaml:"conditions,omitempty"`
+
+	// Raw is an opaque JSON object populated by runtime adapters that need
+	// to surface structured state beyond what Conditions can express. Each
+	// adapter owns its own top-level key inside Raw; consumers parse only
+	// the keys they care about. Empty when no adapter has written.
+	//
+	// Use SetRawKey / GetRawKey to merge or read keys without clobbering
+	// other adapters' state.
+	Raw json.RawMessage `json:"raw,omitempty" yaml:"raw,omitempty"`
+}
+
+// SetRawKey merges value (as JSON) under key in s.Raw. Other top-level keys
+// in s.Raw are preserved; a nil value removes the key. Returns an error if
+// value cannot be marshaled or if existing Raw is not a JSON object.
+func (s *Status) SetRawKey(key string, value any) error {
+	if key == "" {
+		return errors.New("status: SetRawKey key must not be empty")
+	}
+	m := map[string]json.RawMessage{}
+	if len(s.Raw) > 0 {
+		if err := json.Unmarshal(s.Raw, &m); err != nil {
+			return fmt.Errorf("status: existing Raw is not a JSON object: %w", err)
+		}
+	}
+	if value == nil {
+		delete(m, key)
+	} else {
+		encoded, err := json.Marshal(value)
+		if err != nil {
+			return fmt.Errorf("status: marshal %q: %w", key, err)
+		}
+		m[key] = encoded
+	}
+	if len(m) == 0 {
+		s.Raw = nil
+		return nil
+	}
+	out, err := json.Marshal(m)
+	if err != nil {
+		return fmt.Errorf("status: marshal Raw: %w", err)
+	}
+	s.Raw = out
+	return nil
+}
+
+// SetRawKeyJSON is SetRawKey for callers that already hold the value as
+// pre-encoded JSON bytes. Skips the marshal step so byte equality is
+// preserved (useful when the caller wants the on-disk JSON to match a
+// canonical form). encoded must be a valid JSON value; pass nil to remove
+// the key.
+func (s *Status) SetRawKeyJSON(key string, encoded json.RawMessage) error {
+	if key == "" {
+		return errors.New("status: SetRawKeyJSON key must not be empty")
+	}
+	m := map[string]json.RawMessage{}
+	if len(s.Raw) > 0 {
+		if err := json.Unmarshal(s.Raw, &m); err != nil {
+			return fmt.Errorf("status: existing Raw is not a JSON object: %w", err)
+		}
+	}
+	if len(encoded) == 0 {
+		delete(m, key)
+	} else {
+		// Validate encoded is well-formed before storing.
+		if !json.Valid(encoded) {
+			return fmt.Errorf("status: SetRawKeyJSON(%q): value is not valid JSON", key)
+		}
+		m[key] = encoded
+	}
+	if len(m) == 0 {
+		s.Raw = nil
+		return nil
+	}
+	out, err := json.Marshal(m)
+	if err != nil {
+		return fmt.Errorf("status: marshal Raw: %w", err)
+	}
+	s.Raw = out
+	return nil
+}
+
+// GetRawKey unmarshals the value at key in s.Raw into out. Returns (false,
+// nil) when the key is absent. Returns an error if Raw is malformed or out
+// cannot receive the value.
+func (s *Status) GetRawKey(key string, out any) (bool, error) {
+	if len(s.Raw) == 0 || key == "" {
+		return false, nil
+	}
+	m := map[string]json.RawMessage{}
+	if err := json.Unmarshal(s.Raw, &m); err != nil {
+		return false, fmt.Errorf("status: existing Raw is not a JSON object: %w", err)
+	}
+	v, ok := m[key]
+	if !ok {
+		return false, nil
+	}
+	if err := json.Unmarshal(v, out); err != nil {
+		return false, fmt.Errorf("status: unmarshal %q: %w", key, err)
+	}
+	return true, nil
 }
 
 // SetCondition adds or updates the condition matching c.Type on s. If an entry
@@ -108,6 +210,7 @@ type conditionStore struct {
 type statusStore struct {
 	ObservedGeneration int64            `json:"observedGeneration,omitempty"`
 	Conditions         []conditionStore `json:"conditions,omitempty"`
+	Raw                json.RawMessage  `json:"raw,omitempty"`
 }
 
 // MarshalStatusForStorage serializes a Status to JSON suitable for
@@ -124,6 +227,7 @@ func MarshalStatusForStorage(s Status) ([]byte, error) {
 	return json.Marshal(statusStore{
 		ObservedGeneration: s.ObservedGeneration,
 		Conditions:         storeConds,
+		Raw:                s.Raw,
 	})
 }
 
@@ -171,6 +275,7 @@ func UnmarshalStatusFromStorage(data []byte, s *Status) error {
 	*s = Status{
 		ObservedGeneration: w.ObservedGeneration,
 		Conditions:         conds,
+		Raw:                w.Raw,
 	}
 	return nil
 }

--- a/pkg/api/v1alpha1/status_test.go
+++ b/pkg/api/v1alpha1/status_test.go
@@ -108,6 +108,114 @@ func TestStatus_ConditionsRoundTrip(t *testing.T) {
 	}
 }
 
+func TestStatus_SetRawKey_MergesMultipleKeys(t *testing.T) {
+	s := &Status{}
+	if err := s.SetRawKey("agentgateway", map[string]any{"listeners": 2}); err != nil {
+		t.Fatalf("first SetRawKey: %v", err)
+	}
+	if err := s.SetRawKey("kubernetes", map[string]any{"replicas": 3}); err != nil {
+		t.Fatalf("second SetRawKey: %v", err)
+	}
+
+	var gw struct {
+		Listeners int `json:"listeners"`
+	}
+	ok, err := s.GetRawKey("agentgateway", &gw)
+	if err != nil || !ok {
+		t.Fatalf("GetRawKey(agentgateway): ok=%v err=%v", ok, err)
+	}
+	if gw.Listeners != 2 {
+		t.Errorf("agentgateway.listeners: got %d, want 2", gw.Listeners)
+	}
+
+	var k8s struct {
+		Replicas int `json:"replicas"`
+	}
+	ok, err = s.GetRawKey("kubernetes", &k8s)
+	if err != nil || !ok {
+		t.Fatalf("GetRawKey(kubernetes): ok=%v err=%v", ok, err)
+	}
+	if k8s.Replicas != 3 {
+		t.Errorf("kubernetes.replicas: got %d, want 3", k8s.Replicas)
+	}
+}
+
+func TestStatus_SetRawKey_DeletesWithNil(t *testing.T) {
+	s := &Status{}
+	if err := s.SetRawKey("a", map[string]int{"x": 1}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.SetRawKey("b", map[string]int{"y": 2}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.SetRawKey("a", nil); err != nil {
+		t.Fatalf("delete via nil: %v", err)
+	}
+	if ok, _ := s.GetRawKey("a", &map[string]int{}); ok {
+		t.Error("a should have been deleted")
+	}
+	if ok, _ := s.GetRawKey("b", &map[string]int{}); !ok {
+		t.Error("b should be preserved")
+	}
+
+	// Removing the last key should null out Raw entirely.
+	if err := s.SetRawKey("b", nil); err != nil {
+		t.Fatal(err)
+	}
+	if s.Raw != nil {
+		t.Errorf("Raw should be nil after last key removed; got %s", string(s.Raw))
+	}
+}
+
+func TestStatus_SetRawKeyJSON_RejectsInvalidJSON(t *testing.T) {
+	s := &Status{}
+	err := s.SetRawKeyJSON("bad", json.RawMessage(`{not json`))
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+	if !strings.Contains(err.Error(), "not valid JSON") {
+		t.Errorf("error should mention invalid JSON; got: %v", err)
+	}
+	if s.Raw != nil {
+		t.Errorf("Raw should remain unset on invalid input; got %s", string(s.Raw))
+	}
+}
+
+func TestStatus_SetRawKey_RejectsEmptyKey(t *testing.T) {
+	s := &Status{}
+	if err := s.SetRawKey("", 1); err == nil {
+		t.Error("SetRawKey(\"\") should error")
+	}
+	if err := s.SetRawKeyJSON("", json.RawMessage(`1`)); err == nil {
+		t.Error("SetRawKeyJSON(\"\") should error")
+	}
+}
+
+func TestStatus_RawRoundTrip(t *testing.T) {
+	s := Status{ObservedGeneration: 3}
+	if err := s.SetRawKey("agentgateway", map[string]any{"listeners": 2}); err != nil {
+		t.Fatal(err)
+	}
+	data, err := MarshalStatusForStorage(s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got Status
+	if err := UnmarshalStatusFromStorage(data, &got); err != nil {
+		t.Fatal(err)
+	}
+	var payload struct {
+		Listeners int `json:"listeners"`
+	}
+	ok, err := got.GetRawKey("agentgateway", &payload)
+	if err != nil || !ok {
+		t.Fatalf("Raw not round-tripped: ok=%v err=%v", ok, err)
+	}
+	if payload.Listeners != 2 {
+		t.Errorf("agentgateway.listeners: got %d, want 2", payload.Listeners)
+	}
+}
+
 func TestStatus_IsConditionTrue(t *testing.T) {
 	s := &Status{
 		Conditions: []Condition{

--- a/pkg/types/adapter.go
+++ b/pkg/types/adapter.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"context"
+	"encoding/json"
 	"time"
 
 	"github.com/agentregistry-dev/agentregistry/pkg/api/v1alpha1"
@@ -125,6 +126,15 @@ type ApplyResult struct {
 	// runtimes.agentregistry.solo.io/<type>/*). Callers marshal
 	// to string values since Annotations is map[string]string.
 	RuntimeMetadata map[string]string
+
+	// Raw is a map of top-level keys to JSON-encoded values to merge into
+	// Deployment.Status.Raw via Status.SetRawKeyJSON. Each adapter owns its
+	// own top-level key; other keys in Status.Raw are preserved across
+	// the patch. A nil value at a key removes that key.
+	//
+	// Use Raw for structured state that Conditions cannot express cleanly;
+	// stable, typed status should still be modeled as Conditions.
+	Raw map[string]json.RawMessage
 }
 
 // RemoveInput carries the Deployment being torn down plus its resolved

--- a/ui/lib/api/types.gen.ts
+++ b/ui/lib/api/types.gen.ts
@@ -326,6 +326,7 @@ export type SkillSpec = {
 
 export type Status = {
     conditions?: Array<Condition> | null;
+    raw?: unknown;
 };
 
 export type VersionBody = {


### PR DESCRIPTION
# Description

Adds Status.Raw to convey opaque data in Status.

DeploymentRecord and the YAML deploymentStatus projection dropped v1alpha1.Status.Conditions and Status.Raw, so `arctl get deployments -o yaml` only showed the derived phase. Carry both fields through the projection so adapter raw state (e.g. agentgateway exposedAt) and full conditions are visible alongside the compact view.

# Change Type

```
/kind cleanup
```

# Changelog

```release-note
NONE
```