### PR TITLE
Add OSS KRT controller foundations

### DIFF
--- a/internal/registry/controller/deployment.go
+++ b/internal/registry/controller/deployment.go
@@ -1,0 +1,89 @@
+package controller
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/agentregistry-dev/agentregistry/pkg/api/v1alpha1"
+	"github.com/agentregistry-dev/agentregistry/pkg/registry/v1alpha1store"
+)
+
+const (
+	// ReconcileActionApply converges a Deployment toward running desired state.
+	ReconcileActionApply = "apply"
+	// ReconcileActionRemove tears down runtime resources.
+	ReconcileActionRemove = "remove"
+)
+
+// DeploymentRequestPayload is the payload persisted with Deployment
+// reconcile_work. It captures refs needed by a future executor without
+// embedding full object payloads.
+type DeploymentRequestPayload struct {
+	TargetRef    v1alpha1.ResourceRef `json:"targetRef"`
+	RuntimeRef   v1alpha1.ResourceRef `json:"runtimeRef"`
+	DesiredState string               `json:"desiredState,omitempty"`
+}
+
+// DeriveDeploymentWork converts a Deployment source row into durable work. It
+// performs no adapter calls and does not resolve references; executors must
+// re-read the row and dependencies after claiming.
+func DeriveDeploymentWork(deployment *v1alpha1.Deployment) (v1alpha1store.ReconcileWork, error) {
+	if deployment == nil {
+		return v1alpha1store.ReconcileWork{}, errors.New("controller: deployment is required")
+	}
+	meta := deployment.Metadata
+	namespace := meta.NamespaceOrDefault()
+	if meta.Name == "" {
+		return v1alpha1store.ReconcileWork{}, errors.New("controller: deployment metadata.name is required")
+	}
+	if meta.Generation <= 0 {
+		return v1alpha1store.ReconcileWork{}, errors.New("controller: deployment metadata.generation must be positive")
+	}
+
+	action, reason, err := deploymentAction(deployment)
+	if err != nil {
+		return v1alpha1store.ReconcileWork{}, err
+	}
+	payload, err := json.Marshal(DeploymentRequestPayload{
+		TargetRef:    deployment.Spec.TargetRef,
+		RuntimeRef:   deployment.Spec.RuntimeRef,
+		DesiredState: deployment.Spec.DesiredState,
+	})
+	if err != nil {
+		return v1alpha1store.ReconcileWork{}, fmt.Errorf("controller: marshal deployment request payload: %w", err)
+	}
+
+	resource := v1alpha1store.ResourceKey{
+		Kind:      v1alpha1.KindDeployment,
+		Namespace: namespace,
+		Name:      meta.Name,
+	}
+	return v1alpha1store.ReconcileWork{
+		Key:        deploymentWorkKey(resource, meta.UID, meta.Generation, action),
+		Resource:   resource,
+		UID:        meta.UID,
+		Generation: meta.Generation,
+		Action:     action,
+		Reason:     reason,
+		Payload:    payload,
+	}, nil
+}
+
+func deploymentAction(deployment *v1alpha1.Deployment) (action, reason string, err error) {
+	if deployment.Metadata.DeletionTimestamp != nil {
+		return ReconcileActionRemove, "terminating", nil
+	}
+	switch deployment.Spec.DesiredState {
+	case "", v1alpha1.DesiredStateDeployed:
+		return ReconcileActionApply, "desired-deployed", nil
+	case v1alpha1.DesiredStateUndeployed:
+		return ReconcileActionRemove, "desired-undeployed", nil
+	default:
+		return "", "", fmt.Errorf("controller: unsupported deployment desiredState %q", deployment.Spec.DesiredState)
+	}
+}
+
+func deploymentWorkKey(resource v1alpha1store.ResourceKey, uid string, generation int64, action string) string {
+	return fmt.Sprintf("%s:%s:%s:%s:%d:%s", resource.Kind, resource.Namespace, resource.Name, uid, generation, action)
+}

--- a/internal/registry/controller/deployment_test.go
+++ b/internal/registry/controller/deployment_test.go
@@ -1,0 +1,68 @@
+package controller
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/agentregistry-dev/agentregistry/pkg/api/v1alpha1"
+)
+
+func TestDeriveDeploymentWorkDefaultsToApply(t *testing.T) {
+	work, err := DeriveDeploymentWork(deploymentFixture(""))
+	require.NoError(t, err)
+
+	require.Equal(t, "Deployment:default:weather:uid-1:7:apply", work.Key)
+	require.Equal(t, ReconcileActionApply, work.Action)
+	require.Equal(t, "desired-deployed", work.Reason)
+	require.Equal(t, int64(7), work.Generation)
+
+	var payload DeploymentRequestPayload
+	require.NoError(t, json.Unmarshal(work.Payload, &payload))
+	require.Equal(t, v1alpha1.KindMCPServer, payload.TargetRef.Kind)
+	require.Equal(t, v1alpha1.KindRuntime, payload.RuntimeRef.Kind)
+}
+
+func TestDeriveDeploymentWorkRemovesForDesiredUndeployed(t *testing.T) {
+	work, err := DeriveDeploymentWork(deploymentFixture(v1alpha1.DesiredStateUndeployed))
+	require.NoError(t, err)
+
+	require.Equal(t, ReconcileActionRemove, work.Action)
+	require.Equal(t, "desired-undeployed", work.Reason)
+	require.Equal(t, "Deployment:default:weather:uid-1:7:remove", work.Key)
+}
+
+func TestDeriveDeploymentWorkRemovesForTerminatingDeployment(t *testing.T) {
+	deployment := deploymentFixture(v1alpha1.DesiredStateDeployed)
+	now := time.Now()
+	deployment.Metadata.DeletionTimestamp = &now
+
+	work, err := DeriveDeploymentWork(deployment)
+	require.NoError(t, err)
+	require.Equal(t, ReconcileActionRemove, work.Action)
+	require.Equal(t, "terminating", work.Reason)
+}
+
+func TestDeriveDeploymentWorkRejectsInvalidDesiredState(t *testing.T) {
+	_, err := DeriveDeploymentWork(deploymentFixture("running"))
+	require.ErrorContains(t, err, "unsupported deployment desiredState")
+}
+
+func deploymentFixture(desiredState string) *v1alpha1.Deployment {
+	return &v1alpha1.Deployment{
+		TypeMeta: v1alpha1.TypeMeta{APIVersion: v1alpha1.GroupVersion, Kind: v1alpha1.KindDeployment},
+		Metadata: v1alpha1.ObjectMeta{
+			Namespace:  v1alpha1.DefaultNamespace,
+			Name:       "weather",
+			UID:        "uid-1",
+			Generation: 7,
+		},
+		Spec: v1alpha1.DeploymentSpec{
+			TargetRef:    v1alpha1.ResourceRef{Kind: v1alpha1.KindMCPServer, Name: "weather", Tag: "stable"},
+			RuntimeRef:   v1alpha1.ResourceRef{Kind: v1alpha1.KindRuntime, Name: "local"},
+			DesiredState: desiredState,
+		},
+	}
+}

--- a/internal/registry/controller/projector.go
+++ b/internal/registry/controller/projector.go
@@ -1,0 +1,117 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/agentregistry-dev/agentregistry/pkg/registry/v1alpha1store"
+)
+
+// ControlPlaneEventReader is the event-log surface a projector needs. The
+// concrete implementation is v1alpha1store.ControlPlaneEventStore; tests can
+// supply fakes without a database.
+type ControlPlaneEventReader interface {
+	ListAfter(ctx context.Context, afterRevision int64, limit int) ([]v1alpha1store.ControlPlaneEvent, error)
+	OldestRevision(ctx context.Context) (revision int64, ok bool, err error)
+	CurrentRevision(ctx context.Context) (int64, error)
+}
+
+// FullResyncFunc reloads canonical source tables when the event log no longer
+// covers the projector checkpoint.
+type FullResyncFunc func(ctx context.Context) error
+
+// EventApplyFunc updates process-local source collections for one invalidation
+// event. The implementation should re-read the canonical row named by event.Key.
+type EventApplyFunc func(ctx context.Context, event v1alpha1store.ControlPlaneEvent) error
+
+// Projector is the behavior-preserving replay skeleton for KRT source
+// collections. It owns no side effects; it only advances a checkpoint.
+type Projector struct {
+	Events     ControlPlaneEventReader
+	FullResync FullResyncFunc
+	ApplyEvent EventApplyFunc
+	BatchLimit int
+}
+
+// SyncResult describes one projector replay pass.
+type SyncResult struct {
+	Checkpoint   int64
+	Events       int
+	FullResynced bool
+}
+
+// Sync replays retained events after checkpoint. If pruning created a gap, it
+// calls FullResync and advances to the current high-water revision.
+func (p *Projector) Sync(ctx context.Context, checkpoint int64) (SyncResult, error) {
+	if p == nil || p.Events == nil {
+		return SyncResult{}, fmt.Errorf("controller projector: event reader is required")
+	}
+	oldest, ok, err := p.Events.OldestRevision(ctx)
+	if err != nil {
+		return SyncResult{}, err
+	}
+	if ok && checkpoint > 0 && checkpoint < oldest-1 {
+		if p.FullResync == nil {
+			return SyncResult{}, fmt.Errorf("controller projector: checkpoint %d is older than retained event range starting at %d", checkpoint, oldest)
+		}
+		if err := p.FullResync(ctx); err != nil {
+			return SyncResult{}, fmt.Errorf("controller projector full resync: %w", err)
+		}
+		current, err := p.Events.CurrentRevision(ctx)
+		if err != nil {
+			return SyncResult{}, err
+		}
+		return SyncResult{Checkpoint: current, FullResynced: true}, nil
+	}
+
+	limit := p.BatchLimit
+	if limit <= 0 {
+		limit = 500
+	}
+	events, err := p.Events.ListAfter(ctx, checkpoint, limit)
+	if err != nil {
+		return SyncResult{}, err
+	}
+	next := checkpoint
+	for _, event := range events {
+		if p.ApplyEvent != nil {
+			if err := p.ApplyEvent(ctx, event); err != nil {
+				return SyncResult{}, fmt.Errorf("controller projector apply revision %d: %w", event.Revision, err)
+			}
+		}
+		next = event.Revision
+	}
+	return SyncResult{Checkpoint: next, Events: len(events)}, nil
+}
+
+// SourceCollection is a small process-local collection skeleton used by tests
+// and early controller code before a concrete KRT collection is wired in.
+type SourceCollection struct {
+	items map[v1alpha1store.ResourceKey]v1alpha1store.ControlPlaneEvent
+}
+
+// NewSourceCollection constructs an empty source collection.
+func NewSourceCollection() *SourceCollection {
+	return &SourceCollection{items: map[v1alpha1store.ResourceKey]v1alpha1store.ControlPlaneEvent{}}
+}
+
+// Apply records the latest event for a source key, or removes it on delete.
+func (c *SourceCollection) Apply(event v1alpha1store.ControlPlaneEvent) {
+	if c.items == nil {
+		c.items = map[v1alpha1store.ResourceKey]v1alpha1store.ControlPlaneEvent{}
+	}
+	if event.Operation == "delete" {
+		delete(c.items, event.Key)
+		return
+	}
+	c.items[event.Key] = event
+}
+
+// Get returns the last applied event for key.
+func (c *SourceCollection) Get(key v1alpha1store.ResourceKey) (v1alpha1store.ControlPlaneEvent, bool) {
+	if c == nil || c.items == nil {
+		return v1alpha1store.ControlPlaneEvent{}, false
+	}
+	event, ok := c.items[key]
+	return event, ok
+}

--- a/internal/registry/controller/projector_test.go
+++ b/internal/registry/controller/projector_test.go
@@ -1,0 +1,111 @@
+package controller
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/agentregistry-dev/agentregistry/pkg/registry/v1alpha1store"
+)
+
+func TestProjectorSyncReplaysEventsIntoSourceCollection(t *testing.T) {
+	reader := fakeEventReader{
+		events: []v1alpha1store.ControlPlaneEvent{
+			{Revision: 1, Key: v1alpha1store.ResourceKey{Kind: "Deployment", Namespace: "default", Name: "api"}, Operation: "insert"},
+			{Revision: 2, Key: v1alpha1store.ResourceKey{Kind: "Deployment", Namespace: "default", Name: "worker"}, Operation: "insert"},
+		},
+	}
+	collection := NewSourceCollection()
+	projector := &Projector{
+		Events: reader,
+		ApplyEvent: func(_ context.Context, event v1alpha1store.ControlPlaneEvent) error {
+			collection.Apply(event)
+			return nil
+		},
+	}
+
+	res, err := projector.Sync(context.Background(), 0)
+	require.NoError(t, err)
+	require.Equal(t, int64(2), res.Checkpoint)
+	require.Equal(t, 2, res.Events)
+
+	_, ok := collection.Get(v1alpha1store.ResourceKey{Kind: "Deployment", Namespace: "default", Name: "api"})
+	require.True(t, ok)
+	_, ok = collection.Get(v1alpha1store.ResourceKey{Kind: "Deployment", Namespace: "default", Name: "worker"})
+	require.True(t, ok)
+}
+
+func TestProjectorSyncFullResyncsWhenCheckpointFallsBehindRetention(t *testing.T) {
+	reader := fakeEventReader{
+		oldest:  10,
+		current: 15,
+		events:  []v1alpha1store.ControlPlaneEvent{{Revision: 10}},
+	}
+	fullResyncs := 0
+	projector := &Projector{
+		Events: reader,
+		FullResync: func(context.Context) error {
+			fullResyncs++
+			return nil
+		},
+	}
+
+	res, err := projector.Sync(context.Background(), 5)
+	require.NoError(t, err)
+	require.True(t, res.FullResynced)
+	require.Equal(t, int64(15), res.Checkpoint)
+	require.Equal(t, 1, fullResyncs)
+}
+
+func TestSourceCollectionDeletesOnDeleteEvent(t *testing.T) {
+	key := v1alpha1store.ResourceKey{Kind: "Deployment", Namespace: "default", Name: "api"}
+	collection := NewSourceCollection()
+
+	collection.Apply(v1alpha1store.ControlPlaneEvent{Revision: 1, Key: key, Operation: "insert"})
+	_, ok := collection.Get(key)
+	require.True(t, ok)
+
+	collection.Apply(v1alpha1store.ControlPlaneEvent{Revision: 2, Key: key, Operation: "delete"})
+	_, ok = collection.Get(key)
+	require.False(t, ok)
+}
+
+type fakeEventReader struct {
+	events  []v1alpha1store.ControlPlaneEvent
+	oldest  int64
+	current int64
+}
+
+func (f fakeEventReader) ListAfter(_ context.Context, afterRevision int64, limit int) ([]v1alpha1store.ControlPlaneEvent, error) {
+	var out []v1alpha1store.ControlPlaneEvent
+	for _, event := range f.events {
+		if event.Revision > afterRevision {
+			out = append(out, event)
+		}
+	}
+	if limit > 0 && len(out) > limit {
+		out = out[:limit]
+	}
+	return out, nil
+}
+
+func (f fakeEventReader) OldestRevision(context.Context) (int64, bool, error) {
+	if f.oldest > 0 {
+		return f.oldest, true, nil
+	}
+	if len(f.events) == 0 {
+		return 0, false, nil
+	}
+	return f.events[0].Revision, true, nil
+}
+
+func (f fakeEventReader) CurrentRevision(context.Context) (int64, error) {
+	if f.current > 0 {
+		return f.current, nil
+	}
+	if len(f.events) == 0 {
+		return 0, nil
+	}
+	return f.events[len(f.events)-1].Revision, nil
+}

--- a/pkg/registry/v1alpha1store/control_plane_events.go
+++ b/pkg/registry/v1alpha1store/control_plane_events.go
@@ -1,0 +1,165 @@
+package v1alpha1store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// ControlPlaneNotifyChannel is the single coarse wakeup channel for controller
+// projectors. The payload is only a hint; projectors must replay
+// control_plane_events and re-read canonical source rows.
+const ControlPlaneNotifyChannel = "v1alpha1_control_plane_changed"
+
+const defaultEventBatchLimit = 500
+
+// ResourceKey identifies a source row in the v1alpha1 control plane.
+type ResourceKey struct {
+	Kind      string
+	Namespace string
+	Name      string
+	Tag       string
+}
+
+// ControlPlaneEvent records that a canonical v1alpha1 source row changed after
+// a monotonic revision. It intentionally carries identity only, not object
+// payload or derived desired state.
+type ControlPlaneEvent struct {
+	Revision    int64
+	Key         ResourceKey
+	UID         string
+	Generation  int64
+	Operation   string
+	CommittedAt time.Time
+}
+
+// ControlPlaneEventStore reads and prunes the durable invalidation cursor used
+// by KRT projectors.
+type ControlPlaneEventStore struct {
+	pool *pgxpool.Pool
+}
+
+// NewControlPlaneEventStore constructs a control-plane event reader.
+func NewControlPlaneEventStore(pool *pgxpool.Pool) *ControlPlaneEventStore {
+	return &ControlPlaneEventStore{pool: pool}
+}
+
+// ListAfter returns events with revision > afterRevision, ordered by revision.
+func (s *ControlPlaneEventStore) ListAfter(ctx context.Context, afterRevision int64, limit int) ([]ControlPlaneEvent, error) {
+	if s == nil || s.pool == nil {
+		return nil, errors.New("v1alpha1 store: control-plane event store has nil pool")
+	}
+	if limit <= 0 {
+		limit = defaultEventBatchLimit
+	}
+	rows, err := s.pool.Query(ctx, `
+		SELECT revision, kind, namespace, name, tag, uid::text, generation, op, committed_at
+		FROM v1alpha1.control_plane_events
+		WHERE revision > $1
+		ORDER BY revision
+		LIMIT $2`, afterRevision, limit)
+	if err != nil {
+		return nil, fmt.Errorf("list control-plane events: %w", err)
+	}
+	defer rows.Close()
+
+	var out []ControlPlaneEvent
+	for rows.Next() {
+		event, err := scanControlPlaneEvent(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, event)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("read control-plane events: %w", err)
+	}
+	return out, nil
+}
+
+// OldestRevision returns the oldest retained event revision. ok=false means the
+// table is empty.
+func (s *ControlPlaneEventStore) OldestRevision(ctx context.Context) (revision int64, ok bool, err error) {
+	if s == nil || s.pool == nil {
+		return 0, false, errors.New("v1alpha1 store: control-plane event store has nil pool")
+	}
+	var oldest sql.NullInt64
+	if err := s.pool.QueryRow(ctx, `SELECT MIN(revision) FROM v1alpha1.control_plane_events`).Scan(&oldest); err != nil {
+		return 0, false, fmt.Errorf("load oldest control-plane event revision: %w", err)
+	}
+	if !oldest.Valid {
+		return 0, false, nil
+	}
+	return oldest.Int64, true, nil
+}
+
+// CurrentRevision returns the current high-water revision, or 0 when the event
+// table is empty.
+func (s *ControlPlaneEventStore) CurrentRevision(ctx context.Context) (int64, error) {
+	if s == nil || s.pool == nil {
+		return 0, errors.New("v1alpha1 store: control-plane event store has nil pool")
+	}
+	var revision int64
+	if err := s.pool.QueryRow(ctx, `SELECT COALESCE(MAX(revision), 0) FROM v1alpha1.control_plane_events`).Scan(&revision); err != nil {
+		return 0, fmt.Errorf("load current control-plane event revision: %w", err)
+	}
+	return revision, nil
+}
+
+// PruneBefore deletes retained events in bounded batches. At least one of
+// before or keepAfterRevision must be set. Projectors must use gap detection
+// before relying on pruning in production.
+func (s *ControlPlaneEventStore) PruneBefore(ctx context.Context, before time.Time, keepAfterRevision int64, limit int) (int64, error) {
+	if s == nil || s.pool == nil {
+		return 0, errors.New("v1alpha1 store: control-plane event store has nil pool")
+	}
+	if before.IsZero() && keepAfterRevision <= 0 {
+		return 0, errors.New("v1alpha1 store: control-plane event prune requires an age or revision bound")
+	}
+	if limit <= 0 {
+		limit = defaultEventBatchLimit
+	}
+	var beforeArg any
+	if !before.IsZero() {
+		beforeArg = before
+	}
+	cmdTag, err := s.pool.Exec(ctx, `
+		WITH doomed AS (
+			SELECT revision
+			FROM v1alpha1.control_plane_events
+			WHERE ($1::timestamptz IS NULL OR committed_at < $1)
+			  AND ($2::bigint <= 0 OR revision < $2)
+			ORDER BY revision
+			LIMIT $3
+		)
+		DELETE FROM v1alpha1.control_plane_events e
+		USING doomed
+		WHERE e.revision = doomed.revision`, beforeArg, keepAfterRevision, limit)
+	if err != nil {
+		return 0, fmt.Errorf("prune control-plane events: %w", err)
+	}
+	return cmdTag.RowsAffected(), nil
+}
+
+func scanControlPlaneEvent(row pgx.Row) (ControlPlaneEvent, error) {
+	var event ControlPlaneEvent
+	if err := row.Scan(
+		&event.Revision,
+		&event.Key.Kind,
+		&event.Key.Namespace,
+		&event.Key.Name,
+		&event.Key.Tag,
+		&event.UID,
+		&event.Generation,
+		&event.Operation,
+		&event.CommittedAt,
+	); err != nil {
+		return ControlPlaneEvent{}, fmt.Errorf("scan control-plane event: %w", err)
+	}
+	return event, nil
+}

--- a/pkg/registry/v1alpha1store/migrations/009_controller_foundations.sql
+++ b/pkg/registry/v1alpha1store/migrations/009_controller_foundations.sql
@@ -1,0 +1,157 @@
+-- Controller foundations for the KRT-backed reconciliation model.
+--
+-- `control_plane_events` is a durable invalidation cursor, not audit history.
+-- Source-row writes append compact identity events and emit one coarse wakeup
+-- notification. Projectors replay events by revision and re-read canonical
+-- source tables; if retained events no longer cover a checkpoint, they must
+-- full-resync from canonical tables.
+
+CREATE TABLE IF NOT EXISTS v1alpha1.control_plane_events (
+    revision     BIGSERIAL    PRIMARY KEY,
+    kind         TEXT         NOT NULL,
+    namespace    VARCHAR(255) NOT NULL,
+    name         VARCHAR(255) NOT NULL,
+    tag          VARCHAR(255) NOT NULL DEFAULT '',
+    uid          UUID         NOT NULL,
+    generation   BIGINT       NOT NULL,
+    op           TEXT         NOT NULL CHECK (op IN ('insert', 'update', 'delete')),
+    committed_at TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS control_plane_events_committed_at
+    ON v1alpha1.control_plane_events (committed_at, revision);
+CREATE INDEX IF NOT EXISTS control_plane_events_identity
+    ON v1alpha1.control_plane_events (kind, namespace, name, tag, generation);
+
+CREATE OR REPLACE FUNCTION v1alpha1.record_control_plane_event()
+RETURNS TRIGGER AS $$
+DECLARE
+    event_kind TEXT := TG_ARGV[0];
+    event_op TEXT;
+    event_revision BIGINT;
+    row_json JSONB;
+BEGIN
+    IF TG_OP = 'UPDATE' THEN
+        -- Status-only writes already have their own public watch channel. They
+        -- do not invalidate source collections and must not wake KRT projectors.
+        IF NEW.spec IS NOT DISTINCT FROM OLD.spec
+           AND NEW.labels IS NOT DISTINCT FROM OLD.labels
+           AND NEW.annotations IS NOT DISTINCT FROM OLD.annotations
+           AND NEW.deletion_timestamp IS NOT DISTINCT FROM OLD.deletion_timestamp
+           AND to_jsonb(NEW)->'finalizers' IS NOT DISTINCT FROM to_jsonb(OLD)->'finalizers' THEN
+            RETURN NEW;
+        END IF;
+        event_op := 'update';
+        row_json := to_jsonb(NEW);
+    ELSIF TG_OP = 'DELETE' THEN
+        event_op := 'delete';
+        row_json := to_jsonb(OLD);
+    ELSE
+        event_op := 'insert';
+        row_json := to_jsonb(NEW);
+    END IF;
+
+    INSERT INTO v1alpha1.control_plane_events (
+        kind,
+        namespace,
+        name,
+        tag,
+        uid,
+        generation,
+        op
+    ) VALUES (
+        event_kind,
+        row_json->>'namespace',
+        row_json->>'name',
+        COALESCE(row_json->>'tag', ''),
+        (row_json->>'uid')::uuid,
+        (row_json->>'generation')::bigint,
+        event_op
+    )
+    RETURNING revision INTO event_revision;
+
+    PERFORM pg_notify(
+        'v1alpha1_control_plane_changed',
+        json_build_object('revision', event_revision)::text
+    );
+
+    IF TG_OP = 'DELETE' THEN
+        RETURN OLD;
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE TRIGGER agents_control_plane_event
+    AFTER INSERT OR UPDATE OR DELETE ON v1alpha1.agents
+    FOR EACH ROW EXECUTE FUNCTION v1alpha1.record_control_plane_event('Agent');
+CREATE OR REPLACE TRIGGER mcp_servers_control_plane_event
+    AFTER INSERT OR UPDATE OR DELETE ON v1alpha1.mcp_servers
+    FOR EACH ROW EXECUTE FUNCTION v1alpha1.record_control_plane_event('MCPServer');
+CREATE OR REPLACE TRIGGER skills_control_plane_event
+    AFTER INSERT OR UPDATE OR DELETE ON v1alpha1.skills
+    FOR EACH ROW EXECUTE FUNCTION v1alpha1.record_control_plane_event('Skill');
+CREATE OR REPLACE TRIGGER prompts_control_plane_event
+    AFTER INSERT OR UPDATE OR DELETE ON v1alpha1.prompts
+    FOR EACH ROW EXECUTE FUNCTION v1alpha1.record_control_plane_event('Prompt');
+CREATE OR REPLACE TRIGGER runtimes_control_plane_event
+    AFTER INSERT OR UPDATE OR DELETE ON v1alpha1.runtimes
+    FOR EACH ROW EXECUTE FUNCTION v1alpha1.record_control_plane_event('Runtime');
+CREATE OR REPLACE TRIGGER deployments_control_plane_event
+    AFTER INSERT OR UPDATE OR DELETE ON v1alpha1.deployments
+    FOR EACH ROW EXECUTE FUNCTION v1alpha1.record_control_plane_event('Deployment');
+
+CREATE TABLE IF NOT EXISTS v1alpha1.reconcile_work (
+    key             TEXT        PRIMARY KEY,
+    kind            TEXT        NOT NULL,
+    namespace       TEXT        NOT NULL,
+    name            TEXT        NOT NULL,
+    tag             TEXT        NOT NULL DEFAULT '',
+    uid             UUID,
+    generation      BIGINT      NOT NULL,
+    action          TEXT        NOT NULL,
+    reason          TEXT        NOT NULL DEFAULT '',
+    payload         JSONB       NOT NULL DEFAULT '{}'::jsonb,
+    state           TEXT        NOT NULL DEFAULT 'pending'
+                                CHECK (state IN ('pending', 'running', 'backoff', 'completed', 'abandoned')),
+    attempt         INTEGER     NOT NULL DEFAULT 0,
+    next_attempt_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    lease_owner     TEXT,
+    lease_until     TIMESTAMPTZ,
+    last_error      TEXT,
+    completed_at    TIMESTAMPTZ,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS reconcile_work_due
+    ON v1alpha1.reconcile_work (state, next_attempt_at, lease_until, key);
+CREATE INDEX IF NOT EXISTS reconcile_work_identity
+    ON v1alpha1.reconcile_work (kind, namespace, name, tag, generation, action);
+
+CREATE OR REPLACE TRIGGER reconcile_work_set_updated_at
+    BEFORE UPDATE ON v1alpha1.reconcile_work
+    FOR EACH ROW EXECUTE FUNCTION v1alpha1.set_updated_at();
+
+CREATE TABLE IF NOT EXISTS v1alpha1.reconcile_events (
+    id              BIGSERIAL   PRIMARY KEY,
+    work_key        TEXT        NOT NULL,
+    kind            TEXT        NOT NULL,
+    namespace       TEXT        NOT NULL,
+    name            TEXT        NOT NULL,
+    tag             TEXT        NOT NULL DEFAULT '',
+    uid             UUID,
+    generation      BIGINT      NOT NULL,
+    action          TEXT        NOT NULL,
+    attempt         INTEGER     NOT NULL DEFAULT 0,
+    outcome         TEXT        NOT NULL,
+    message         TEXT        NOT NULL DEFAULT '',
+    error           TEXT        NOT NULL DEFAULT '',
+    next_attempt_at TIMESTAMPTZ,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS reconcile_events_work_key_created
+    ON v1alpha1.reconcile_events (work_key, created_at DESC, id DESC);
+CREATE INDEX IF NOT EXISTS reconcile_events_identity_created
+    ON v1alpha1.reconcile_events (kind, namespace, name, tag, generation, action, created_at DESC);

--- a/pkg/registry/v1alpha1store/reconcile_store.go
+++ b/pkg/registry/v1alpha1store/reconcile_store.go
@@ -1,0 +1,453 @@
+package v1alpha1store
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+const defaultWorkBatchLimit = 100
+
+// ReconcileWork is durable, current coordination state. It is intentionally
+// separate from ReconcileEvent history.
+type ReconcileWork struct {
+	Key           string
+	Resource      ResourceKey
+	UID           string
+	Generation    int64
+	Action        string
+	Reason        string
+	Payload       json.RawMessage
+	State         string
+	Attempt       int
+	NextAttemptAt time.Time
+	LeaseOwner    string
+	LeaseUntil    *time.Time
+	LastError     string
+	CompletedAt   *time.Time
+	CreatedAt     time.Time
+	UpdatedAt     time.Time
+}
+
+// ReconcileWorkStore owns durable work claims and leases.
+type ReconcileWorkStore struct {
+	pool *pgxpool.Pool
+}
+
+// NewReconcileWorkStore constructs a reconcile work store.
+func NewReconcileWorkStore(pool *pgxpool.Pool) *ReconcileWorkStore {
+	return &ReconcileWorkStore{pool: pool}
+}
+
+// Upsert inserts or coalesces work for the same key. Existing running/backoff
+// state is reset to pending only when the requested generation/action key is the
+// same durable work item being refreshed.
+func (s *ReconcileWorkStore) Upsert(ctx context.Context, work ReconcileWork) error {
+	if s == nil || s.pool == nil {
+		return errors.New("v1alpha1 store: reconcile work store has nil pool")
+	}
+	if work.Key == "" || work.Resource.Kind == "" || work.Resource.Namespace == "" || work.Resource.Name == "" || work.Action == "" {
+		return errors.New("v1alpha1 store: reconcile work key, resource identity, and action are required")
+	}
+	if work.Generation <= 0 {
+		return errors.New("v1alpha1 store: reconcile work generation must be positive")
+	}
+	if len(work.Payload) == 0 {
+		work.Payload = json.RawMessage(`{}`)
+	}
+	if work.NextAttemptAt.IsZero() {
+		work.NextAttemptAt = time.Now().UTC()
+	}
+	_, err := s.pool.Exec(ctx, `
+		INSERT INTO v1alpha1.reconcile_work (
+			key, kind, namespace, name, tag, uid, generation, action, reason, payload, state, next_attempt_at
+		) VALUES (
+			$1, $2, $3, $4, $5, NULLIF($6, '')::uuid, $7, $8, $9, $10, 'pending', $11
+		)
+		ON CONFLICT (key) DO UPDATE
+		SET kind = EXCLUDED.kind,
+		    namespace = EXCLUDED.namespace,
+		    name = EXCLUDED.name,
+		    tag = EXCLUDED.tag,
+		    uid = EXCLUDED.uid,
+		    generation = EXCLUDED.generation,
+		    action = EXCLUDED.action,
+		    reason = EXCLUDED.reason,
+		    payload = EXCLUDED.payload,
+		    state = 'pending',
+		    next_attempt_at = LEAST(v1alpha1.reconcile_work.next_attempt_at, EXCLUDED.next_attempt_at),
+		    lease_owner = NULL,
+		    lease_until = NULL,
+		    completed_at = NULL,
+		    last_error = NULL`,
+		work.Key,
+		work.Resource.Kind,
+		work.Resource.Namespace,
+		work.Resource.Name,
+		work.Resource.Tag,
+		work.UID,
+		work.Generation,
+		work.Action,
+		work.Reason,
+		[]byte(work.Payload),
+		work.NextAttemptAt,
+	)
+	if err != nil {
+		return fmt.Errorf("upsert reconcile work: %w", err)
+	}
+	return nil
+}
+
+// ClaimDue claims currently due work using row locks so multiple workers can
+// race safely. Expired running leases are claimable again.
+func (s *ReconcileWorkStore) ClaimDue(ctx context.Context, owner string, leaseUntil time.Time, limit int) ([]ReconcileWork, error) {
+	if s == nil || s.pool == nil {
+		return nil, errors.New("v1alpha1 store: reconcile work store has nil pool")
+	}
+	if owner == "" {
+		return nil, errors.New("v1alpha1 store: reconcile work lease owner is required")
+	}
+	if leaseUntil.IsZero() {
+		return nil, errors.New("v1alpha1 store: reconcile work lease_until is required")
+	}
+	if limit <= 0 {
+		limit = defaultWorkBatchLimit
+	}
+	rows, err := s.pool.Query(ctx, `
+		WITH due AS (
+			SELECT key
+			FROM v1alpha1.reconcile_work
+			WHERE (
+				state IN ('pending', 'backoff')
+				AND next_attempt_at <= NOW()
+			) OR (
+				state = 'running'
+				AND lease_until < NOW()
+			)
+			ORDER BY next_attempt_at, key
+			FOR UPDATE SKIP LOCKED
+			LIMIT $1
+		)
+		UPDATE v1alpha1.reconcile_work w
+		SET state = 'running',
+		    lease_owner = $2,
+		    lease_until = $3,
+		    attempt = w.attempt + 1,
+		    last_error = NULL
+		FROM due
+		WHERE w.key = due.key
+		RETURNING w.key, w.kind, w.namespace, w.name, w.tag, COALESCE(w.uid::text, ''),
+		          w.generation, w.action, w.reason, w.payload, w.state, w.attempt,
+		          w.next_attempt_at, w.lease_owner, w.lease_until, w.last_error,
+		          w.completed_at, w.created_at, w.updated_at`,
+		limit, owner, leaseUntil)
+	if err != nil {
+		return nil, fmt.Errorf("claim reconcile work: %w", err)
+	}
+	defer rows.Close()
+
+	var out []ReconcileWork
+	for rows.Next() {
+		work, err := scanReconcileWork(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, work)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("read claimed reconcile work: %w", err)
+	}
+	return out, nil
+}
+
+// Complete deletes work after the caller has recorded its outcome in
+// reconcile_events. A missing key is a no-op, which keeps executor retries
+// idempotent around crash recovery.
+func (s *ReconcileWorkStore) Complete(ctx context.Context, key string) error {
+	if s == nil || s.pool == nil {
+		return errors.New("v1alpha1 store: reconcile work store has nil pool")
+	}
+	if key == "" {
+		return errors.New("v1alpha1 store: reconcile work key is required")
+	}
+	if _, err := s.pool.Exec(ctx, `DELETE FROM v1alpha1.reconcile_work WHERE key=$1`, key); err != nil {
+		return fmt.Errorf("complete reconcile work: %w", err)
+	}
+	return nil
+}
+
+// Backoff releases a claim and makes the work due again at nextAttemptAt.
+func (s *ReconcileWorkStore) Backoff(ctx context.Context, key, lastError string, nextAttemptAt time.Time) error {
+	if s == nil || s.pool == nil {
+		return errors.New("v1alpha1 store: reconcile work store has nil pool")
+	}
+	if key == "" {
+		return errors.New("v1alpha1 store: reconcile work key is required")
+	}
+	if nextAttemptAt.IsZero() {
+		return errors.New("v1alpha1 store: reconcile work next_attempt_at is required")
+	}
+	_, err := s.pool.Exec(ctx, `
+		UPDATE v1alpha1.reconcile_work
+		SET state='backoff',
+		    next_attempt_at=$2,
+		    lease_owner=NULL,
+		    lease_until=NULL,
+		    last_error=$3
+		WHERE key=$1`, key, nextAttemptAt, lastError)
+	if err != nil {
+		return fmt.Errorf("backoff reconcile work: %w", err)
+	}
+	return nil
+}
+
+// Prune removes completed or abandoned rows in bounded batches. Pending,
+// running, and backoff rows remain actionable and are never pruned here.
+func (s *ReconcileWorkStore) Prune(ctx context.Context, before time.Time, limit int) (int64, error) {
+	if s == nil || s.pool == nil {
+		return 0, errors.New("v1alpha1 store: reconcile work store has nil pool")
+	}
+	if before.IsZero() {
+		return 0, errors.New("v1alpha1 store: reconcile work prune requires an age bound")
+	}
+	if limit <= 0 {
+		limit = defaultWorkBatchLimit
+	}
+	cmdTag, err := s.pool.Exec(ctx, `
+		WITH doomed AS (
+			SELECT key
+			FROM v1alpha1.reconcile_work
+			WHERE state IN ('completed', 'abandoned')
+			  AND COALESCE(completed_at, updated_at) < $1
+			ORDER BY COALESCE(completed_at, updated_at), key
+			LIMIT $2
+		)
+		DELETE FROM v1alpha1.reconcile_work w
+		USING doomed
+		WHERE w.key = doomed.key`, before, limit)
+	if err != nil {
+		return 0, fmt.Errorf("prune reconcile work: %w", err)
+	}
+	return cmdTag.RowsAffected(), nil
+}
+
+// ReconcileEvent is append-only-ish operational history. It may be pruned by
+// policy, but it is never used as source-of-truth desired state.
+type ReconcileEvent struct {
+	ID            int64
+	WorkKey       string
+	Resource      ResourceKey
+	UID           string
+	Generation    int64
+	Action        string
+	Attempt       int
+	Outcome       string
+	Message       string
+	Error         string
+	NextAttemptAt *time.Time
+	CreatedAt     time.Time
+}
+
+// ReconcileEventStore owns attempt history.
+type ReconcileEventStore struct {
+	pool *pgxpool.Pool
+}
+
+// NewReconcileEventStore constructs a reconcile event store.
+func NewReconcileEventStore(pool *pgxpool.Pool) *ReconcileEventStore {
+	return &ReconcileEventStore{pool: pool}
+}
+
+// Append records one reconcile attempt/outcome.
+func (s *ReconcileEventStore) Append(ctx context.Context, event ReconcileEvent) (int64, error) {
+	if s == nil || s.pool == nil {
+		return 0, errors.New("v1alpha1 store: reconcile event store has nil pool")
+	}
+	if event.WorkKey == "" || event.Resource.Kind == "" || event.Resource.Namespace == "" || event.Resource.Name == "" || event.Action == "" || event.Outcome == "" {
+		return 0, errors.New("v1alpha1 store: reconcile event work key, identity, action, and outcome are required")
+	}
+	if event.Generation <= 0 {
+		return 0, errors.New("v1alpha1 store: reconcile event generation must be positive")
+	}
+	var id int64
+	err := s.pool.QueryRow(ctx, `
+		INSERT INTO v1alpha1.reconcile_events (
+			work_key, kind, namespace, name, tag, uid, generation, action,
+			attempt, outcome, message, error, next_attempt_at
+		) VALUES (
+			$1, $2, $3, $4, $5, NULLIF($6, '')::uuid, $7, $8,
+			$9, $10, $11, $12, $13
+		)
+		RETURNING id`,
+		event.WorkKey,
+		event.Resource.Kind,
+		event.Resource.Namespace,
+		event.Resource.Name,
+		event.Resource.Tag,
+		event.UID,
+		event.Generation,
+		event.Action,
+		event.Attempt,
+		event.Outcome,
+		event.Message,
+		event.Error,
+		event.NextAttemptAt,
+	).Scan(&id)
+	if err != nil {
+		return 0, fmt.Errorf("append reconcile event: %w", err)
+	}
+	return id, nil
+}
+
+// ListByWorkKey returns recent history for one work key.
+func (s *ReconcileEventStore) ListByWorkKey(ctx context.Context, workKey string, limit int) ([]ReconcileEvent, error) {
+	if s == nil || s.pool == nil {
+		return nil, errors.New("v1alpha1 store: reconcile event store has nil pool")
+	}
+	if workKey == "" {
+		return nil, errors.New("v1alpha1 store: reconcile event work key is required")
+	}
+	if limit <= 0 {
+		limit = defaultWorkBatchLimit
+	}
+	rows, err := s.pool.Query(ctx, `
+		SELECT id, work_key, kind, namespace, name, tag, COALESCE(uid::text, ''),
+		       generation, action, attempt, outcome, message, error, next_attempt_at, created_at
+		FROM v1alpha1.reconcile_events
+		WHERE work_key=$1
+		ORDER BY created_at DESC, id DESC
+		LIMIT $2`, workKey, limit)
+	if err != nil {
+		return nil, fmt.Errorf("list reconcile events: %w", err)
+	}
+	defer rows.Close()
+
+	var out []ReconcileEvent
+	for rows.Next() {
+		event, err := scanReconcileEvent(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, event)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("read reconcile events: %w", err)
+	}
+	return out, nil
+}
+
+// Prune deletes old reconcile history in bounded batches.
+func (s *ReconcileEventStore) Prune(ctx context.Context, before time.Time, limit int) (int64, error) {
+	if s == nil || s.pool == nil {
+		return 0, errors.New("v1alpha1 store: reconcile event store has nil pool")
+	}
+	if before.IsZero() {
+		return 0, errors.New("v1alpha1 store: reconcile event prune requires an age bound")
+	}
+	if limit <= 0 {
+		limit = defaultWorkBatchLimit
+	}
+	cmdTag, err := s.pool.Exec(ctx, `
+		WITH doomed AS (
+			SELECT id
+			FROM v1alpha1.reconcile_events
+			WHERE created_at < $1
+			ORDER BY created_at, id
+			LIMIT $2
+		)
+		DELETE FROM v1alpha1.reconcile_events e
+		USING doomed
+		WHERE e.id = doomed.id`, before, limit)
+	if err != nil {
+		return 0, fmt.Errorf("prune reconcile events: %w", err)
+	}
+	return cmdTag.RowsAffected(), nil
+}
+
+func scanReconcileWork(row pgx.Row) (ReconcileWork, error) {
+	var (
+		work        ReconcileWork
+		leaseUntil  sql.NullTime
+		completedAt sql.NullTime
+		payload     []byte
+		uid         string
+		leaseOwner  sql.NullString
+		lastError   sql.NullString
+	)
+	if err := row.Scan(
+		&work.Key,
+		&work.Resource.Kind,
+		&work.Resource.Namespace,
+		&work.Resource.Name,
+		&work.Resource.Tag,
+		&uid,
+		&work.Generation,
+		&work.Action,
+		&work.Reason,
+		&payload,
+		&work.State,
+		&work.Attempt,
+		&work.NextAttemptAt,
+		&leaseOwner,
+		&leaseUntil,
+		&lastError,
+		&completedAt,
+		&work.CreatedAt,
+		&work.UpdatedAt,
+	); err != nil {
+		return ReconcileWork{}, fmt.Errorf("scan reconcile work: %w", err)
+	}
+	work.UID = uid
+	work.Payload = append(json.RawMessage(nil), payload...)
+	if leaseOwner.Valid {
+		work.LeaseOwner = leaseOwner.String
+	}
+	if leaseUntil.Valid {
+		work.LeaseUntil = &leaseUntil.Time
+	}
+	if lastError.Valid {
+		work.LastError = lastError.String
+	}
+	if completedAt.Valid {
+		work.CompletedAt = &completedAt.Time
+	}
+	return work, nil
+}
+
+func scanReconcileEvent(row pgx.Row) (ReconcileEvent, error) {
+	var (
+		event         ReconcileEvent
+		uid           string
+		nextAttemptAt sql.NullTime
+	)
+	if err := row.Scan(
+		&event.ID,
+		&event.WorkKey,
+		&event.Resource.Kind,
+		&event.Resource.Namespace,
+		&event.Resource.Name,
+		&event.Resource.Tag,
+		&uid,
+		&event.Generation,
+		&event.Action,
+		&event.Attempt,
+		&event.Outcome,
+		&event.Message,
+		&event.Error,
+		&nextAttemptAt,
+		&event.CreatedAt,
+	); err != nil {
+		return ReconcileEvent{}, fmt.Errorf("scan reconcile event: %w", err)
+	}
+	event.UID = uid
+	if nextAttemptAt.Valid {
+		event.NextAttemptAt = &nextAttemptAt.Time
+	}
+	return event, nil
+}

--- a/pkg/registry/v1alpha1store/store_test.go
+++ b/pkg/registry/v1alpha1store/store_test.go
@@ -563,3 +563,110 @@ func TestStore_NotifyPayloadDiscreteFields(t *testing.T) {
 		"name must round-trip intact, including the / character")
 	require.Equal(t, DefaultTag(), payload.Tag, "tag emitted as the default latest tag")
 }
+
+func TestStore_ControlPlaneEventsTrackSourceWritesOnly(t *testing.T) {
+	pool := NewTestPool(t)
+	store := NewStore(pool, testTable)
+	events := NewControlPlaneEventStore(pool)
+	ctx := context.Background()
+
+	_, err := store.Upsert(ctx, &v1alpha1.Agent{
+		Metadata: v1alpha1.ObjectMeta{Namespace: testNS, Name: "evented"},
+		Spec:     v1alpha1.AgentSpec{Title: "first"},
+	})
+	require.NoError(t, err)
+
+	batch, err := events.ListAfter(ctx, 0, 10)
+	require.NoError(t, err)
+	require.NotEmpty(t, batch)
+	insert := batch[len(batch)-1]
+	require.Equal(t, v1alpha1.KindAgent, insert.Key.Kind)
+	require.Equal(t, testNS, insert.Key.Namespace)
+	require.Equal(t, "evented", insert.Key.Name)
+	require.Equal(t, DefaultTag(), insert.Key.Tag)
+	require.Equal(t, "insert", insert.Operation)
+
+	err = store.PatchStatus(ctx, testNS, "evented", DefaultTag(), v1alpha1.StatusPatcher(func(s *v1alpha1.Status) {
+		s.SetCondition(v1alpha1.Condition{Type: "Ready", Status: v1alpha1.ConditionTrue})
+	}))
+	require.NoError(t, err)
+	batch, err = events.ListAfter(ctx, insert.Revision, 10)
+	require.NoError(t, err)
+	require.Empty(t, batch, "status-only patches must not invalidate controller source collections")
+
+	_, err = store.Upsert(ctx, &v1alpha1.Agent{
+		Metadata: v1alpha1.ObjectMeta{Namespace: testNS, Name: "evented"},
+		Spec:     v1alpha1.AgentSpec{Title: "second"},
+	})
+	require.NoError(t, err)
+	batch, err = events.ListAfter(ctx, insert.Revision, 10)
+	require.NoError(t, err)
+	require.Len(t, batch, 1)
+	require.Equal(t, "update", batch[0].Operation)
+	require.Equal(t, int64(2), batch[0].Generation)
+
+	require.NoError(t, store.Delete(ctx, testNS, "evented", DefaultTag()))
+	batch, err = events.ListAfter(ctx, batch[0].Revision, 10)
+	require.NoError(t, err)
+	require.Len(t, batch, 1)
+	require.Equal(t, "delete", batch[0].Operation)
+}
+
+func TestReconcileWorkStore_ClaimBackoffEventAndComplete(t *testing.T) {
+	pool := NewTestPool(t)
+	ctx := context.Background()
+	workStore := NewReconcileWorkStore(pool)
+	eventStore := NewReconcileEventStore(pool)
+
+	work := ReconcileWork{
+		Key:           "Deployment:default:weather:uid-1:1:apply",
+		Resource:      ResourceKey{Kind: v1alpha1.KindDeployment, Namespace: testNS, Name: "weather"},
+		Generation:    1,
+		Action:        "apply",
+		Reason:        "desired-deployed",
+		Payload:       json.RawMessage(`{"targetRef":{"kind":"MCPServer","name":"weather"}}`),
+		NextAttemptAt: time.Now().Add(-time.Minute),
+	}
+	require.NoError(t, workStore.Upsert(ctx, work))
+
+	claimed, err := workStore.ClaimDue(ctx, "worker-a", time.Now().Add(time.Minute), 10)
+	require.NoError(t, err)
+	require.Len(t, claimed, 1)
+	require.Equal(t, work.Key, claimed[0].Key)
+	require.Equal(t, "running", claimed[0].State)
+	require.Equal(t, 1, claimed[0].Attempt)
+	require.Equal(t, "worker-a", claimed[0].LeaseOwner)
+
+	claimed, err = workStore.ClaimDue(ctx, "worker-b", time.Now().Add(time.Minute), 10)
+	require.NoError(t, err)
+	require.Empty(t, claimed, "non-expired running leases must not double-claim")
+
+	require.NoError(t, workStore.Backoff(ctx, work.Key, "temporary", time.Now().Add(-time.Second)))
+	claimed, err = workStore.ClaimDue(ctx, "worker-b", time.Now().Add(time.Minute), 10)
+	require.NoError(t, err)
+	require.Len(t, claimed, 1)
+	require.Equal(t, 2, claimed[0].Attempt)
+	require.Equal(t, "worker-b", claimed[0].LeaseOwner)
+
+	id, err := eventStore.Append(ctx, ReconcileEvent{
+		WorkKey:    work.Key,
+		Resource:   work.Resource,
+		Generation: work.Generation,
+		Action:     work.Action,
+		Attempt:    claimed[0].Attempt,
+		Outcome:    "success",
+		Message:    "claimed work completed",
+	})
+	require.NoError(t, err)
+	require.NotZero(t, id)
+
+	history, err := eventStore.ListByWorkKey(ctx, work.Key, 10)
+	require.NoError(t, err)
+	require.Len(t, history, 1)
+	require.Equal(t, "success", history[0].Outcome)
+
+	require.NoError(t, workStore.Complete(ctx, work.Key))
+	claimed, err = workStore.ClaimDue(ctx, "worker-c", time.Now().Add(time.Minute), 10)
+	require.NoError(t, err)
+	require.Empty(t, claimed)
+}


### PR DESCRIPTION
# Description

Adds the first behavior-preserving OSS KRT controller substrate:

- durable `control_plane_events` migration, coarse wakeup trigger, retention/pruning API, and projector gap-detection/full-resync skeleton
- durable `reconcile_work` claims/leases plus `reconcile_events` attempt history stores
- pure Deployment reconcile work derivation for apply/remove intent without adapter side effects
- focused unit and migration-backed store tests for event invalidation, work claiming, event history, and Deployment request derivation

This intentionally does not wire Deployment adapters or replace the existing synchronous hooks. That remains the next PR behind an executor flag.

# Change Type

/kind feature

# Changelog

```release-note
NONE
```

# Additional Notes

Verification run locally:

- `go test ./...`
- `go test -tags=integration ./pkg/registry/v1alpha1store -run 'TestStore_ControlPlaneEventsTrackSourceWritesOnly|TestReconcileWorkStore_ClaimBackoffEventAndComplete' -count=1` against a temporary Postgres container
- `make lint`
- `make test` passed; DB-backed integration tests skipped when no localhost Postgres was running
