### PR TITLE
makefile: evaluate $(shell ...) vars once instead of per-reference

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,20 @@
 # https://www.gnu.org/software/make/manual/html_node/Special-Variables.html#Special-Variables
 .DEFAULT_GOAL := help
 
-# Load .env into make's variable scope if it exists
+# Load .env into make's variable scope if it exists. Only variables actually
+# defined in .env are exported to recipes; bare `export` would export every
+# Makefile variable, which forces Make to re-evaluate all recursively-defined
+# $(shell ...) variables on every recipe invocation.
+#
+# Surrounding double quotes are stripped from .env values: `include .env`
+# keeps quotes as part of the value, whereas `source .env` in a shell would
+# strip them. Without this, lines like FOO="bar" leak the literal quotes
+# into child processes.
 ifneq (,$(wildcard .env))
   include .env
-  export
+  ENV_VARS := $(shell grep -v '^\s*\#' .env | grep -v '^\s*$$' | sed 's/=.*//')
+  $(foreach v,$(ENV_VARS),$(eval $(v) := $(patsubst "%,%,$(patsubst %",%,$($(v))))))
+  $(foreach v,$(ENV_VARS),$(eval export $(v)))
 endif
 
 # Image configuration

--- a/Makefile
+++ b/Makefile
@@ -21,11 +21,19 @@ OUTDIR ?= _output
 # DOCKER_REGISTRY (localhost:5001) is kept for helm chart image references.
 DOCKER_BUILD_REGISTRY ?= kind-registry:5000
 DOCKER_BUILD_ARGS ?= --push --platform linux/$(LOCALARCH)
-BUILD_DATE ?= $(shell date -u '+%Y-%m-%d')
-GIT_COMMIT ?= $(shell git rev-parse --short HEAD || echo "unknown")
-VERSION ?= $(shell git describe --tags --always 2>/dev/null | grep v || echo "v0.0.0-g$(GIT_COMMIT)")
+ifndef BUILD_DATE
+BUILD_DATE := $(shell date -u '+%Y-%m-%d')
+endif
+ifndef GIT_COMMIT
+GIT_COMMIT := $(shell git rev-parse --short HEAD || echo "unknown")
+endif
+ifndef VERSION
+VERSION := $(shell git describe --tags --always 2>/dev/null | grep v || echo "v0.0.0-g$(GIT_COMMIT)")
+endif
 KAGENT_VERSION ?= v0.8.0-beta6
-KAGENT_HELM_VERSION ?= $(shell echo $(KAGENT_VERSION) | sed 's/^v//')
+ifndef KAGENT_HELM_VERSION
+KAGENT_HELM_VERSION := $(shell echo $(KAGENT_VERSION) | sed 's/^v//')
+endif
 KAGENT_NAMESPACE ?= kagent
 KAGENT_HELM_CHART_CRDS ?= oci://ghcr.io/kagent-dev/kagent/helm/kagent-crds
 KAGENT_HELM_CHART ?= oci://ghcr.io/kagent-dev/kagent/helm/kagent
@@ -43,7 +51,9 @@ LDFLAGS := \
 	-X 'github.com/agentregistry-dev/agentregistry/internal/version.DockerRegistry=$(DOCKER_REGISTRY)'
 
 # Local architecture detection to build for the current platform
-LOCALARCH ?= $(shell uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/')
+ifndef LOCALARCH
+LOCALARCH := $(shell uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/')
+endif
 
 # Developer tools (golangci-lint, gotestsum, kind) are pinned in tools/go.mod
 # and invoked via `go tool -modfile=tools/go.mod <name>`. This keeps their
@@ -58,7 +68,9 @@ KIND          ?= $(GO_TOOL) kind
 
 ## Helm / Chart settings
 # CHART_VERSION strips the leading 'v' from VERSION for use in Chart.yaml (Helm requires semver without the prefix).
-CHART_VERSION ?= $(shell echo $(VERSION) | sed 's/^v//')
+ifndef CHART_VERSION
+CHART_VERSION := $(shell echo $(VERSION) | sed 's/^v//')
+endif
 HELM_CHART_DIR ?= ./charts/agentregistry
 HELM_PACKAGE_DIR ?= build/charts
 HELM_REGISTRY ?= ghcr.io


### PR DESCRIPTION
# Description

`make verify` on macOS was taking 10+ minutes warm, vs ~1 minute in CI. Two related issues in the Makefile prologue were the cause:

**1. Bare `export` after `.env` include exports every Makefile variable.** Combined with recursively-defined `$(shell ...)` variables (`BUILD_DATE`, `GIT_COMMIT`, `VERSION`, `KAGENT_HELM_VERSION`, `LOCALARCH`, `CHART_VERSION`), every recipe re-evaluated the whole exported set, forking `git`, `date`, and `uname` thousands of times. `make --debug=v fmt` reported **29,284 variable re-expansions** for a single target — about ~58s of fork+exec overhead per recipe on macOS. Linux CI hides the regression because fork+exec is ~10× cheaper there.

**2. Recursive `?= $(shell …)` definitions** also re-fork on every reference within a recipe (e.g. `LDFLAGS` references `$(VERSION)` and `$(GIT_COMMIT)` separately), even without the bare-export amplification.

## Fixes

- Switched the `.env` loader to the same selective-export pattern used by `agentregistry-enterprise`: parse `.env` once, strip surrounding double quotes from each value, then `export` only those variables.
- Wrapped each `$(shell …)` definition in `ifndef … := … endif`, so each shell call runs exactly once per `make` process. Preserves env-override semantics (CI can still inject `VERSION=…`, etc.).

Resolved variable values are unchanged — verified via `make -p`.

Local timings (warm caches):

| Target | Before | After |
| --- | --- | --- |
| `make fmt` | 60s | 3.8s |
| `make verify` | 10m 13s | 10.8s |

Quote stripping is an incidental robustness win: previously an `.env` line like `FOO="bar"` would leak the literal `"bar"` (with quotes) into child processes.

# Change Type

/kind fix

# Changelog

```release-note
NONE
```

# Additional Notes

`make --debug=v fmt 2>&1 | grep -c "not recursively expanding"` returns `0` after this change (was `29284`).
