### PR TITLE
use deployment name for get/delete deployments

### DIFF
--- a/internal/cli/declarative/declarative.go
+++ b/internal/cli/declarative/declarative.go
@@ -161,14 +161,14 @@ func init() {
 		Kind:    "deployment",
 		Plural:  "deployments",
 		Aliases: []string{"Deployment"},
-		Get: func(_ context.Context, name, _ string) (any, error) {
-			return getDeploymentByTarget(context.Background(), name)
+		Get: func(ctx context.Context, name, _ string) (any, error) {
+			return client.GetTyped(ctx, apiClient, v1alpha1.KindDeployment, v1alpha1.DefaultNamespace, name, "", func() *v1alpha1.Deployment { return &v1alpha1.Deployment{} })
 		},
-		Delete: func(_ context.Context, name, tag string, force bool) error {
-			return deleteDeploymentByTarget(context.Background(), name, tag, force)
+		Delete: func(ctx context.Context, name, tag string, force bool) error {
+			return deleteAny(ctx, v1alpha1.KindDeployment, name, tag, force, func() *v1alpha1.Deployment { return &v1alpha1.Deployment{} })
 		},
-		ListFunc: func(_ context.Context, _ scheme.ListOpts) ([]any, error) {
-			return listDeploymentAny(context.Background())
+		ListFunc: func(ctx context.Context, _ scheme.ListOpts) ([]any, error) {
+			return listDeploymentAny(ctx)
 		},
 		RowFunc: func(item any) []string {
 			deployment, ok := item.(*cliCommon.DeploymentRecord)

--- a/internal/cli/declarative/declarative.go
+++ b/internal/cli/declarative/declarative.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/agentregistry-dev/agentregistry/internal/cli/common"
 	cliCommon "github.com/agentregistry-dev/agentregistry/internal/cli/common"
 	"github.com/agentregistry-dev/agentregistry/internal/cli/scheme"
 	"github.com/agentregistry-dev/agentregistry/internal/client"
@@ -162,7 +163,11 @@ func init() {
 		Plural:  "deployments",
 		Aliases: []string{"Deployment"},
 		Get: func(ctx context.Context, name, _ string) (any, error) {
-			return client.GetTyped(ctx, apiClient, v1alpha1.KindDeployment, v1alpha1.DefaultNamespace, name, "", func() *v1alpha1.Deployment { return &v1alpha1.Deployment{} })
+			deployment, err := client.GetTyped(ctx, apiClient, v1alpha1.KindDeployment, v1alpha1.DefaultNamespace, name, "", func() *v1alpha1.Deployment { return &v1alpha1.Deployment{} })
+			if err != nil {
+				return nil, err
+			}
+			return common.DeploymentRecordFromObject(deployment), nil
 		},
 		Delete: func(ctx context.Context, name, tag string, force bool) error {
 			return deleteAny(ctx, v1alpha1.KindDeployment, name, tag, force, func() *v1alpha1.Deployment { return &v1alpha1.Deployment{} })

--- a/internal/cli/declarative/declarative.go
+++ b/internal/cli/declarative/declarative.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/agentregistry-dev/agentregistry/internal/cli/common"
 	cliCommon "github.com/agentregistry-dev/agentregistry/internal/cli/common"
 	"github.com/agentregistry-dev/agentregistry/internal/cli/scheme"
 	"github.com/agentregistry-dev/agentregistry/internal/client"
@@ -167,7 +166,7 @@ func init() {
 			if err != nil {
 				return nil, err
 			}
-			return common.DeploymentRecordFromObject(deployment), nil
+			return cliCommon.DeploymentRecordFromObject(deployment), nil
 		},
 		Delete: func(ctx context.Context, name, tag string, force bool) error {
 			return deleteAny(ctx, v1alpha1.KindDeployment, name, tag, force, func() *v1alpha1.Deployment { return &v1alpha1.Deployment{} })

--- a/internal/cli/declarative/deployment_delete_test.go
+++ b/internal/cli/declarative/deployment_delete_test.go
@@ -40,17 +40,16 @@ func deploymentTestServer(t *testing.T, list []v1alpha1.Deployment, failIDs map[
 	mux.HandleFunc("/v0/deployments/", func(w http.ResponseWriter, r *http.Request) {
 		path := strings.TrimPrefix(r.URL.Path, "/v0/deployments/")
 		parts := strings.Split(path, "/")
-		if len(parts) != 2 {
+		if len(parts) != 1 {
 			http.Error(w, `{"error":"bad get/delete path"}`, http.StatusBadRequest)
 			return
 		}
-		id := parts[0] + "/" + parts[1]
 		switch r.Method {
 		case http.MethodGet:
 			mu.Lock()
 			defer mu.Unlock()
 			for _, d := range list {
-				if d.Metadata.Name == id {
+				if d.Metadata.Name == parts[0] {
 					_ = json.NewEncoder(w).Encode(d)
 					return
 				}
@@ -59,10 +58,10 @@ func deploymentTestServer(t *testing.T, list []v1alpha1.Deployment, failIDs map[
 		case http.MethodDelete:
 			mu.Lock()
 			capturedQuery = append(capturedQuery, r.URL.RawQuery)
-			deleted = append(deleted, id)
+			deleted = append(deleted, parts[0])
 			mu.Unlock()
-			if failIDs[id] {
-				http.Error(w, fmt.Sprintf(`{"error":"simulated delete failure for %s"}`, id), http.StatusInternalServerError)
+			if failIDs[parts[0]] {
+				http.Error(w, fmt.Sprintf(`{"error":"simulated delete failure for %s"}`, parts[0]), http.StatusInternalServerError)
 				return
 			}
 			w.WriteHeader(http.StatusNoContent)
@@ -89,7 +88,7 @@ func setupClientForServer(t *testing.T, srv *httptest.Server) {
 // are left alone.
 func TestDeploymentDelete_RemovesNamedDeployment(t *testing.T) {
 	deployments := []v1alpha1.Deployment{
-		deploymentFixture("default/aws-v1", "summarizer", "1.0.0", "my-aws", "agent", "pending"),
+		deploymentFixture("aws-v1", "summarizer", "1.0.0", "my-aws", "agent", "pending"),
 		deploymentFixture("gcp-v1", "summarizer", "1.0.0", "my-gcp", "agent", "pending"),
 		deploymentFixture("aws-v2", "summarizer", "2.0.0", "my-aws", "agent", "pending"),
 		deploymentFixture("other", "unrelated", "1.0.0", "my-aws", "agent", "pending"),
@@ -98,23 +97,23 @@ func TestDeploymentDelete_RemovesNamedDeployment(t *testing.T) {
 	setupClientForServer(t, srv)
 
 	cmd := declarative.NewDeleteCmd()
-	cmd.SetArgs([]string{"deployment", "default/aws-v1"})
+	cmd.SetArgs([]string{"deployment", "aws-v1"})
 	require.NoError(t, cmd.Execute())
 
-	assert.ElementsMatch(t, []string{"default/aws-v1"}, *deleted,
+	assert.ElementsMatch(t, []string{"aws-v1"}, *deleted,
 		"every deployment targeting summarizer should be deleted; unrelated targets untouched")
 }
 
 // (2) When no deployment matches the target name, returns a not-found error.
 func TestDeploymentDelete_NotFound(t *testing.T) {
 	deployments := []v1alpha1.Deployment{
-		deploymentFixture("default/aws-v2", "other-target", "2.0.0", "my-aws", "agent", "pending"),
+		deploymentFixture("aws-v2", "other-target", "2.0.0", "my-aws", "agent", "pending"),
 	}
 	srv, deleted, _ := deploymentTestServer(t, deployments, nil)
 	setupClientForServer(t, srv)
 
 	cmd := declarative.NewDeleteCmd()
-	cmd.SetArgs([]string{"deployment", "default/summarizer"})
+	cmd.SetArgs([]string{"deployment", "summarizer"})
 	err := cmd.Execute()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not found",
@@ -124,21 +123,21 @@ func TestDeploymentDelete_NotFound(t *testing.T) {
 
 func TestDeploymentDelete_ServerFailure(t *testing.T) {
 	deployments := []v1alpha1.Deployment{
-		deploymentFixture("default/aws-v1", "summarizer", "1.0.0", "my-aws", "agent", "pending"),
-		deploymentFixture("default/gcp-v1", "summarizer", "1.0.0", "my-gcp", "agent", "pending"),
+		deploymentFixture("aws-v1", "summarizer", "1.0.0", "my-aws", "agent", "pending"),
+		deploymentFixture("gcp-v1", "summarizer", "1.0.0", "my-gcp", "agent", "pending"),
 	}
 	// Fail the GCP delete only.
-	srv, deleted, _ := deploymentTestServer(t, deployments, map[string]bool{"default/gcp-v1": true})
+	srv, deleted, _ := deploymentTestServer(t, deployments, map[string]bool{"gcp-v1": true})
 	setupClientForServer(t, srv)
 
 	cmd := declarative.NewDeleteCmd()
-	cmd.SetArgs([]string{"deployment", "default/gcp-v1"})
+	cmd.SetArgs([]string{"deployment", "gcp-v1"})
 	err := cmd.Execute()
 	require.Error(t, err, "failure must propagate")
-	assert.Contains(t, err.Error(), "default/gcp-v1", "error should identify which deployment failed")
+	assert.Contains(t, err.Error(), "gcp-v1", "error should identify which deployment failed")
 
 	// Both DELETEs should have been attempted — we don't stop on first failure.
-	assert.ElementsMatch(t, []string{"default/gcp-v1"}, *deleted)
+	assert.ElementsMatch(t, []string{"gcp-v1"}, *deleted)
 }
 
 // (4) --tag is rejected for deployments and runtimes: neither kind has a tag
@@ -159,14 +158,14 @@ func TestDelete_RejectsTagForDeploymentAndRuntime(t *testing.T) {
 // (5) --force sends ?force=true query param to the server.
 func TestDeploymentDelete_ForcePassesQueryParam(t *testing.T) {
 	deployments := []v1alpha1.Deployment{
-		deploymentFixture("default/aws-v1", "summarizer", "1.0.0", "my-aws", "agent", "deployed"),
+		deploymentFixture("aws-v1", "summarizer", "1.0.0", "my-aws", "agent", "deployed"),
 	}
 
 	srv, _, capturedForce := deploymentTestServer(t, deployments, map[string]bool{"default/gcp-v1": true})
 	setupClientForServer(t, srv)
 
 	cmd := declarative.NewDeleteCmd()
-	cmd.SetArgs([]string{"deployment", "default/aws-v1", "--force"})
+	cmd.SetArgs([]string{"deployment", "aws-v1", "--force"})
 	require.NoError(t, cmd.Execute())
 
 	require.Len(t, (*capturedForce), 1)
@@ -185,14 +184,14 @@ func TestDeploymentDelete_ForceWithFileReturnsError(t *testing.T) {
 // (7) Without --force, no ?force query param is sent.
 func TestDeploymentDelete_NoForceFlagOmitsQueryParam(t *testing.T) {
 	deployments := []v1alpha1.Deployment{
-		deploymentFixture("default/aws-v1", "summarizer", "1.0.0", "my-aws", "agent", "deployed"),
+		deploymentFixture("aws-v1", "summarizer", "1.0.0", "my-aws", "agent", "deployed"),
 	}
 
-	srv, _, capturedQuery := deploymentTestServer(t, deployments, map[string]bool{"default/gcp-v1": true})
+	srv, _, capturedQuery := deploymentTestServer(t, deployments, map[string]bool{"gcp-v1": true})
 	setupClientForServer(t, srv)
 
 	cmd := declarative.NewDeleteCmd()
-	cmd.SetArgs([]string{"deployment", "default/aws-v1"})
+	cmd.SetArgs([]string{"deployment", "aws-v1"})
 	require.NoError(t, cmd.Execute())
 
 	require.Len(t, *capturedQuery, 1)

--- a/internal/cli/declarative/deployment_delete_test.go
+++ b/internal/cli/declarative/deployment_delete_test.go
@@ -22,10 +22,11 @@ import (
 //   - DELETE /v0/deployments/{name}         → status 204 unless id is in `failIDs`, then 500
 //
 // Captures every received DELETE id in order for assertions.
-func deploymentTestServer(t *testing.T, list []v1alpha1.Deployment, failIDs map[string]bool) (*httptest.Server, *[]string) {
+func deploymentTestServer(t *testing.T, list []v1alpha1.Deployment, failIDs map[string]bool) (*httptest.Server, *[]string, *[]string) {
 	t.Helper()
 	var mu sync.Mutex
-	deleted := []string{}
+	deleted := make([]string, 0)
+	capturedQuery := make([]string, 0)
 	mux := http.NewServeMux()
 	mux.HandleFunc("/v0/deployments", func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method {
@@ -37,29 +38,42 @@ func deploymentTestServer(t *testing.T, list []v1alpha1.Deployment, failIDs map[
 		}
 	})
 	mux.HandleFunc("/v0/deployments/", func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodDelete {
+		path := strings.TrimPrefix(r.URL.Path, "/v0/deployments/")
+		parts := strings.Split(path, "/")
+		if len(parts) != 2 {
+			http.Error(w, `{"error":"bad get/delete path"}`, http.StatusBadRequest)
+			return
+		}
+		id := parts[0] + "/" + parts[1]
+		switch r.Method {
+		case http.MethodGet:
+			mu.Lock()
+			defer mu.Unlock()
+			for _, d := range list {
+				if d.Metadata.Name == id {
+					_ = json.NewEncoder(w).Encode(d)
+					return
+				}
+			}
+			w.WriteHeader(http.StatusNotFound)
+		case http.MethodDelete:
+			mu.Lock()
+			capturedQuery = append(capturedQuery, r.URL.RawQuery)
+			deleted = append(deleted, id)
+			mu.Unlock()
+			if failIDs[id] {
+				http.Error(w, fmt.Sprintf(`{"error":"simulated delete failure for %s"}`, id), http.StatusInternalServerError)
+				return
+			}
+			w.WriteHeader(http.StatusNoContent)
+		default:
 			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 			return
 		}
-		path := strings.TrimPrefix(r.URL.Path, "/v0/deployments/")
-		parts := strings.Split(path, "/")
-		if len(parts) != 1 {
-			http.Error(w, `{"error":"bad delete path"}`, http.StatusBadRequest)
-			return
-		}
-		id := v1alpha1.DefaultNamespace + "/" + parts[0]
-		mu.Lock()
-		deleted = append(deleted, id)
-		mu.Unlock()
-		if failIDs[id] {
-			http.Error(w, fmt.Sprintf(`{"error":"simulated delete failure for %s"}`, id), http.StatusInternalServerError)
-			return
-		}
-		w.WriteHeader(http.StatusNoContent)
 	})
 	srv := httptest.NewServer(mux)
 	t.Cleanup(srv.Close)
-	return srv, &deleted
+	return srv, &deleted, &capturedQuery
 }
 
 func setupClientForServer(t *testing.T, srv *httptest.Server) {
@@ -73,34 +87,34 @@ func setupClientForServer(t *testing.T, srv *httptest.Server) {
 // for that target — deployments don't carry a tag of their own, so the CLI
 // can't (and shouldn't) narrow the cut by target tag here. Unrelated targets
 // are left alone.
-func TestDeploymentDelete_RemovesAllMatchesByTargetName(t *testing.T) {
+func TestDeploymentDelete_RemovesNamedDeployment(t *testing.T) {
 	deployments := []v1alpha1.Deployment{
-		deploymentFixture("aws-v1", "summarizer", "1.0.0", "my-aws", "agent", "pending"),
+		deploymentFixture("default/aws-v1", "summarizer", "1.0.0", "my-aws", "agent", "pending"),
 		deploymentFixture("gcp-v1", "summarizer", "1.0.0", "my-gcp", "agent", "pending"),
 		deploymentFixture("aws-v2", "summarizer", "2.0.0", "my-aws", "agent", "pending"),
 		deploymentFixture("other", "unrelated", "1.0.0", "my-aws", "agent", "pending"),
 	}
-	srv, deleted := deploymentTestServer(t, deployments, nil)
+	srv, deleted, _ := deploymentTestServer(t, deployments, nil)
 	setupClientForServer(t, srv)
 
 	cmd := declarative.NewDeleteCmd()
-	cmd.SetArgs([]string{"deployment", "summarizer"})
+	cmd.SetArgs([]string{"deployment", "default/aws-v1"})
 	require.NoError(t, cmd.Execute())
 
-	assert.ElementsMatch(t, []string{"default/aws-v1", "default/gcp-v1", "default/aws-v2"}, *deleted,
+	assert.ElementsMatch(t, []string{"default/aws-v1"}, *deleted,
 		"every deployment targeting summarizer should be deleted; unrelated targets untouched")
 }
 
 // (2) When no deployment matches the target name, returns a not-found error.
 func TestDeploymentDelete_NotFound(t *testing.T) {
 	deployments := []v1alpha1.Deployment{
-		deploymentFixture("aws-v2", "other-target", "2.0.0", "my-aws", "agent", "pending"),
+		deploymentFixture("default/aws-v2", "other-target", "2.0.0", "my-aws", "agent", "pending"),
 	}
-	srv, deleted := deploymentTestServer(t, deployments, nil)
+	srv, deleted, _ := deploymentTestServer(t, deployments, nil)
 	setupClientForServer(t, srv)
 
 	cmd := declarative.NewDeleteCmd()
-	cmd.SetArgs([]string{"deployment", "summarizer"})
+	cmd.SetArgs([]string{"deployment", "default/summarizer"})
 	err := cmd.Execute()
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not found",
@@ -108,26 +122,23 @@ func TestDeploymentDelete_NotFound(t *testing.T) {
 	assert.Empty(t, *deleted, "no DELETE requests should be issued when nothing matches")
 }
 
-// (3) When the server rejects one of the matching deletes, the error is surfaced and
-// identifies the failing deployment — not silently ignored.
-func TestDeploymentDelete_PartialFailure(t *testing.T) {
+func TestDeploymentDelete_ServerFailure(t *testing.T) {
 	deployments := []v1alpha1.Deployment{
-		deploymentFixture("aws-v1", "summarizer", "1.0.0", "my-aws", "agent", "pending"),
-		deploymentFixture("gcp-v1", "summarizer", "1.0.0", "my-gcp", "agent", "pending"),
+		deploymentFixture("default/aws-v1", "summarizer", "1.0.0", "my-aws", "agent", "pending"),
+		deploymentFixture("default/gcp-v1", "summarizer", "1.0.0", "my-gcp", "agent", "pending"),
 	}
 	// Fail the GCP delete only.
-	srv, deleted := deploymentTestServer(t, deployments, map[string]bool{"default/gcp-v1": true})
+	srv, deleted, _ := deploymentTestServer(t, deployments, map[string]bool{"default/gcp-v1": true})
 	setupClientForServer(t, srv)
 
 	cmd := declarative.NewDeleteCmd()
-	cmd.SetArgs([]string{"deployment", "summarizer"})
+	cmd.SetArgs([]string{"deployment", "default/gcp-v1"})
 	err := cmd.Execute()
-	require.Error(t, err, "partial failure must propagate")
+	require.Error(t, err, "failure must propagate")
 	assert.Contains(t, err.Error(), "default/gcp-v1", "error should identify which deployment failed")
 
 	// Both DELETEs should have been attempted — we don't stop on first failure.
-	assert.ElementsMatch(t, []string{"default/aws-v1", "default/gcp-v1"}, *deleted,
-		"both matching deployments should be attempted even when one fails")
+	assert.ElementsMatch(t, []string{"default/gcp-v1"}, *deleted)
 }
 
 // (4) --tag is rejected for deployments and runtimes: neither kind has a tag
@@ -148,32 +159,18 @@ func TestDelete_RejectsTagForDeploymentAndRuntime(t *testing.T) {
 // (5) --force sends ?force=true query param to the server.
 func TestDeploymentDelete_ForcePassesQueryParam(t *testing.T) {
 	deployments := []v1alpha1.Deployment{
-		deploymentFixture("aws-v1", "summarizer", "1.0.0", "my-aws", "agent", "deployed"),
+		deploymentFixture("default/aws-v1", "summarizer", "1.0.0", "my-aws", "agent", "deployed"),
 	}
 
-	var capturedForce []string
-	var mu sync.Mutex
-	mux := http.NewServeMux()
-	mux.HandleFunc("/v0/deployments", func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(map[string]any{"items": deployments})
-	})
-	mux.HandleFunc("/v0/deployments/", func(w http.ResponseWriter, r *http.Request) {
-		mu.Lock()
-		capturedForce = append(capturedForce, r.URL.Query().Get("force"))
-		mu.Unlock()
-		w.WriteHeader(http.StatusNoContent)
-	})
-	srv := httptest.NewServer(mux)
-	t.Cleanup(srv.Close)
+	srv, _, capturedForce := deploymentTestServer(t, deployments, map[string]bool{"default/gcp-v1": true})
 	setupClientForServer(t, srv)
 
 	cmd := declarative.NewDeleteCmd()
-	cmd.SetArgs([]string{"deployment", "summarizer", "--force"})
+	cmd.SetArgs([]string{"deployment", "default/aws-v1", "--force"})
 	require.NoError(t, cmd.Execute())
 
-	require.Len(t, capturedForce, 1)
-	assert.Equal(t, "true", capturedForce[0], "?force=true must be sent when --force is passed")
+	require.Len(t, (*capturedForce), 1)
+	assert.Equal(t, "force=true", (*capturedForce)[0], "?force=true must be sent when --force is passed")
 }
 
 // (6) --force cannot be combined with -f (file mode).
@@ -188,32 +185,18 @@ func TestDeploymentDelete_ForceWithFileReturnsError(t *testing.T) {
 // (7) Without --force, no ?force query param is sent.
 func TestDeploymentDelete_NoForceFlagOmitsQueryParam(t *testing.T) {
 	deployments := []v1alpha1.Deployment{
-		deploymentFixture("aws-v1", "summarizer", "1.0.0", "my-aws", "agent", "deployed"),
+		deploymentFixture("default/aws-v1", "summarizer", "1.0.0", "my-aws", "agent", "deployed"),
 	}
 
-	var capturedQuery []string
-	var mu sync.Mutex
-	mux := http.NewServeMux()
-	mux.HandleFunc("/v0/deployments", func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(map[string]any{"items": deployments})
-	})
-	mux.HandleFunc("/v0/deployments/", func(w http.ResponseWriter, r *http.Request) {
-		mu.Lock()
-		capturedQuery = append(capturedQuery, r.URL.RawQuery)
-		mu.Unlock()
-		w.WriteHeader(http.StatusNoContent)
-	})
-	srv := httptest.NewServer(mux)
-	t.Cleanup(srv.Close)
+	srv, _, capturedQuery := deploymentTestServer(t, deployments, map[string]bool{"default/gcp-v1": true})
 	setupClientForServer(t, srv)
 
 	cmd := declarative.NewDeleteCmd()
-	cmd.SetArgs([]string{"deployment", "summarizer"})
+	cmd.SetArgs([]string{"deployment", "default/aws-v1"})
 	require.NoError(t, cmd.Execute())
 
-	require.Len(t, capturedQuery, 1)
-	assert.Empty(t, capturedQuery[0], "no query params should be sent without --force")
+	require.Len(t, *capturedQuery, 1)
+	assert.Empty(t, (*capturedQuery)[0], "no query params should be sent without --force")
 }
 
 // (8) --force is rejected for non-deployment kinds.

--- a/internal/cli/declarative/deployment_get_test.go
+++ b/internal/cli/declarative/deployment_get_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -59,6 +60,7 @@ func deploymentFixture(metaName, targetName, targetTag, runtimeID, resourceType,
 
 func deploymentTestServerV1Alpha1(t *testing.T, deployments []v1alpha1.Deployment) *httptest.Server {
 	t.Helper()
+	var mu sync.Mutex
 	mux := http.NewServeMux()
 	mux.HandleFunc("/v0/deployments", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
@@ -67,13 +69,37 @@ func deploymentTestServerV1Alpha1(t *testing.T, deployments []v1alpha1.Deploymen
 		}
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(map[string]any{"items": deployments})
+
+	})
+	mux.HandleFunc("/v0/deployments/", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+
+		path := strings.TrimPrefix(r.URL.Path, "/v0/deployments/")
+		parts := strings.Split(path, "/")
+		if len(parts) != 1 {
+			http.Error(w, `{"error":"bad get path"}`, http.StatusBadRequest)
+			return
+		}
+		mu.Lock()
+		defer mu.Unlock()
+		for _, d := range deployments {
+			if d.Metadata.Name == parts[0] {
+				_ = json.NewEncoder(w).Encode(d)
+				return
+			}
+		}
+		w.WriteHeader(http.StatusNotFound)
 	})
 	srv := httptest.NewServer(mux)
 	t.Cleanup(srv.Close)
 	return srv
 }
 
-// (1) Get by name returns the matching deployment when exactly one exists.
+// (1) Get by name returns the matching deployment when one exists.
 func TestDeploymentGet_ReturnsMatchByName(t *testing.T) {
 	deployments := []v1alpha1.Deployment{
 		deploymentFixture("aws-v1", "summarizer", "1.0.0", "my-aws", "agent", "deployed"),
@@ -85,39 +111,13 @@ func TestDeploymentGet_ReturnsMatchByName(t *testing.T) {
 	out := &bytes.Buffer{}
 	cmd := declarative.NewGetCmd()
 	cmd.SetOut(out)
-	cmd.SetArgs([]string{"deployment", "summarizer"})
+	cmd.SetArgs([]string{"deployment", "aws-v1"})
 	require.NoError(t, cmd.Execute())
 
-	assert.Contains(t, out.String(), "summarizer",
-		"get should render the matching deployment's name in the table output")
+	assert.Contains(t, out.String(), "default/aws-v1",
+		"get should render the matching deployment's name in the table output "+out.String())
 	assert.NotContains(t, out.String(), "unrelated",
 		"unrelated deployments must not appear")
-}
-
-// (2) Get returns the first match when multiple deployments share a name.
-// Users needing disambiguation should use `arctl get deployments`.
-func TestDeploymentGet_ReturnsFirstWhenMultipleShareName(t *testing.T) {
-	deployments := []v1alpha1.Deployment{
-		deploymentFixture("aws-v1", "summarizer", "1.0.0", "my-aws", "agent", "deployed"),
-		deploymentFixture("gcp-v1", "summarizer", "1.0.0", "my-gcp", "agent", "deployed"),
-		deploymentFixture("aws-v2", "summarizer", "2.0.0", "my-aws", "agent", "deployed"),
-	}
-	srv := deploymentTestServerV1Alpha1(t, deployments)
-	setupClientForServer(t, srv)
-
-	out := &bytes.Buffer{}
-	cmd := declarative.NewGetCmd()
-	cmd.SetOut(out)
-	cmd.SetArgs([]string{"deployment", "summarizer"})
-	require.NoError(t, cmd.Execute())
-
-	// First match by list order is aws-v1; output should include its ID, not the others.
-	assert.Contains(t, out.String(), "default/aws-v1",
-		"first deployment for the name should be returned")
-	assert.NotContains(t, out.String(), "default/gcp-v1",
-		"only the first match is surfaced; subsequent matches are filtered out")
-	assert.NotContains(t, out.String(), "default/aws-v2",
-		"other deployments must not be surfaced when get returns first match")
 }
 
 // (3) Get surfaces the registry's not-found sentinel when no deployment matches.
@@ -176,7 +176,7 @@ func TestDeploymentGet_YAMLOutputIncludesStatus(t *testing.T) {
 	out := &bytes.Buffer{}
 	cmd := declarative.NewGetCmd()
 	cmd.SetOut(out)
-	cmd.SetArgs([]string{"deployment", "summarizer", "-o", "yaml"})
+	cmd.SetArgs([]string{"deployment", "aws-v1", "-o", "yaml"})
 	require.NoError(t, cmd.Execute())
 
 	got := out.String()

--- a/internal/cli/declarative/deployment_get_test.go
+++ b/internal/cli/declarative/deployment_get_test.go
@@ -69,7 +69,6 @@ func deploymentTestServerV1Alpha1(t *testing.T, deployments []v1alpha1.Deploymen
 		}
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(map[string]any{"items": deployments})
-
 	})
 	mux.HandleFunc("/v0/deployments/", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {

--- a/internal/cli/declarative/resources.go
+++ b/internal/cli/declarative/resources.go
@@ -12,7 +12,6 @@ import (
 	"github.com/agentregistry-dev/agentregistry/internal/client"
 	"github.com/agentregistry-dev/agentregistry/pkg/api/v1alpha1"
 	"github.com/agentregistry-dev/agentregistry/pkg/printer"
-	"github.com/agentregistry-dev/agentregistry/pkg/registry/database"
 )
 
 // deploymentStatus is the shape emitted under .status when a deployment is
@@ -128,51 +127,6 @@ func listDeploymentAny(ctx context.Context) ([]any, error) {
 		out = append(out, dep)
 	}
 	return out, nil
-}
-
-func getDeploymentByTarget(ctx context.Context, name string) (any, error) {
-	deployments, err := cliCommon.ListDeployments(ctx, apiClient)
-	if err != nil {
-		return nil, err
-	}
-	for _, dep := range deployments {
-		if dep != nil && dep.TargetName == name {
-			return dep, nil
-		}
-	}
-	return nil, database.ErrNotFound
-}
-
-// deleteDeploymentByTarget deletes every deployment whose target has the given
-// name. Deployments do not carry a tag of their own — the only tag in play is
-// the target's, which is not part of the deployment's identity — so the tag
-// parameter is ignored and rejected upstream at the CLI surface. The dispatch
-// signature is shared across kinds, which is why the parameter is still
-// present here.
-func deleteDeploymentByTarget(ctx context.Context, name, _ string, force bool) error {
-	deployments, err := cliCommon.ListDeployments(ctx, apiClient)
-	if err != nil {
-		return fmt.Errorf("listing deployments: %w", err)
-	}
-
-	var matches []*cliCommon.DeploymentRecord
-	for _, dep := range deployments {
-		if dep == nil || dep.TargetName != name {
-			continue
-		}
-		matches = append(matches, dep)
-	}
-	if len(matches) == 0 {
-		return database.ErrNotFound
-	}
-
-	var errs []error
-	for _, dep := range matches {
-		if err := apiClient.Delete(ctx, v1alpha1.KindDeployment, dep.Namespace, dep.Name, "", client.DeleteOpts{Force: force}); err != nil {
-			errs = append(errs, fmt.Errorf("deleting %s (runtime %s): %w", dep.ID, dep.RuntimeID, err))
-		}
-	}
-	return errorsJoin(errs)
 }
 
 func deploymentToDocument(dep *cliCommon.DeploymentRecord) any {


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don't apply.
-->

# Description
Update cli get/delete deployment command to use deployment name instead of deployment target

<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

# Change Type
/kind fix

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bump
/kind cleanup
/kind design
/kind deprecation
/kind documentation
/kind feature
/kind fix
/kind flake
/kind install
```
-->

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
NONE
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
