### PR TITLE
 feat(api): reshape MCPTransport to declare http port/path; arctl init generates it

### DIFF
--- a/internal/cli/declarative/init.go
+++ b/internal/cli/declarative/init.go
@@ -654,6 +654,9 @@ Picks a framework + language interactively (or via --framework / --language).`,
 		Args:         cobra.MaximumNArgs(1),
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if initPort < 1 || initPort > 65535 {
+				return fmt.Errorf("--port must be between 1 and 65535, got %d", initPort)
+			}
 			var full string
 			if len(args) == 1 {
 				full = args[0]

--- a/internal/cli/declarative/init.go
+++ b/internal/cli/declarative/init.go
@@ -731,7 +731,7 @@ Picks a framework + language interactively (or via --framework / --language).`,
 					return fmt.Errorf("update .gitignore: %w", err)
 				}
 			}
-			if err := writeDeclarativeMCPYAML(projectDir, full, image, initDescription); err != nil {
+			if err := writeDeclarativeMCPYAML(projectDir, full, image, initDescription, initPort); err != nil {
 				return err
 			}
 
@@ -785,7 +785,7 @@ func mcpTemplateVars(name, baseName, description, image, frameworkDir, projectDi
 	}
 }
 
-func writeDeclarativeMCPYAML(projectDir, name, image, description string) error {
+func writeDeclarativeMCPYAML(projectDir, name, image, description string, port int) error {
 	nameParts := strings.SplitN(name, "/", 2)
 	shortName := nameParts[len(nameParts)-1]
 
@@ -794,6 +794,11 @@ func writeDeclarativeMCPYAML(projectDir, name, image, description string) error 
 		desc = fmt.Sprintf("%s MCP server", shortName)
 	}
 
+	// Declare the transport that matches the scaffolded server: arctl init's
+	// fastmcp template serves Streamable HTTP on the chosen --port at /mcp
+	// (the same port `arctl run` maps and the deploy path wires to the
+	// Service + container). Generating it here means the manifest is
+	// deployable as-is — no manual transport/port edit before apply.
 	server := v1alpha1.MCPServer{
 		TypeMeta: v1alpha1.TypeMeta{
 			APIVersion: scheme.APIVersion,
@@ -809,7 +814,11 @@ func writeDeclarativeMCPYAML(projectDir, name, image, description string) error 
 				Package: &v1alpha1.MCPPackage{
 					RegistryType: "oci",
 					Identifier:   image,
-					Transport:    v1alpha1.MCPTransport{Type: "stdio"},
+					Transport: v1alpha1.MCPTransport{
+						Type: "http",
+						Port: uint32(port),
+						Path: "/mcp",
+					},
 				},
 			},
 		},

--- a/internal/cli/declarative/init.go
+++ b/internal/cli/declarative/init.go
@@ -819,7 +819,7 @@ func writeDeclarativeMCPYAML(projectDir, name, image, description string, port i
 					Identifier:   image,
 					Transport: v1alpha1.MCPTransport{
 						Type: "http",
-						Port: uint32(port),
+						Port: uint16(port),
 						Path: "/mcp",
 					},
 				},

--- a/internal/cli/declarative/init_test.go
+++ b/internal/cli/declarative/init_test.go
@@ -140,6 +140,16 @@ func TestInitMCP_WritesYAMLAndArctl(t *testing.T) {
 	_, err = os.Stat(filepath.Join(projectDir, "mcp.yaml"))
 	require.NoError(t, err)
 
+	// The generated manifest declares the http transport matching the
+	// scaffolded fastmcp server (default --port 3000, path /mcp) so it's
+	// deployable as-is.
+	mcpSpec := readYAMLFile(t, filepath.Join(projectDir, "mcp.yaml"))["spec"].(map[string]any)
+	pkg := mcpSpec["source"].(map[string]any)["package"].(map[string]any)
+	transport := pkg["transport"].(map[string]any)
+	assert.Equal(t, "http", transport["type"])
+	assert.EqualValues(t, 3000, transport["port"])
+	assert.Equal(t, "/mcp", transport["path"])
+
 	cfg, err := buildconfig.Read(projectDir)
 	require.NoError(t, err)
 	assert.Equal(t, "fastmcp", cfg.Framework)

--- a/internal/registry/runtimes/utils/deployment_adapter_utils.go
+++ b/internal/registry/runtimes/utils/deployment_adapter_utils.go
@@ -176,13 +176,9 @@ func translateLocalMCPServer(
 		transportType = runtimetypes.TransportTypeStdio
 	default:
 		transportType = runtimetypes.TransportTypeHTTP
-		u, err := parseURL(pkg.Transport.URL)
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse transport url: %v", err)
-		}
 		httpTransport = &runtimetypes.HTTPTransport{
-			Port: u.port,
-			Path: u.path,
+			Port: pkg.Transport.Port,
+			Path: pkg.Transport.Path,
 		}
 	}
 

--- a/internal/registry/runtimes/utils/deployment_adapter_utils.go
+++ b/internal/registry/runtimes/utils/deployment_adapter_utils.go
@@ -177,7 +177,7 @@ func translateLocalMCPServer(
 	default:
 		transportType = runtimetypes.TransportTypeHTTP
 		httpTransport = &runtimetypes.HTTPTransport{
-			Port: pkg.Transport.Port,
+			Port: uint32(pkg.Transport.Port),
 			Path: pkg.Transport.Path,
 		}
 	}

--- a/internal/registry/runtimes/utils/deployment_adapter_utils_test.go
+++ b/internal/registry/runtimes/utils/deployment_adapter_utils_test.go
@@ -73,7 +73,8 @@ func TestTranslateMCPServerLocalIncludesOverridesAndExtraArgs(t *testing.T) {
 					},
 					Transport: v1alpha1.MCPTransport{
 						Type: "http",
-						URL:  "http://localhost:7777/mcp",
+						Port: 7777,
+						Path: "/mcp",
 					},
 				},
 			},

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -514,15 +514,13 @@ components:
     MCPTransport:
       additionalProperties: false
       properties:
-        headers:
-          items:
-            $ref: '#/components/schemas/MCPKeyValueInput'
-          type:
-          - array
-          - "null"
-        type:
+        path:
           type: string
-        url:
+        port:
+          format: int32
+          minimum: 0
+          type: integer
+        type:
           type: string
       required:
       - type

--- a/pkg/api/v1alpha1/mcpserver.go
+++ b/pkg/api/v1alpha1/mcpserver.go
@@ -56,7 +56,7 @@ type MCPServerSource struct {
 // host is constructed at deploy time. Both are ignored for stdio.
 type MCPTransport struct {
 	Type string `json:"type" yaml:"type"`                     // "http" | "stdio"
-	Port uint32 `json:"port,omitempty" yaml:"port,omitempty"` // http listen port (ignored for stdio)
+	Port uint16 `json:"port,omitempty" yaml:"port,omitempty"` // http listen port 1-65535 (ignored for stdio)
 	Path string `json:"path,omitempty" yaml:"path,omitempty"` // http endpoint path, e.g. "/mcp" (ignored for stdio)
 }
 

--- a/pkg/api/v1alpha1/mcpserver.go
+++ b/pkg/api/v1alpha1/mcpserver.go
@@ -50,12 +50,14 @@ type MCPServerSource struct {
 	Repository *Repository `json:"repository,omitempty" yaml:"repository,omitempty"`
 }
 
-// MCPTransport describes a transport endpoint — used both inside MCPPackage
-// (to tag a package's preferred transport) and as a top-level remote target.
+// MCPTransport describes how a deployable MCPPackage exposes itself. Used
+// only inside MCPPackage; remotes use MCPRemote, which carries its own URL.
+// For http, the listen Port and endpoint Path are set explicitly because the
+// host is constructed at deploy time. Both are ignored for stdio.
 type MCPTransport struct {
-	Type    string             `json:"type" yaml:"type"`
-	URL     string             `json:"url,omitempty" yaml:"url,omitempty"`
-	Headers []MCPKeyValueInput `json:"headers,omitempty" yaml:"headers,omitempty"`
+	Type string `json:"type" yaml:"type"`                     // "http" | "stdio"
+	Port uint32 `json:"port,omitempty" yaml:"port,omitempty"` // http listen port (ignored for stdio)
+	Path string `json:"path,omitempty" yaml:"path,omitempty"` // http endpoint path, e.g. "/mcp" (ignored for stdio)
 }
 
 // MCPPackage is a runnable distribution of the MCP server (stdio binary,

--- a/pkg/api/v1alpha1/mcpserver_validate.go
+++ b/pkg/api/v1alpha1/mcpserver_validate.go
@@ -66,12 +66,8 @@ func validateMCPServerSource(src *MCPServerSource) FieldErrors {
 	if pkg.Transport.Type == "" {
 		errs.Append("spec.source.package.transport.type", fmt.Errorf("%w", ErrRequiredField))
 	}
-	if pkg.Transport.Type == "http" {
-		if pkg.Transport.Port == 0 {
-			errs.Append("spec.source.package.transport.port", fmt.Errorf("%w: required for http transport", ErrRequiredField))
-		} else if pkg.Transport.Port > 65535 {
-			errs.Append("spec.source.package.transport.port", fmt.Errorf("invalid port %d: must be 1-65535", pkg.Transport.Port))
-		}
+	if pkg.Transport.Type == "http" && pkg.Transport.Port == 0 {
+		errs.Append("spec.source.package.transport.port", fmt.Errorf("%w: required for http transport", ErrRequiredField))
 	}
 	return errs
 }

--- a/pkg/api/v1alpha1/mcpserver_validate.go
+++ b/pkg/api/v1alpha1/mcpserver_validate.go
@@ -66,8 +66,12 @@ func validateMCPServerSource(src *MCPServerSource) FieldErrors {
 	if pkg.Transport.Type == "" {
 		errs.Append("spec.source.package.transport.type", fmt.Errorf("%w", ErrRequiredField))
 	}
-	if pkg.Transport.Type == "http" && pkg.Transport.Port == 0 {
-		errs.Append("spec.source.package.transport.port", fmt.Errorf("%w: required for http transport", ErrRequiredField))
+	if pkg.Transport.Type == "http" {
+		if pkg.Transport.Port == 0 {
+			errs.Append("spec.source.package.transport.port", fmt.Errorf("%w: required for http transport", ErrRequiredField))
+		} else if pkg.Transport.Port > 65535 {
+			errs.Append("spec.source.package.transport.port", fmt.Errorf("invalid port %d: must be 1-65535", pkg.Transport.Port))
+		}
 	}
 	return errs
 }

--- a/pkg/api/v1alpha1/mcpserver_validate.go
+++ b/pkg/api/v1alpha1/mcpserver_validate.go
@@ -66,5 +66,8 @@ func validateMCPServerSource(src *MCPServerSource) FieldErrors {
 	if pkg.Transport.Type == "" {
 		errs.Append("spec.source.package.transport.type", fmt.Errorf("%w", ErrRequiredField))
 	}
+	if pkg.Transport.Type == "http" && pkg.Transport.Port == 0 {
+		errs.Append("spec.source.package.transport.port", fmt.Errorf("%w: required for http transport", ErrRequiredField))
+	}
 	return errs
 }

--- a/pkg/api/v1alpha1/validation_test.go
+++ b/pkg/api/v1alpha1/validation_test.go
@@ -445,3 +445,24 @@ func TestMCPServerValidate_RequiresSourceOrRemote(t *testing.T) {
 	paths := failedFields(t, m.Validate())
 	require.Contains(t, paths, "spec")
 }
+
+func TestMCPServerValidate_HTTPPortRange(t *testing.T) {
+	mk := func(port uint32) *MCPServer {
+		return &MCPServer{
+			Metadata: ObjectMeta{Name: "x"},
+			Spec: MCPServerSpec{
+				Source: &MCPServerSource{
+					Package: &MCPPackage{
+						RegistryType: "oci",
+						Identifier:   "img:latest",
+						Transport:    MCPTransport{Type: "http", Port: port},
+					},
+				},
+			},
+		}
+	}
+	const portPath = "spec.source.package.transport.port"
+	require.Contains(t, failedFields(t, mk(0).Validate()), portPath, "http with port 0 must fail")
+	require.Contains(t, failedFields(t, mk(70000).Validate()), portPath, "http with port >65535 must fail")
+	require.NotContains(t, failedFields(t, mk(8080).Validate()), portPath, "http with a valid port must pass the port check")
+}

--- a/pkg/api/v1alpha1/validation_test.go
+++ b/pkg/api/v1alpha1/validation_test.go
@@ -447,7 +447,7 @@ func TestMCPServerValidate_RequiresSourceOrRemote(t *testing.T) {
 }
 
 func TestMCPServerValidate_HTTPPortRange(t *testing.T) {
-	mk := func(port uint32) *MCPServer {
+	mk := func(port uint16) *MCPServer {
 		return &MCPServer{
 			Metadata: ObjectMeta{Name: "x"},
 			Spec: MCPServerSpec{
@@ -463,6 +463,5 @@ func TestMCPServerValidate_HTTPPortRange(t *testing.T) {
 	}
 	const portPath = "spec.source.package.transport.port"
 	require.Contains(t, failedFields(t, mk(0).Validate()), portPath, "http with port 0 must fail")
-	require.Contains(t, failedFields(t, mk(70000).Validate()), portPath, "http with port >65535 must fail")
 	require.NotContains(t, failedFields(t, mk(8080).Validate()), portPath, "http with a valid port must pass the port check")
 }

--- a/ui/lib/api/types.gen.ts
+++ b/ui/lib/api/types.gen.ts
@@ -246,9 +246,9 @@ export type McpServerSpec = {
 };
 
 export type McpTransport = {
-    headers?: Array<McpKeyValueInput> | null;
+    path?: string;
+    port?: number;
     type: string;
-    url?: string;
 };
 
 export type ObjectMeta = {


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don't apply.
-->

# Description

<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

 **What changed:**
  - `MCPTransport` is now `{type, port, path}` — drops `url`/`headers`, adds `port`/`path`. For a deployable package the host is built at deploy time, so port+path are the only meaningful bits; they were previously smuggled inside a placeholder `url`. (`MCPRemote` is a separate type and keeps its
  own `url`/`headers`.)
  - `deployment_adapter_utils.go` reads `Transport.Port`/`.Path` directly instead of parsing them out of `Transport.URL`. `parseURL` is retained for
  `MCPRemote.URL`.
  - `mcpserver_validate.go` errors when an http transport has no port.
  - `arctl init mcp` generates `transport: {type: http, port: <--port, default 3000>, path: /mcp}` matching the scaffolded server (previously hardcoded
   `stdio`).

# Change Type

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bump
/kind cleanup
/kind design
/kind deprecation
/kind documentation
/kind feature
/kind fix
/kind flake
/kind install
```
-->
/kind feature
/kind breaking_change
# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
breaking (v1alpha1 API): `MCPTransport` replaces `url`/`headers` with `port`/`path`. `arctl init mcp` generates a matching http transport.
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
