### PR TITLE
.golangci: Simplify Go formatter configuration

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -99,7 +99,6 @@ issues:
 formatters:
   enable:
     - gofmt
-    - goimports
     - gci
   settings:
     gci:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,10 +89,10 @@ make build
 
 ```bash
 # Format code
-gofmt -w .
+make fmt
 
 # Run linter
-golangci-lint run
+make lint
 ```
 
 ### TypeScript/React
@@ -328,4 +328,3 @@ make build-cli
 
 
 Thank you for contributing! 🎉
-


### PR DESCRIPTION
# Description

Simplifies the Go formatter configuration by letting `gci` own import grouping
alongside `gofmt`, removing the overlapping `goimports` formatter.

Also updates the contributing guide to use the repository Makefile targets for
formatting and linting so contributors run the pinned project tooling.

# Change Type

/kind cleanup

# Changelog

```release-note
NONE
```

# Additional Notes

Validated with `golangci-lint config verify` and `make fmt`.
