### PR TITLE
test(mcp): close server session in TestMCPListServers_HappyPath teardown

### DIFF
--- a/internal/mcp/registryserver/server_integration_test.go
+++ b/internal/mcp/registryserver/server_integration_test.go
@@ -47,8 +47,16 @@ func TestMCPListServers_HappyPath(t *testing.T) {
 
 	serverSession, err := server.Connect(ctx, serverTransport, nil)
 	require.NoError(t, err, "connect MCP server")
+	// Tear the server down with an explicit graceful Close rather than Wait.
+	// Wait blocks for the client to disconnect and surfaces the read/write
+	// error that ended the connection, which races with clientSession.Close:
+	// if the client closes between the server's last write and its read loop
+	// noticing, Wait returns a non-nil "server is closing: EOF" error instead
+	// of nil. Close shuts the server's side of the in-memory transport down
+	// directly and only reports the transport close error (always nil for the
+	// net.Pipe backing NewInMemoryTransports), so teardown is deterministic.
 	defer func() {
-		require.NoError(t, serverSession.Wait())
+		require.NoError(t, serverSession.Close())
 	}()
 
 	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "v0.0.1"}, nil)


### PR DESCRIPTION
  # Description

  `TestMCPListServers_HappyPath` flakes during teardown with `server is closing: EOF`.

  The deferred `serverSession.Wait()` races with `clientSession.Close()`. `Wait()` blocks for the client to disconnect and surfaces
  the error that ended the connection — if the client closes between the server's last write and its read loop noticing, `Wait()`
  returns `"server is closing: EOF"` instead of `nil`, so the deferred `require.NoError` fails even though every body assertion
  already passed.

 This work tears the server down with an explicit graceful `serverSession.Close()` instead of `Wait()`. `Close()` shuts the server's side of the in-memory transport down directly and only reports the transport close error, which is always `nil` for the `net.Pipe` behind `NewInMemoryTransports()`, making teardown deterministic. Test-only change; no production code touched.

  Fixes #516

  # Change Type

  /kind flake

  # Changelog

  ```release-note
  NONE

  Additional Notes

  Verified with go test -tags=integration -run TestMCPListServers_HappyPath -count=200 — 200/200 pass.
