### PR TITLE
helm: add database.postgres.secretRef to source the URL from a Secret

### DIFF
--- a/charts/agentregistry/README.md
+++ b/charts/agentregistry/README.md
@@ -168,10 +168,13 @@ This creates a `Role`/`RoleBinding` in each listed namespace (plus the installat
 | database.postgres.bundled.image.tag | string | `"18"` | Bundled PostgreSQL image tag |
 | database.postgres.bundled.resources | object | `{"limits":{"cpu":"1","memory":"1Gi"},"requests":{"cpu":"250m","memory":"256Mi"}}` | Resource requests/limits for the bundled PostgreSQL container |
 | database.postgres.bundled.storage | string | `"5Gi"` | PersistentVolumeClaim size for the bundled PostgreSQL data directory |
-| database.postgres.url | string | `""` | When set, Agent Registry connects here instead of the bundled instance. The bundled pod (if enabled) still deploys but is unused; the init container is skipped. |
+| database.postgres.secretRef | object | `{"key":"AGENT_REGISTRY_DATABASE_URL","name":""}` | Source the PostgreSQL connection URL from an existing Secret instead of inlining it. Use this when credentials are managed by an external secret store (e.g. AWS Secrets Manager via External Secrets Operator) and synced into the cluster as a Secret. The chart does not create or manage this Secret. Mutually exclusive with `url` and with `bundled.enabled=true`. On credential rotation, Kubernetes does NOT auto-restart the pod — pair with a controller such as stakater/Reloader if you need automatic restarts on Secret content changes. |
+| database.postgres.secretRef.key | string | `"AGENT_REGISTRY_DATABASE_URL"` | Key within the Secret that holds the connection URL. |
+| database.postgres.secretRef.name | string | `""` | Name of an existing Secret in the release namespace. Leave empty to disable. |
+| database.postgres.url | string | `""` | When set, Agent Registry connects here instead of the bundled instance. The bundled pod (if enabled) still deploys but is unused; the init container is skipped. Mutually exclusive with `secretRef.name`. |
 | dnsConfig | object | `{}` | DNS configuration for the pod |
 | dnsPolicy | string | `""` | DNS policy for the pod |
-| extraEnvVars | list | `[]` | Array of extra environment variables for the Agent Registry container |
+| extraEnvVars | list | `[]` | Array of extra environment variables for the Agent Registry container. Additive only — cannot override env vars the chart already renders. For credentialed fields use the dedicated knobs (e.g. `database.postgres.secretRef`). |
 | fullnameOverride | string | `""` | Override the full name of the chart |
 | global.imagePullSecrets | list | `[]` | Global Docker registry secret names |
 | global.imageRegistry | string | `""` | Global container image registry override |

--- a/charts/agentregistry/templates/_helpers.tpl
+++ b/charts/agentregistry/templates/_helpers.tpl
@@ -319,9 +319,15 @@ Called from templates/validate.yaml so it fires during helm template/install.
 {{- else if and (not .Values.config.existingSecret) (not (regexMatch "^[0-9a-fA-F]+$" .Values.config.jwtPrivateKey)) }}
 {{- $errors = append $errors "config.jwtPrivateKey must be a valid hex string (e.g. generated with: openssl rand -hex 32)." }}
 {{- end }}
+{{- if and .Values.database.postgres.url .Values.database.postgres.secretRef.name }}
+{{- $errors = append $errors "database.postgres.url and database.postgres.secretRef.name are mutually exclusive: set one, not both." }}
+{{- end }}
+{{- if and .Values.database.postgres.bundled.enabled .Values.database.postgres.secretRef.name }}
+{{- $errors = append $errors "database.postgres.secretRef.name is mutually exclusive with database.postgres.bundled.enabled=true: set bundled.enabled=false when sourcing the URL from an external Secret." }}
+{{- end }}
 {{- if not .Values.database.postgres.bundled.enabled }}
-{{- if not .Values.database.postgres.url }}
-{{- $errors = append $errors "database.postgres.url must be set when database.postgres.bundled.enabled=false." }}
+{{- if and (not .Values.database.postgres.url) (not .Values.database.postgres.secretRef.name) }}
+{{- $errors = append $errors "Either database.postgres.url or database.postgres.secretRef.name must be set when database.postgres.bundled.enabled=false." }}
 {{- end }}
 {{- end }}
 {{- range $errors }}

--- a/charts/agentregistry/templates/deployment.yaml
+++ b/charts/agentregistry/templates/deployment.yaml
@@ -134,7 +134,13 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.config.existingSecret | default (include "agentregistry.fullname" .) }}
                   key: AGENT_REGISTRY_JWT_PRIVATE_KEY
-            {{- if .Values.database.postgres.url }}
+            {{- if .Values.database.postgres.secretRef.name }}
+            - name: AGENT_REGISTRY_DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.database.postgres.secretRef.name }}
+                  key: {{ .Values.database.postgres.secretRef.key | default "AGENT_REGISTRY_DATABASE_URL" }}
+            {{- else if .Values.database.postgres.url }}
             - name: AGENT_REGISTRY_DATABASE_URL
               value: {{ .Values.database.postgres.url | quote }}
             {{- else if .Values.database.postgres.bundled.enabled }}
@@ -146,7 +152,7 @@ spec:
             - name: AGENT_REGISTRY_DATABASE_URL
               value: {{ printf "postgres://agentregistry:$(POSTGRES_PASSWORD)@%s:5432/agentregistry?sslmode=disable" (include "agentregistry.postgresql.fullname" .) | quote }}
             {{- else }}
-            {{ fail "No database connection configured. Set database.postgres.url or enable database.postgres.bundled." }}
+            {{ fail "No database connection configured. Set database.postgres.url, database.postgres.secretRef.name, or enable database.postgres.bundled." }}
             {{- end }}
             {{- if .Values.extraEnvVars }}
             {{- tpl (toYaml .Values.extraEnvVars) . | nindent 12 }}

--- a/charts/agentregistry/tests/deployment_test.yaml
+++ b/charts/agentregistry/tests/deployment_test.yaml
@@ -243,3 +243,68 @@ tests:
     asserts:
       - isNull:
           path: spec.template.spec.initContainers
+
+  # ── secretRef-backed external Postgres ──────────────────────────────────────
+
+  - it: sets AGENT_REGISTRY_DATABASE_URL via valueFrom.secretKeyRef when database.postgres.secretRef.name is set
+    template: deployment.yaml
+    set:
+      database.postgres.bundled.enabled: false
+      database.postgres.secretRef.name: my-postgres-secret
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AGENT_REGISTRY_DATABASE_URL
+            valueFrom:
+              secretKeyRef:
+                name: my-postgres-secret
+                key: AGENT_REGISTRY_DATABASE_URL
+
+  - it: uses custom secret key when database.postgres.secretRef.key is set
+    template: deployment.yaml
+    set:
+      database.postgres.bundled.enabled: false
+      database.postgres.secretRef.name: my-postgres-secret
+      database.postgres.secretRef.key: DB_URL
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AGENT_REGISTRY_DATABASE_URL
+            valueFrom:
+              secretKeyRef:
+                name: my-postgres-secret
+                key: DB_URL
+
+  - it: does not inject POSTGRES_PASSWORD when database.postgres.secretRef.name is set
+    template: deployment.yaml
+    set:
+      database.postgres.bundled.enabled: false
+      database.postgres.secretRef.name: my-postgres-secret
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: POSTGRES_PASSWORD
+
+  - it: does not render a plain value entry for AGENT_REGISTRY_DATABASE_URL when secretRef.name is set
+    template: deployment.yaml
+    set:
+      database.postgres.bundled.enabled: false
+      database.postgres.secretRef.name: my-postgres-secret
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AGENT_REGISTRY_DATABASE_URL
+            value: ""
+
+  - it: does not include wait-for-postgres init container when database.postgres.secretRef.name is set
+    template: deployment.yaml
+    set:
+      database.postgres.bundled.enabled: false
+      database.postgres.secretRef.name: my-postgres-secret
+    asserts:
+      - isNull:
+          path: spec.template.spec.initContainers

--- a/charts/agentregistry/tests/validation_test.yaml
+++ b/charts/agentregistry/tests/validation_test.yaml
@@ -72,3 +72,31 @@ tests:
       - hasDocuments:
           count: 0
 
+  # ── secretRef-backed external Postgres ────────────────────────────────────
+
+  - it: renders nothing when database.postgres.secretRef.name is set (bundled disabled)
+    set:
+      config.jwtPrivateKey: deadbeef1234567890abcdef
+      database.postgres.bundled.enabled: false
+      database.postgres.secretRef.name: my-postgres-secret
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: fails when database.postgres.url and database.postgres.secretRef.name are both set
+    set:
+      config.jwtPrivateKey: deadbeef1234567890abcdef
+      database.postgres.bundled.enabled: false
+      database.postgres.url: "postgres://user:pass@host:5432/db"
+      database.postgres.secretRef.name: my-postgres-secret
+    asserts:
+      - failedTemplate:
+          errorPattern: "mutually exclusive"
+
+  - it: fails when database.postgres.bundled.enabled=true and database.postgres.secretRef.name is set
+    set:
+      config.jwtPrivateKey: deadbeef1234567890abcdef
+      database.postgres.secretRef.name: my-postgres-secret
+    asserts:
+      - failedTemplate:
+          errorPattern: "mutually exclusive"

--- a/charts/agentregistry/values.yaml
+++ b/charts/agentregistry/values.yaml
@@ -271,8 +271,19 @@ rbac:
 database:
   postgres:
     # -- External PostgreSQL connection string.
-    # -- When set, Agent Registry connects here instead of the bundled instance. The bundled pod (if enabled) still deploys but is unused; the init container is skipped.
+    # -- When set, Agent Registry connects here instead of the bundled instance. The bundled pod (if enabled) still deploys but is unused; the init container is skipped. Mutually exclusive with `secretRef.name`.
     url: ""
+    # -- Source the PostgreSQL connection URL from an existing Secret instead of inlining it.
+    # Use this when credentials are managed by an external secret store (e.g. AWS Secrets Manager
+    # via External Secrets Operator) and synced into the cluster as a Secret. The chart does not
+    # create or manage this Secret. Mutually exclusive with `url` and with `bundled.enabled=true`.
+    # On credential rotation, Kubernetes does NOT auto-restart the pod — pair with a controller
+    # such as stakater/Reloader if you need automatic restarts on Secret content changes.
+    secretRef:
+      # -- Name of an existing Secret in the release namespace. Leave empty to disable.
+      name: ""
+      # -- Key within the Secret that holds the connection URL.
+      key: AGENT_REGISTRY_DATABASE_URL
     # -- Bundled PostgreSQL — dev/eval only.
     bundled:
       # -- Deploy a PostgreSQL instance alongside Agent Registry

--- a/charts/agentregistry/values.yaml
+++ b/charts/agentregistry/values.yaml
@@ -178,7 +178,10 @@ startupProbe:
 
 # @section Extensibility
 
-# -- Array of extra environment variables for the Agent Registry container
+# -- Array of extra environment variables for the Agent Registry container.
+# Additive only — cannot override env vars the chart already renders.
+# For credentialed fields use the dedicated knobs (e.g.
+# `database.postgres.secretRef`).
 extraEnvVars: []
 
 # @section Scheduling

--- a/docs/byo-postgres.md
+++ b/docs/byo-postgres.md
@@ -1,0 +1,50 @@
+# Bring Your Own Postgres
+
+Point the agentregistry chart at an external Postgres (RDS, Cloud SQL, etc.) instead of the bundled dev/eval pod. The connection string can be supplied inline in Helm values (`database.postgres.url`) or sourced from an existing Kubernetes Secret (`database.postgres.secretRef`).
+
+## Chart values
+
+| Value | Default | Notes |
+|---|---|---|
+| `database.postgres.bundled.enabled` | `true` | Set `false` to bring your own. |
+| `database.postgres.url` | `""` | Inline connection string. |
+| `database.postgres.secretRef.name` | `""` | Secret in the release namespace holding the connection string. |
+| `database.postgres.secretRef.key` | `AGENT_REGISTRY_DATABASE_URL` | Key within that Secret. |
+
+Exactly one path (bundled / inline `url` / `secretRef`) must be active; the chart fails fast otherwise.
+
+## Connection-string formats
+
+`AGENT_REGISTRY_DATABASE_URL` accepts either libpq form, auto-detected on the leading `postgres://` prefix:
+
+- **URL** — `postgres://user:password@host:port/db?sslmode=require`. Reserved characters in user/password must be percent-encoded.
+- **Keyword/value (DSN)** — `host=... port=... user=... password='...' dbname=... sslmode=require`. Single-quote the password; no encoding.
+
+Use keyword/value form when credentials come from a rotating store (AWS Secrets Manager, Vault) — rotation flows in without re-encoding.
+
+## Setup
+
+1. Ensure the database referenced in your connection string exists on your Postgres instance. The chart does not run `CREATE DATABASE`; whatever `dbname=` you supply must already be present. Migrations run against the database the connection points at.
+
+2. Point the chart at your Postgres. Pick one path:
+
+   **Inline `url`** — connection string lives in Helm values:
+
+   ```bash
+   helm upgrade --install agentregistry oci://<registry>/agentregistry \
+     --namespace <ns> --create-namespace \
+     --set database.postgres.bundled.enabled=false \
+     --set database.postgres.url="host=<host> port=5432 user=<user> password='<password>' dbname=<database> sslmode=require"
+   ```
+
+   **`secretRef`** — connection string lives in a Kubernetes Secret you create or have synced. Use this when credentials shouldn't be in values (rotation, GitOps, etc.):
+
+   ```bash
+   kubectl -n <ns> create secret generic db-creds \
+     --from-literal=AGENT_REGISTRY_DATABASE_URL="host=<host> port=5432 user=<user> password='<password>' dbname=<database> sslmode=require"
+
+   helm upgrade --install agentregistry oci://<registry>/agentregistry \
+     --namespace <ns> --create-namespace \
+     --set database.postgres.bundled.enabled=false \
+     --set database.postgres.secretRef.name=db-creds
+   ```


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don't apply.
-->

# Description
Adds `database.postgres.secretRef.{name, key}` to the agentregistry chart so users can source the Postgres connection URL from an existing Kubernetes Secret instead of inlining it in values.
<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

# Change Type

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bump
/kind cleanup
/kind design
/kind deprecation
/kind documentation
/kind feature
/kind fix
/kind flake
/kind install
```
-->
/kind feature
# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
feat(helm): support sourcing the Postgres connection URL from an existing Kubernetes Secret via `database.postgres.secretRef.{name,key}`
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
**Two accepted connection-string formats.** `AGENT_REGISTRY_DATABASE_URL` accepts either libpq URL form
  (`postgres://user:pass@host:port/db?sslmode=require`) or keyword/value form (`host=... user=... password='...' dbname=... sslmode=require`). The pgx driver auto-detects based on the leading `postgres://` prefix. Keyword/value form is recommended when credentials come from a rotating secret store (AWS Secrets Manager, Vault) — it avoids URL-encoding special characters in the password on every rotation.