### PR TITLE
resource: add per-kind AppOptions.Prepare pre-persist hook

### DIFF
--- a/internal/registry/api/handlers/v0/crud/crud.go
+++ b/internal/registry/api/handlers/v0/crud/crud.go
@@ -47,6 +47,11 @@ type PerKindHooks struct {
 	// PostDeletes run after a successful DELETE; see
 	// resource.Config.PostDelete. Mirrors PostUpserts above.
 	PostDeletes map[string]func(ctx context.Context, obj v1alpha1.Object) error
+	// Prepares run after validation and before Store.Upsert; see
+	// resource.Config.Prepare. Wired by downstream builds that need to
+	// mutate the decoded object before persistence (e.g. strip
+	// sensitive spec fields). Missing keys = no prepare hook for that kind.
+	Prepares map[string]func(ctx context.Context, obj v1alpha1.Object) error
 	// InitialFinalizers seeds create-time finalizers per kind; see
 	// resource.Config.InitialFinalizers.
 	InitialFinalizers map[string]func(obj v1alpha1.Object) []string
@@ -88,6 +93,7 @@ func Register(
 			ListFilter:        perKind.ListFilters[kind],
 			PostUpsert:        perKind.PostUpserts[kind],
 			PostDelete:        perKind.PostDeletes[kind],
+			Prepare:           perKind.Prepares[kind],
 			DeleteAdmission:   deleteAdmission,
 			InitialFinalizers: perKind.InitialFinalizers[kind],
 		}, true

--- a/internal/registry/api/router/v0.go
+++ b/internal/registry/api/router/v0.go
@@ -225,6 +225,19 @@ func registerKindRoutes(
 	// same per-kind hook table populated above, so Deployment reconciliation
 	// and any caller-supplied PostUpsert/PostDelete fire identically on
 	// the batch path.
+	// ApplyConfig.Prepare is a single global hook, not a per-kind map, so
+	// dispatch by Kind over the per-kind Prepares table to match the
+	// dedicated PUT route's per-kind wiring.
+	var applyPrepare func(ctx context.Context, obj v1alpha1.Object) error
+	if len(perKind.Prepares) > 0 {
+		prepares := perKind.Prepares
+		applyPrepare = func(ctx context.Context, obj v1alpha1.Object) error {
+			if p := prepares[obj.GetKind()]; p != nil {
+				return p(ctx, obj)
+			}
+			return nil
+		}
+	}
 	applyCfg := resource.ApplyConfig{
 		BasePrefix:        basePrefix,
 		Stores:            stores,
@@ -236,6 +249,7 @@ func registerKindRoutes(
 		InitialFinalizers: perKind.InitialFinalizers,
 		Admission:         admission,
 		DeleteAdmission:   deleteAdmission,
+		Prepare:           applyPrepare,
 	}
 	productionApplyCfg := applyCfg
 	productionApplyCfg.Admission = resource.ProductionAdmission

--- a/internal/registry/registry_app.go
+++ b/internal/registry/registry_app.go
@@ -280,6 +280,12 @@ func crudPerKindHooks(options types.AppOptions) crud.PerKindHooks {
 			hooks.PostDeletes[kind] = fn
 		}
 	}
+	if len(options.Prepares) > 0 {
+		hooks.Prepares = make(map[string]func(ctx context.Context, obj v1alpha1.Object) error, len(options.Prepares))
+		for kind, fn := range options.Prepares {
+			hooks.Prepares[kind] = fn
+		}
+	}
 	if len(options.InitialFinalizers) > 0 {
 		hooks.InitialFinalizers = make(map[string]func(obj v1alpha1.Object) []string, len(options.InitialFinalizers))
 		maps.Copy(hooks.InitialFinalizers, options.InitialFinalizers)

--- a/pkg/registry/resource/handler.go
+++ b/pkg/registry/resource/handler.go
@@ -113,6 +113,14 @@ type Config struct {
 	// and writes the terminal Removed condition.
 	PostDelete func(ctx context.Context, obj v1alpha1.Object) error
 
+	// Prepare is optional; when set, the apply handler invokes it after
+	// validation (refs/registries) and before admission/Store.Upsert, so
+	// the kind can mutate the decoded object before it is persisted (e.g.
+	// strip sensitive spec fields). Runs on both the dedicated PUT
+	// route and the batch /v0/apply path. Hook errors short-circuit the
+	// write and surface to the caller.
+	Prepare func(ctx context.Context, obj v1alpha1.Object) error
+
 	// DeleteAdmission optionally owns the final delete after authz. Nil uses
 	// ProductionDeleteAdmission, which deletes from the configured Store and
 	// runs PostDelete.
@@ -498,6 +506,7 @@ func registerApplyMutable[T v1alpha1.Object](api huma.API, cfg Config, newObj fu
 			RegistryValidator: cfg.RegistryValidator,
 			PostUpsert:        cfg.PostUpsert,
 			InitialFinalizers: cfg.InitialFinalizers,
+			Prepare:           cfg.Prepare,
 		}, false); ae != nil {
 			return nil, mapApplyErrorToHuma(ae, kind, ns, name, "")
 		}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -68,6 +68,12 @@ type PostUpsert func(ctx context.Context, obj v1alpha1.Object) error
 // batch's per-doc delete hook.
 type PostDelete func(ctx context.Context, obj v1alpha1.Object) error
 
+// Prepare runs after validation and before Store.Upsert on a
+// v1alpha1 resource. Wired into resource.Config.Prepare + the apply
+// batch's per-doc prepare hook. Used to mutate the decoded object
+// before persistence (e.g. strip sensitive spec fields).
+type Prepare func(ctx context.Context, obj v1alpha1.Object) error
+
 const (
 	AdmissionSourceApply  = "apply"
 	AdmissionSourceDelete = "delete"
@@ -230,6 +236,13 @@ type AppOptions struct {
 
 	// PostDeletes mirror PostUpserts on the delete path.
 	PostDeletes map[string]PostDelete
+
+	// Prepares run per-kind after validation and before Store.Upsert on
+	// both the dedicated PUT route and the batch /v0/apply path. Keyed by
+	// canonical Kind. Used to mutate the decoded object before persistence
+	// (e.g. strip sensitive spec fields). Missing keys = no prepare
+	// hook for that kind.
+	Prepares map[string]Prepare
 
 	// Admission optionally accepts a validated write before the row reaches
 	// production storage. Nil preserves normal direct writes.


### PR DESCRIPTION
# Description

Add a Prepare hook that runs after validation and before Store.Upsert on both the dedicated PUT route and the batch /v0/apply path, letting downstream builds mutate a decoded object before it is persisted (e.g. strip+encrypt sensitive spec fields).

- types: AppOptions.Prepare map[kind]Prepare + Prepare func type
- resource.Config.Prepare, threaded into registerApplyMutable -> applyCore
- crud.PerKindHooks.Prepares wired into cfgFor; crudPerKindHooks copies AppOptions.Prepare
- router buildApply sets ApplyConfig.Prepare to a kind-dispatcher

# Change Type

```
/kind cleanup
```

# Changelog

```release-note
NONE
```
