### PR TITLE
examples: Update v1alpha1 manifests

### DIFF
--- a/examples/full-stack.yaml
+++ b/examples/full-stack.yaml
@@ -31,8 +31,11 @@ metadata:
   tag: stable
 spec:
   title: Summarization
-  category: nlp
   description: "Summarizes long text into concise form"
+  source:
+    repository:
+      url: https://github.com/acme/agent-skills
+      subfolder: skills/summarize
 ---
 apiVersion: ar.dev/v1alpha1
 kind: Prompt

--- a/examples/mcp-remote.yaml
+++ b/examples/mcp-remote.yaml
@@ -1,5 +1,5 @@
 apiVersion: ar.dev/v1alpha1
-kind: RemoteMCPServer
+kind: MCPServer
 metadata:
   name: databricks-unity-catalog
 spec:

--- a/examples/mcp.yaml
+++ b/examples/mcp.yaml
@@ -11,7 +11,7 @@ spec:
       identifier: localhost:5001/acme/fetch:1.0.0
       runtimeHint: docker                       # optional: hint for local runtime
       transport:
-        type: stdio                             # stdio | sse | streamable-http
+        type: stdio                             # stdio | http
       # Required for every registryType except mcpb. Must match the
       # identity the publisher embedded into the published artifact
       # (e.g. the io.modelcontextprotocol.server.name OCI label, npm mcpName).

--- a/examples/skill.yaml
+++ b/examples/skill.yaml
@@ -4,10 +4,8 @@ metadata:
   name: summarize
 spec:
   title: Summarization
-  category: nlp
   description: "Summarizes long text into concise form"
-  packages:
-    - registryType: oci
-      identifier: ghcr.io/acme/summarize-skill:1.0.0
-      transport:
-        type: stdio                             # OCI containers communicate via stdio
+  source:
+    repository:
+      url: https://github.com/acme/agent-skills
+      subfolder: skills/summarize


### PR DESCRIPTION
# Description

Updates the example v1alpha1 manifests to match the current resource type
definitions.

The remote MCP example now uses `kind: MCPServer` with `spec.remote`, the Skill
examples use `spec.source.repository`, and the MCP package transport comment
matches the current `stdio`/`http` package transport shape.

# Change Type

/kind cleanup

# Changelog

```release-note
NONE
```

# Additional Notes

This is stacked on `cleanup/remove-dead-internal-utils` so the PR diff stays
limited to the examples directory.
