### PR TITLE
ci: Bump checkout action to v6

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - uses: actions/setup-go@v6
       with:

--- a/.github/workflows/chart-tests.yml
+++ b/.github/workflows/chart-tests.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -19,7 +19,7 @@ jobs:
     name: e2e (${{ matrix.backend }})
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Go
         uses: actions/setup-go@v5

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -25,7 +25,7 @@ jobs:
           exit 0
 
       - if: github.event_name != 'merge_group'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Sync /kind labels & enforce changelog fields
         if: github.event_name != 'merge_group'
         uses: kgateway-dev/pr-kind-labeler@main

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
   lint-go:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: actions/setup-go@v6
         with:
@@ -28,7 +28,7 @@ jobs:
   lint-ui:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       contents: read
       packages: write
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 0
 
@@ -75,7 +75,7 @@ jobs:
       contents: write
       packages: write
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 0
 

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -13,7 +13,7 @@ jobs:
   verify:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: actions/setup-go@v6
         with:

--- a/docs/governance/cncf/technical-review.md
+++ b/docs/governance/cncf/technical-review.md
@@ -225,7 +225,7 @@ Operators can set `rbac.watchedNamespaces` in the Helm values to restrict the re
 1. **Reproducible builds** — Container images are built via multi-stage Dockerfiles with pinned base image versions and deterministic Go module dependencies (`go.sum`).
 2. **Multi-platform support** — Images are built for linux/amd64 and linux/arm64 using Docker Buildx, ensuring consistent builds across architectures.
 3. **Checksums** — Helm chart releases include a `checksums.txt` file alongside the packaged charts and CLI binaries in the GitHub Release.
-4. **Pinned CI dependencies** — GitHub Actions workflows use pinned versions for all actions (e.g., `actions/checkout@v4`, `actions/setup-go@v6`, `golangci/golangci-lint-action@v7`).
+4. **Pinned CI dependencies** — GitHub Actions workflows use pinned versions for all actions (e.g., `actions/checkout@v6`, `actions/setup-go@v6`).
 5. **Go module integrity** — Dependencies are verified against `go.sum` checksums and the Go module proxy/checksum database.
 6. **Minimal permissions in CI** — Release workflows request only the permissions needed (`contents: read/write`, `packages: write`), following the principle of least privilege for GitHub Actions tokens.
 


### PR DESCRIPTION
# Description

Bump all GitHub Actions workflow references from `actions/checkout@v4` to `actions/checkout@v6`.

Also update the CNCF technical review example so the pinned CI dependency documentation matches the workflows.

# Change Type

/kind bump

# Changelog

```release-note
NONE
```

# Additional Notes

No runtime behavior changes.
