### PR TITLE
e2e: Remove dead test helpers

### DIFF
--- a/e2e/helpers.go
+++ b/e2e/helpers.go
@@ -138,16 +138,6 @@ func RequireOutputContains(t *testing.T, result ArctlResult, substr string) {
 	}
 }
 
-// RequireEnv skips the test if the given environment variable is not set.
-func RequireEnv(t *testing.T, envVar string) string {
-	t.Helper()
-	val := os.Getenv(envVar)
-	if val == "" {
-		t.Skipf("Skipping: requires %s environment variable", envVar)
-	}
-	return val
-}
-
 // RegistryURL returns the agentregistry URL set during TestMain setup.
 func RegistryURL(t *testing.T) string {
 	t.Helper()
@@ -214,11 +204,6 @@ func WaitForHealth(t *testing.T, url string, timeout time.Duration) {
 		time.Sleep(2 * time.Second)
 	}
 	t.Fatalf("Health check timed out after %v: %s", timeout, url)
-}
-
-// ListServersURL returns the full URL for the list-servers endpoint.
-func ListServersURL(regURL string) string {
-	return regURL + "/servers"
 }
 
 // RegistryGet performs an HTTP GET against the given URL and returns the response.

--- a/e2e/helpers_docker.go
+++ b/e2e/helpers_docker.go
@@ -25,21 +25,6 @@ func CleanupDockerImage(t *testing.T, image string) {
 	})
 }
 
-// CleanupDockerCompose registers a t.Cleanup that runs docker compose down in the given directory.
-func CleanupDockerCompose(t *testing.T, projectDir string) {
-	t.Helper()
-	t.Cleanup(func() {
-		t.Logf("Cleaning up Docker Compose in: %s", projectDir)
-		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
-		defer cancel()
-		cmd := exec.CommandContext(ctx, "docker", "compose", "down", "--volumes", "--remove-orphans")
-		cmd.Dir = projectDir
-		if out, err := cmd.CombinedOutput(); err != nil {
-			t.Logf("Warning: docker compose down failed in %s: %v\n%s", projectDir, err, string(out))
-		}
-	})
-}
-
 // DockerImageExists checks if a Docker image exists locally.
 func DockerImageExists(t *testing.T, image string) bool {
 	t.Helper()

--- a/e2e/init_build_run_test.go
+++ b/e2e/init_build_run_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -231,7 +232,7 @@ func TestE2E_RunWatch_RebuildsOnFileChange(t *testing.T) {
 	for time.Now().Before(deadline) {
 		stdout.Read(buf)
 		got += string(buf)
-		if assert.ObjectsAreEqual(true, contains(got, "Change detected")) {
+		if strings.Contains(got, "Change detected") {
 			return
 		}
 	}
@@ -325,15 +326,4 @@ spec:
 	assert.Contains(t, combined, "remote MCPServer")
 	assert.Contains(t, combined, "npx -y @modelcontextprotocol/inspector")
 	assert.Contains(t, combined, "https://example.test/mcp")
-}
-
-func contains(s, sub string) bool {
-	return len(s) >= len(sub) && (s == sub || (func() bool {
-		for i := 0; i+len(sub) <= len(s); i++ {
-			if s[i:i+len(sub)] == sub {
-				return true
-			}
-		}
-		return false
-	}()))
 }

--- a/e2e/remote_resources_test.go
+++ b/e2e/remote_resources_test.go
@@ -7,19 +7,8 @@ package e2e
 
 import (
 	"fmt"
-	"net/http"
 	"testing"
 )
-
-// verifyMCPServerExists checks that the MCPServer exists in the registry via HTTP GET.
-func verifyMCPServerExists(t *testing.T, regURL, name, tag string) {
-	t.Helper()
-	resp := RegistryGet(t, resourceURL(regURL, "mcpservers", name, tag))
-	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("Expected MCPServer %s@%s to exist (HTTP 200) but got %d", name, tag, resp.StatusCode)
-	}
-}
 
 // TestDeclarativeApply_RemoteMCPServer covers apply → get → delete for a
 // remote MCPServer (Spec.Remote set). Verifies the row is created and is
@@ -55,7 +44,7 @@ spec:
 	RequireSuccess(t, result)
 	RequireOutputContains(t, result, "MCPServer/"+name)
 
-	verifyMCPServerExists(t, regURL, name, tag)
+	verifyServerExists(t, regURL, name, tag)
 }
 
 // TestDeclarativeApply_AgentReferencesRemoteMCPServer covers an Agent
@@ -112,6 +101,6 @@ spec:
 	RequireOutputContains(t, result, "MCPServer/"+remoteName)
 	RequireOutputContains(t, result, "Agent/"+agentName)
 
-	verifyMCPServerExists(t, regURL, remoteName, tag)
+	verifyServerExists(t, regURL, remoteName, tag)
 	verifyAgentExists(t, regURL, agentName, tag)
 }


### PR DESCRIPTION
# Description

Remove dead and duplicate helper code from the e2e suite before larger test
pyramid refactoring. This drops unused environment, server URL, and Docker
Compose helpers, reuses the shared MCP server existence verifier, and replaces
a hand-rolled substring helper with `strings.Contains`.

# Change Type

/kind cleanup

# Changelog

```release-note
NONE
```

# Additional Notes

Verified with `go test -c -tags=e2e ./e2e`.
