### PR TITLE
ci: drop redundant caches and add timeout in build workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,6 +12,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
     - uses: actions/checkout@v6
@@ -27,22 +28,8 @@ jobs:
       uses: actions/setup-node@v4
       with:
         node-version: 20.9.x
-
-    - name: Cache Go modules
-      uses: actions/cache@v3
-      with:
-        path: ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
-
-    - name: Cache npm dependencies
-      uses: actions/cache@v3
-      with:
-        path: ui/node_modules
-        key: ${{ runner.os }}-node-${{ hashFiles('ui/package-lock.json') }}
-        restore-keys: |
-          ${{ runner.os }}-node-
+        cache: npm
+        cache-dependency-path: ui/package-lock.json
 
     - name: Install UI Dependencies
       run: npm ci


### PR DESCRIPTION
# Description

Refactor build.yaml: setup-go/setup-node already handle module and
npm caching, so the two manual actions/cache@v3 steps were redundant.
Removed them and added a job timeout. Fixes #469.

# Change Type

/kind cleanup

# Changelog

```release-note
NONE
```
