### PR TITLE
support ns/name refs for all commands

### DIFF
--- a/internal/cli/declarative/all_tags_test.go
+++ b/internal/cli/declarative/all_tags_test.go
@@ -87,8 +87,12 @@ func tagsListServer(t *testing.T, rows []v1alpha1.Agent) (*httptest.Server, *[]s
 		captured []string
 	)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path := r.URL.Path
+		if r.URL.RawQuery != "" {
+			path += "?" + r.URL.RawQuery
+		}
 		mu.Lock()
-		captured = append(captured, r.Method+" "+r.URL.Path)
+		captured = append(captured, r.Method+" "+path)
 		mu.Unlock()
 		if r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/tags") {
 			w.Header().Set("Content-Type", "application/json")
@@ -127,6 +131,23 @@ func TestGet_AllTags_Agent_PrintsAllRows(t *testing.T) {
 	for _, line := range []string{"acme-bot   2", "acme-bot   1"} {
 		assert.Contains(t, got, line, "expected %q in output:\n%s", line, got)
 	}
+}
+
+func TestGet_AllTags_Agent_PrintsAllRowsByNamespaceName(t *testing.T) {
+	rows := []v1alpha1.Agent{
+		agentTagFixture("acme-bot", "2"),
+		agentTagFixture("acme-bot", "1"),
+	}
+	srv, paths := tagsListServer(t, rows)
+	setupClientForServer(t, srv)
+
+	cmd := declarative.NewGetCmd(declarativeTestDeps(nil))
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"agent", "team-a/acme-bot", "--all-tags"})
+	require.NoError(t, cmd.Execute())
+
+	require.Contains(t, *paths, "GET /v0/agents/acme-bot/tags?namespace=team-a")
 }
 
 // (2) `arctl get agent NAME --all-tags -o json` emits a JSON array of
@@ -212,8 +233,12 @@ func deleteAllTagsServer(t *testing.T, rows []v1alpha1.Agent, failTag string) (*
 		captured []string
 	)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path := r.URL.Path
+		if r.URL.RawQuery != "" {
+			path += "?" + r.URL.RawQuery
+		}
 		mu.Lock()
-		captured = append(captured, r.Method+" "+r.URL.Path)
+		captured = append(captured, r.Method+" "+path)
 		mu.Unlock()
 		switch {
 		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/tags"):
@@ -254,6 +279,25 @@ func TestDelete_AllTags_Agent_DeletesEveryListedTag(t *testing.T) {
 	require.Contains(t, *paths, "DELETE /v0/agents/acme-bot/stable")
 	require.Contains(t, *paths, "DELETE /v0/agents/acme-bot/latest")
 	assert.Contains(t, out.String(), "all tags")
+}
+
+func TestDelete_AllTags_Agent_DeletesEveryListedTagByNamespaceName(t *testing.T) {
+	rows := []v1alpha1.Agent{
+		agentTagFixture("acme-bot", "stable"),
+		agentTagFixture("acme-bot", "latest"),
+	}
+	srv, paths := deleteAllTagsServer(t, rows, "")
+	setupClientForServer(t, srv)
+
+	cmd := declarative.NewDeleteCmd(declarativeTestDeps(nil))
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"agent", "team-a/acme-bot", "--all-tags"})
+	require.NoError(t, cmd.Execute())
+
+	require.Contains(t, *paths, "GET /v0/agents/acme-bot/tags?namespace=team-a")
+	require.Contains(t, *paths, "DELETE /v0/agents/acme-bot/stable?namespace=team-a")
+	require.Contains(t, *paths, "DELETE /v0/agents/acme-bot/latest?namespace=team-a")
 }
 
 // (7) `arctl delete deployment NAME --all-tags` errors cleanly.

--- a/internal/cli/declarative/declarative.go
+++ b/internal/cli/declarative/declarative.go
@@ -3,6 +3,7 @@ package declarative
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -115,19 +116,21 @@ func init() {
 		},
 	})
 
-	// Deployment is registered manually because its Get/Delete dispatch
-	// does NOT key on the v1alpha1 metadata identity (namespace/name/
-	// tag). Users address deployments by the underlying target's name
-	// — `arctl get deployment <agent-or-mcp-name>` — and the CLI walks the
-	// /v0/deployments listing to find the matching row. The typed
-	// helper assumes (kind, namespace, name, tag) lookup, which is
-	// the wrong shape for this dispatch.
+	// Deployment is registered manually because it is a mutable namespace/name
+	// object: the server's deployment store does not expose /tags or
+	// DeleteAllTags endpoints. Get accepts either NAME or NAMESPACE/NAME;
+	// ListTags / DeleteAllTags are intentionally omitted so the dispatch layer
+	// rejects --all-tags cleanly.
 	scheme.Register(&scheme.Kind{
 		Kind:    "deployment",
 		Plural:  "deployments",
 		Aliases: []string{"Deployment"},
 		Get: func(ctx context.Context, c *client.Client, name, _ string) (any, error) {
-			deployment, err := client.GetTyped(ctx, c, v1alpha1.KindDeployment, v1alpha1.DefaultNamespace, name, "", func() *v1alpha1.Deployment { return &v1alpha1.Deployment{} })
+			namespace, deploymentName, err := deploymentLookupRef(name)
+			if err != nil {
+				return nil, err
+			}
+			deployment, err := client.GetTyped(ctx, c, v1alpha1.KindDeployment, namespace, deploymentName, "", func() *v1alpha1.Deployment { return &v1alpha1.Deployment{} })
 			if err != nil {
 				return nil, err
 			}
@@ -158,6 +161,16 @@ func init() {
 			{Header: "TYPE"}, {Header: "RUNTIME"}, {Header: "STATUS"},
 		},
 	})
+}
+
+func deploymentLookupRef(arg string) (namespace, name string, err error) {
+	if namespace, name, ok := strings.Cut(arg, "/"); ok {
+		if namespace == "" || name == "" || strings.Contains(name, "/") {
+			return "", "", fmt.Errorf("deployment reference must be NAME or NAMESPACE/NAME")
+		}
+		return namespace, name, nil
+	}
+	return v1alpha1.DefaultNamespace, arg, nil
 }
 
 // typedKind builds a scheme.Kind whose Get / List / Delete dispatch

--- a/internal/cli/declarative/declarative.go
+++ b/internal/cli/declarative/declarative.go
@@ -3,7 +3,6 @@ package declarative
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -106,7 +105,11 @@ func init() {
 			return runtimeRow(runtime)
 		},
 		Get: func(ctx context.Context, c *client.Client, name, _ string) (any, error) {
-			return client.GetTyped(ctx, c, v1alpha1.KindRuntime, v1alpha1.DefaultNamespace, name, "", func() *v1alpha1.Runtime { return &v1alpha1.Runtime{} })
+			ref, err := parseResourceLookupRef(name)
+			if err != nil {
+				return nil, err
+			}
+			return client.GetTyped(ctx, c, v1alpha1.KindRuntime, ref.Namespace, ref.Name, "", func() *v1alpha1.Runtime { return &v1alpha1.Runtime{} })
 		},
 		ListFunc: func(ctx context.Context, c *client.Client, opts scheme.ListOpts) ([]any, error) {
 			return listAny(ctx, c, v1alpha1.KindRuntime, opts, func() *v1alpha1.Runtime { return &v1alpha1.Runtime{} })
@@ -118,19 +121,19 @@ func init() {
 
 	// Deployment is registered manually because it is a mutable namespace/name
 	// object: the server's deployment store does not expose /tags or
-	// DeleteAllTags endpoints. Get accepts either NAME or NAMESPACE/NAME;
-	// ListTags / DeleteAllTags are intentionally omitted so the dispatch layer
-	// rejects --all-tags cleanly.
+	// DeleteAllTags endpoints. Explicit get/delete accept either NAME or
+	// NAMESPACE/NAME; ListTags / DeleteAllTags are intentionally omitted so
+	// the dispatch layer rejects --all-tags cleanly.
 	scheme.Register(&scheme.Kind{
 		Kind:    "deployment",
 		Plural:  "deployments",
 		Aliases: []string{"Deployment"},
 		Get: func(ctx context.Context, c *client.Client, name, _ string) (any, error) {
-			namespace, deploymentName, err := deploymentLookupRef(name)
+			ref, err := parseResourceLookupRef(name)
 			if err != nil {
 				return nil, err
 			}
-			deployment, err := client.GetTyped(ctx, c, v1alpha1.KindDeployment, namespace, deploymentName, "", func() *v1alpha1.Deployment { return &v1alpha1.Deployment{} })
+			deployment, err := client.GetTyped(ctx, c, v1alpha1.KindDeployment, ref.Namespace, ref.Name, "", func() *v1alpha1.Deployment { return &v1alpha1.Deployment{} })
 			if err != nil {
 				return nil, err
 			}
@@ -163,16 +166,6 @@ func init() {
 	})
 }
 
-func deploymentLookupRef(arg string) (namespace, name string, err error) {
-	if namespace, name, ok := strings.Cut(arg, "/"); ok {
-		if namespace == "" || name == "" || strings.Contains(name, "/") {
-			return "", "", fmt.Errorf("deployment reference must be NAME or NAMESPACE/NAME")
-		}
-		return namespace, name, nil
-	}
-	return v1alpha1.DefaultNamespace, arg, nil
-}
-
 // typedKind builds a scheme.Kind whose Get / List / Delete dispatch
 // closures all wire through the typed v1alpha1 client helpers
 // (client.GetTyped[T] / client.ListAllTyped[T] / client.Delete) for
@@ -202,7 +195,11 @@ func typedKind[T v1alpha1.Object](
 			return row(t)
 		},
 		Get: func(ctx context.Context, c *client.Client, name, tag string) (any, error) {
-			return client.GetTyped(ctx, c, canonicalKind, v1alpha1.DefaultNamespace, name, tag, newObj)
+			ref, err := parseResourceLookupRef(name)
+			if err != nil {
+				return nil, err
+			}
+			return client.GetTyped(ctx, c, canonicalKind, ref.Namespace, ref.Name, tag, newObj)
 		},
 		ListFunc: func(ctx context.Context, c *client.Client, opts scheme.ListOpts) ([]any, error) {
 			return listAny(ctx, c, canonicalKind, opts, newObj)

--- a/internal/cli/declarative/delete.go
+++ b/internal/cli/declarative/delete.go
@@ -34,7 +34,7 @@ TYPE must be one of: agent, mcp, skill, prompt, deployment
   arctl delete agent acme-summarizer --tag stable
   arctl delete agent acme-summarizer --all-tags
   arctl delete mcp acme-fetch --tag stable
-  arctl delete deployment my-agent`,
+  arctl delete deployment team-a/my-agent`,
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runDeclarativeDelete(cmd, deps, args)

--- a/internal/cli/declarative/deployment_delete_test.go
+++ b/internal/cli/declarative/deployment_delete_test.go
@@ -45,10 +45,14 @@ func deploymentTestServer(t *testing.T, list []v1alpha1.Deployment, failIDs map[
 		}
 		switch r.Method {
 		case http.MethodGet:
+			namespace := r.URL.Query().Get("namespace")
+			if namespace == "" {
+				namespace = v1alpha1.DefaultNamespace
+			}
 			mu.Lock()
 			defer mu.Unlock()
 			for _, d := range list {
-				if d.Metadata.Name == parts[0] {
+				if d.Metadata.Name == parts[0] && d.Metadata.NamespaceOrDefault() == namespace {
 					_ = json.NewEncoder(w).Encode(d)
 					return
 				}
@@ -94,6 +98,22 @@ func TestDeploymentDelete_RemovesNamedDeployment(t *testing.T) {
 
 	assert.ElementsMatch(t, []string{"aws-v1"}, *deleted,
 		"every deployment targeting summarizer should be deleted; unrelated targets untouched")
+}
+
+func TestDeploymentDelete_RemovesMatchByNamespaceName(t *testing.T) {
+	defaultDeployment := deploymentFixture("aws-v1", "default-summarizer", "1.0.0", "my-aws", "agent", "pending")
+	teamDeployment := deploymentFixture("aws-v1", "team-summarizer", "1.0.0", "my-aws", "agent", "pending")
+	teamDeployment.Metadata.Namespace = "team-a"
+	srv, deleted, capturedQuery := deploymentTestServer(t, []v1alpha1.Deployment{defaultDeployment, teamDeployment}, nil)
+	setupClientForServer(t, srv)
+
+	cmd := declarative.NewDeleteCmd(declarativeTestDeps(nil))
+	cmd.SetArgs([]string{"deployment", "team-a/aws-v1"})
+	require.NoError(t, cmd.Execute())
+
+	assert.ElementsMatch(t, []string{"aws-v1"}, *deleted)
+	require.Len(t, *capturedQuery, 1)
+	assert.Equal(t, "namespace=team-a", (*capturedQuery)[0])
 }
 
 // (2) When no deployment matches the target name, returns a not-found error.

--- a/internal/cli/declarative/deployment_get_test.go
+++ b/internal/cli/declarative/deployment_get_test.go
@@ -83,10 +83,14 @@ func deploymentTestServerV1Alpha1(t *testing.T, deployments []v1alpha1.Deploymen
 			http.Error(w, `{"error":"bad get path"}`, http.StatusBadRequest)
 			return
 		}
+		namespace := r.URL.Query().Get("namespace")
+		if namespace == "" {
+			namespace = v1alpha1.DefaultNamespace
+		}
 		mu.Lock()
 		defer mu.Unlock()
 		for _, d := range deployments {
-			if d.Metadata.Name == parts[0] {
+			if d.Metadata.Name == parts[0] && d.Metadata.NamespaceOrDefault() == namespace {
 				_ = json.NewEncoder(w).Encode(d)
 				return
 			}
@@ -117,6 +121,25 @@ func TestDeploymentGet_ReturnsMatchByName(t *testing.T) {
 		"get should render the matching deployment's name in the table output "+out.String())
 	assert.NotContains(t, out.String(), "unrelated",
 		"unrelated deployments must not appear")
+}
+
+func TestDeploymentGet_ReturnsMatchByNamespaceName(t *testing.T) {
+	defaultDeployment := deploymentFixture("aws-v1", "default-summarizer", "1.0.0", "my-aws", "agent", "deployed")
+	teamDeployment := deploymentFixture("aws-v1", "team-summarizer", "1.0.0", "my-aws", "agent", "deployed")
+	teamDeployment.Metadata.Namespace = "team-a"
+
+	srv := deploymentTestServerV1Alpha1(t, []v1alpha1.Deployment{defaultDeployment, teamDeployment})
+	setupClientForServer(t, srv)
+
+	out := &bytes.Buffer{}
+	cmd := declarative.NewGetCmd(declarativeTestDeps(nil))
+	cmd.SetOut(out)
+	cmd.SetArgs([]string{"deployment", "team-a/aws-v1"})
+	require.NoError(t, cmd.Execute())
+
+	assert.Contains(t, out.String(), "team-a/aws-v1")
+	assert.Contains(t, out.String(), "team-summarizer")
+	assert.NotContains(t, out.String(), "default-summarizer")
 }
 
 // (3) Get surfaces the registry's not-found sentinel when no deployment matches.

--- a/internal/cli/declarative/deployment_wait_test.go
+++ b/internal/cli/declarative/deployment_wait_test.go
@@ -43,10 +43,14 @@ func deploymentWaitTestServer(t *testing.T, deployments []v1alpha1.Deployment) *
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
+		namespace := r.URL.Query().Get("namespace")
+		if namespace == "" {
+			namespace = v1alpha1.DefaultNamespace
+		}
 		mu.Lock()
 		defer mu.Unlock()
 		for _, d := range deployments {
-			if d.Metadata.Name == parts[0] {
+			if d.Metadata.Name == parts[0] && d.Metadata.NamespaceOrDefault() == namespace {
 				_ = json.NewEncoder(w).Encode(d)
 				return
 			}
@@ -72,6 +76,22 @@ func TestDeploymentWait_DeployedReturnsImmediately(t *testing.T) {
 
 	require.NoError(t, cmd.Execute())
 	assert.Contains(t, out.String(), "deployment/aws-v1 deployed")
+}
+
+func TestDeploymentWait_ReturnsMatchByNamespaceName(t *testing.T) {
+	defaultDeployment := deploymentFixture("aws-v1", "default-summarizer", "1.0.0", "my-aws", "agent", "failed")
+	teamDeployment := deploymentFixture("aws-v1", "team-summarizer", "1.0.0", "my-aws", "agent", "deployed")
+	teamDeployment.Metadata.Namespace = "team-a"
+	srv := deploymentWaitTestServer(t, []v1alpha1.Deployment{defaultDeployment, teamDeployment})
+	setupClientForServer(t, srv)
+
+	out := &bytes.Buffer{}
+	cmd := declarative.NewWaitCmd(declarativeTestDeps(nil))
+	cmd.SetOut(out)
+	cmd.SetArgs([]string{"deployment", "team-a/aws-v1", "--timeout=1s"})
+
+	require.NoError(t, cmd.Execute())
+	assert.Contains(t, out.String(), "deployment/team-a/aws-v1 deployed")
 }
 
 // Terminal failure when waiting for "deployed" surfaces an error rather than

--- a/internal/cli/declarative/extension.go
+++ b/internal/cli/declarative/extension.go
@@ -62,7 +62,11 @@ func NewExtensionKind(k ExtensionKind) *scheme.Kind {
 			return []string{meta.Name}
 		},
 		Get: func(ctx context.Context, c *client.Client, name, _ string) (any, error) {
-			return client.GetTyped(ctx, c, k.CanonicalKind, v1alpha1.DefaultNamespace, name, "", k.NewObject)
+			ref, err := parseResourceLookupRef(name)
+			if err != nil {
+				return nil, err
+			}
+			return client.GetTyped(ctx, c, k.CanonicalKind, ref.Namespace, ref.Name, "", k.NewObject)
 		},
 		ListFunc: func(ctx context.Context, c *client.Client, opts scheme.ListOpts) ([]any, error) {
 			return listAny(ctx, c, k.CanonicalKind, opts, k.NewObject)

--- a/internal/cli/declarative/get.go
+++ b/internal/cli/declarative/get.go
@@ -35,6 +35,7 @@ Examples:
   arctl get agent acme-summarizer -o yaml
   arctl get agent acme-summarizer --tag stable
   arctl get agent acme-summarizer --all-tags
+  arctl get deployment team-a/acme-summarizer
   arctl get skills -o json`,
 		Args:         cobra.RangeArgs(1, 2),
 		SilenceUsage: true,

--- a/internal/cli/declarative/get_test.go
+++ b/internal/cli/declarative/get_test.go
@@ -96,8 +96,12 @@ func tagGetServer(t *testing.T, latest, specific v1alpha1.Agent) (*httptest.Serv
 		captured []string
 	)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path := r.URL.Path
+		if r.URL.RawQuery != "" {
+			path += "?" + r.URL.RawQuery
+		}
 		mu.Lock()
-		captured = append(captured, r.Method+" "+r.URL.Path)
+		captured = append(captured, r.Method+" "+path)
 		mu.Unlock()
 		if r.Method != http.MethodGet {
 			http.Error(w, `{"error":"method"}`, http.StatusMethodNotAllowed)
@@ -148,6 +152,22 @@ func TestGet_Tag_FetchesSpecificTag(t *testing.T) {
 		}
 	}
 	assert.True(t, hitSpecific, "expected GET to exact-tag path, got %v", *captured)
+}
+
+func TestGet_Tag_FetchesSpecificTagByNamespaceName(t *testing.T) {
+	v1 := agentTagFixture("acme-bot", "1")
+	v2 := agentTagFixture("acme-bot", "2")
+	srv, captured := tagGetServer(t, v2, v1)
+	setupClientForServer(t, srv)
+
+	out := &bytes.Buffer{}
+	cmd := declarative.NewGetCmd(declarativeTestDeps(nil))
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.SetArgs([]string{"agent", "team-a/acme-bot", "--tag", "1", "-o", "json"})
+	require.NoError(t, cmd.Execute())
+
+	require.Contains(t, *captured, "GET /v0/agents/acme-bot/1?namespace=team-a")
 }
 
 // TestGet_Tag_DefaultsToLatest verifies that omitting --tag still

--- a/internal/cli/declarative/kinds_dispatch.go
+++ b/internal/cli/declarative/kinds_dispatch.go
@@ -9,9 +9,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/agentregistry-dev/agentregistry/internal/cli/scheme"
 	"github.com/agentregistry-dev/agentregistry/internal/client"
+	"github.com/agentregistry-dev/agentregistry/pkg/api/v1alpha1"
 	cliruntime "github.com/agentregistry-dev/agentregistry/pkg/cli/runtime"
 )
 
@@ -25,6 +27,24 @@ func kindRegistry(deps cliruntime.Deps) *scheme.Registry {
 		return deps.Kinds
 	}
 	return scheme.NewRegistry(scheme.All()...)
+}
+
+type resourceLookupRef struct {
+	Namespace string
+	Name      string
+}
+
+func parseResourceLookupRef(arg string) (resourceLookupRef, error) {
+	if arg == "" {
+		return resourceLookupRef{}, fmt.Errorf("resource reference must be NAME or NAMESPACE/NAME")
+	}
+	if namespace, name, ok := strings.Cut(arg, "/"); ok {
+		if namespace == "" || name == "" || strings.Contains(name, "/") {
+			return resourceLookupRef{}, fmt.Errorf("resource reference must be NAME or NAMESPACE/NAME")
+		}
+		return resourceLookupRef{Namespace: namespace, Name: name}, nil
+	}
+	return resourceLookupRef{Namespace: v1alpha1.DefaultNamespace, Name: arg}, nil
 }
 
 // listItems fetches items for the given kind using its registered ListFunc.

--- a/internal/cli/declarative/resources.go
+++ b/internal/cli/declarative/resources.go
@@ -67,7 +67,11 @@ func listAny[T v1alpha1.Object](ctx context.Context, c *client.Client, kind stri
 // listTagsAny lists artifact tags and erases the concrete envelope type so the
 // table printer can format the rows.
 func listTagsAny[T v1alpha1.Object](ctx context.Context, c *client.Client, kind, name string, newObj func() T) ([]any, error) {
-	items, err := client.ListTagsOfName(ctx, c, kind, v1alpha1.DefaultNamespace, name, newObj)
+	ref, err := parseResourceLookupRef(name)
+	if err != nil {
+		return nil, err
+	}
+	items, err := client.ListTagsOfName(ctx, c, kind, ref.Namespace, ref.Name, newObj)
 	if err != nil {
 		return nil, err
 	}
@@ -82,23 +86,22 @@ func listTagsAny[T v1alpha1.Object](ctx context.Context, c *client.Client, kind,
 // imperative command can report tag-scoped failures while preserving the
 // declarative DELETE /v0/apply contract for file input.
 func deleteAllTagsAny[T v1alpha1.Object](ctx context.Context, c *client.Client, kind, name string, newObj func() T) error {
-	items, err := listTagsAny(ctx, c, kind, name, newObj)
+	ref, err := parseResourceLookupRef(name)
+	if err != nil {
+		return err
+	}
+	items, err := client.ListTagsOfName(ctx, c, kind, ref.Namespace, ref.Name, newObj)
 	if err != nil {
 		return err
 	}
 	var errs []error
 	for _, item := range items {
-		obj, ok := item.(v1alpha1.Object)
-		if !ok {
-			errs = append(errs, fmt.Errorf("%s/%s: unexpected tag list item type %T", kind, name, item))
-			continue
-		}
-		tag := obj.GetMetadata().Tag
+		tag := item.GetMetadata().Tag
 		if tag == "" {
 			errs = append(errs, fmt.Errorf("%s/%s: listed tag row has empty metadata.tag", kind, name))
 			continue
 		}
-		if err := c.Delete(ctx, kind, v1alpha1.DefaultNamespace, name, tag); err != nil {
+		if err := c.Delete(ctx, kind, ref.Namespace, ref.Name, tag); err != nil {
 			errs = append(errs, fmt.Errorf("%s/%s@%s: %w", kind, name, tag, err))
 		}
 	}
@@ -106,15 +109,19 @@ func deleteAllTagsAny[T v1alpha1.Object](ctx context.Context, c *client.Client, 
 }
 
 func deleteAny[T v1alpha1.Object](ctx context.Context, c *client.Client, kind, name, tag string, newObj func() T) error {
+	ref, err := parseResourceLookupRef(name)
+	if err != nil {
+		return err
+	}
 	targetTag := tag
 	if targetTag == "" {
-		obj, err := client.GetTyped(ctx, c, kind, v1alpha1.DefaultNamespace, name, "", newObj)
+		obj, err := client.GetTyped(ctx, c, kind, ref.Namespace, ref.Name, "", newObj)
 		if err != nil {
 			return err
 		}
 		targetTag = obj.GetMetadata().Tag
 	}
-	return c.Delete(ctx, kind, v1alpha1.DefaultNamespace, name, targetTag)
+	return c.Delete(ctx, kind, ref.Namespace, ref.Name, targetTag)
 }
 
 func listDeploymentAny(ctx context.Context, c *client.Client) ([]any, error) {

--- a/internal/cli/declarative/runtime_get_test.go
+++ b/internal/cli/declarative/runtime_get_test.go
@@ -28,8 +28,12 @@ func runtimeTestServer(t *testing.T, runtimes []v1alpha1.Runtime) *httptest.Serv
 			return
 		}
 		name := strings.TrimPrefix(r.URL.Path, "/v0/runtimes/")
+		namespace := r.URL.Query().Get("namespace")
+		if namespace == "" {
+			namespace = v1alpha1.DefaultNamespace
+		}
 		for _, rt := range runtimes {
-			if rt.Metadata.Name == name {
+			if rt.Metadata.Name == name && rt.Metadata.NamespaceOrDefault() == namespace {
 				w.Header().Set("Content-Type", "application/json")
 				_ = json.NewEncoder(w).Encode(rt)
 				return
@@ -108,4 +112,24 @@ func TestRuntimeGet_TableOutput(t *testing.T) {
 	got := out.String()
 	assert.Contains(t, got, "my-kagent")
 	assert.Contains(t, got, "Kagent")
+}
+
+func TestRuntimeGet_ReturnsMatchByNamespaceName(t *testing.T) {
+	defaultRuntime := runtimeFixture("my-kagent", "Local", nil)
+	teamRuntime := runtimeFixture("my-kagent", "Kagent", map[string]any{"namespace": "team-kagent"})
+	teamRuntime.Metadata.Namespace = "team-a"
+	runtimes := []v1alpha1.Runtime{defaultRuntime, teamRuntime}
+	srv := runtimeTestServer(t, runtimes)
+	setupClientForServer(t, srv)
+
+	out := &bytes.Buffer{}
+	cmd := declarative.NewGetCmd(declarativeTestDeps(nil))
+	cmd.SetOut(out)
+	cmd.SetArgs([]string{"runtime", "team-a/my-kagent"})
+	require.NoError(t, cmd.Execute())
+
+	got := out.String()
+	assert.Contains(t, got, "my-kagent")
+	assert.Contains(t, got, "Kagent")
+	assert.NotContains(t, got, "Local")
 }

--- a/internal/cli/declarative/wait.go
+++ b/internal/cli/declarative/wait.go
@@ -36,6 +36,7 @@ Timeout regimes:
   --timeout=0    poll once and return the current state
   --timeout=-1   wait forever`,
 		Example: `  arctl wait deployment aws-v1
+  arctl wait deployment team-a/aws-v1
   arctl wait deployment aws-v1 --for=failed
   arctl wait deployment aws-v1 --for=delete --timeout=10m`,
 		Args:         cobra.ExactArgs(2),
@@ -52,6 +53,10 @@ Timeout regimes:
 
 func runDeclarativeWait(cmd *cobra.Command, deps cliruntime.Deps, args []string) error {
 	typeName, name := args[0], args[1]
+	ref, err := parseResourceLookupRef(name)
+	if err != nil {
+		return err
+	}
 	k, err := kindRegistry(deps).Lookup(typeName)
 	if err != nil {
 		return err
@@ -90,7 +95,7 @@ func runDeclarativeWait(cmd *cobra.Command, deps cliruntime.Deps, args []string)
 	}
 
 	resolve := func(ctx context.Context) (*cliCommon.DeploymentRecord, error) {
-		return resolveDeploymentForWait(ctx, c, name)
+		return resolveDeploymentForWait(ctx, c, ref)
 	}
 
 	if err := cliCommon.WaitForDeployment(cmd.Context(), resolve, opts); err != nil {
@@ -105,9 +110,9 @@ func runDeclarativeWait(cmd *cobra.Command, deps cliruntime.Deps, args []string)
 	return nil
 }
 
-func resolveDeploymentForWait(ctx context.Context, c *client.Client, name string) (*cliCommon.DeploymentRecord, error) {
+func resolveDeploymentForWait(ctx context.Context, c *client.Client, ref resourceLookupRef) (*cliCommon.DeploymentRecord, error) {
 	dep, err := client.GetTyped(ctx, c, v1alpha1.KindDeployment,
-		v1alpha1.DefaultNamespace, name, "",
+		ref.Namespace, ref.Name, "",
 		func() *v1alpha1.Deployment { return &v1alpha1.Deployment{} })
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
# Description

- **Motivation:** when you run `arctl get <resources> ` they return with `namespace/name` but you can't operate a single resource with that format
- **What changed:** add parsing to support `arctl get|delete|wait <resource> <ns>/<name>` and pass the namespace to the API correctly

# Change Type

```
/kind feature
```

# Changelog

```release-note
Added namespace/name support for arctl get, delete, and wait resource lookups
```

# Additional Notes