### PR TITLE
fix(discovery): lifecycle for stale and orphaned discovered Deployments

### DIFF
--- a/internal/registry/controller/discovery.go
+++ b/internal/registry/controller/discovery.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
 
 	"github.com/agentregistry-dev/agentregistry/pkg/api/v1alpha1"
+	pkgdb "github.com/agentregistry-dev/agentregistry/pkg/registry/database"
 	"github.com/agentregistry-dev/agentregistry/pkg/registry/v1alpha1store"
 	"github.com/agentregistry-dev/agentregistry/pkg/types"
 )
@@ -16,6 +18,20 @@ import (
 const (
 	deploymentDiscoveryCondition = "Discovered"
 	deploymentRuntimeDetailsKey  = "runtimeMetadata"
+
+	// deploymentDiscoveryMissesKey tracks, in status details, how many
+	// consecutive successful polls omitted a discovered row. Provider list
+	// APIs (notably AWS) are eventually consistent, so a single missing poll
+	// is not evidence the workload is gone.
+	deploymentDiscoveryMissesKey = "discoveryMisses"
+	// deploymentDiscoveryStaleAfterMisses is how many consecutive misses it
+	// takes before the Discovered/Ready conditions flip to False.
+	deploymentDiscoveryStaleAfterMisses = 3
+	// deploymentDiscoveryDeleteAfterMisses is how many consecutive misses it
+	// takes before the row is deleted outright. Rows whose Runtime no longer
+	// exists skip the counter and are deleted immediately — no future poll
+	// could confirm them again.
+	deploymentDiscoveryDeleteAfterMisses = 5
 )
 
 // DeploymentDiscoveryController materializes adapter discovery snapshots into
@@ -30,7 +46,12 @@ type DeploymentDiscoveryController struct {
 type DeploymentDiscoverySyncResult struct {
 	Runtimes   int
 	Discovered int
-	Stale      int
+	// Stale counts discovered rows currently at or past the consecutive-miss
+	// staleness threshold (their Discovered/Ready conditions are False).
+	Stale int
+	// Removed counts discovered rows deleted this pass — either past the
+	// consecutive-miss deletion threshold or orphaned by Runtime deletion.
+	Removed int
 }
 
 func (c *DeploymentDiscoveryController) Run(ctx context.Context, interval time.Duration) error {
@@ -45,7 +66,7 @@ func (c *DeploymentDiscoveryController) Run(ctx context.Context, interval time.D
 		if err != nil {
 			logger.Error("deployment discovery sync failed", "error", err)
 		} else {
-			logger.Debug("deployment discovery synced", "runtimes", result.Runtimes, "discovered", result.Discovered, "stale", result.Stale)
+			logger.Debug("deployment discovery synced", "runtimes", result.Runtimes, "discovered", result.Discovered, "stale", result.Stale, "removed", result.Removed)
 		}
 
 		timer := time.NewTimer(interval)
@@ -76,11 +97,13 @@ func (c *DeploymentDiscoveryController) Sync(ctx context.Context) (DeploymentDis
 	var result DeploymentDiscoverySyncResult
 	var firstErr error
 	observed := map[string]struct{}{}
+	knownRuntimes := map[string]struct{}{}
 	successfulRuntimes := map[string]struct{}{}
 	for _, runtime := range runtimes {
 		if runtime == nil {
 			continue
 		}
+		knownRuntimes[runtimeDiscoveryKey(runtime.Metadata.NamespaceOrDefault(), runtime.Metadata.Name)] = struct{}{}
 		adapter := c.Adapters[strings.TrimSpace(runtime.Spec.Type)]
 		if adapter == nil {
 			continue
@@ -129,16 +152,45 @@ func (c *DeploymentDiscoveryController) Sync(ctx context.Context) (DeploymentDis
 		if _, ok := observed[key]; ok {
 			continue
 		}
-		if _, ok := successfulRuntimes[deploymentRuntimeKey(deployment)]; !ok {
+		runtimeKey := deploymentRuntimeKey(deployment)
+		if _, ok := knownRuntimes[runtimeKey]; !ok {
+			// The owning Runtime row is gone, so no future poll can confirm
+			// this workload again. Remove the row immediately.
+			if err := c.deleteDiscoveredDeployment(ctx, deployment); err != nil {
+				if firstErr == nil {
+					firstErr = err
+				}
+				continue
+			}
+			result.Removed++
 			continue
 		}
-		if err := c.patchStaleStatus(ctx, deployment); err != nil {
+		if _, ok := successfulRuntimes[runtimeKey]; !ok {
+			// The Runtime exists but this pass could not confirm provider
+			// state (discovery errored, or the adapter does not implement
+			// discovery). Leave the row untouched rather than guess.
+			continue
+		}
+		misses := discoveredMissCount(deployment) + 1
+		if misses >= deploymentDiscoveryDeleteAfterMisses {
+			if err := c.deleteDiscoveredDeployment(ctx, deployment); err != nil {
+				if firstErr == nil {
+					firstErr = err
+				}
+				continue
+			}
+			result.Removed++
+			continue
+		}
+		if err := c.patchMissedStatus(ctx, deployment, misses); err != nil {
 			if firstErr == nil {
 				firstErr = err
 			}
 			continue
 		}
-		result.Stale++
+		if misses >= deploymentDiscoveryStaleAfterMisses {
+			result.Stale++
+		}
 	}
 	return result, firstErr
 }
@@ -322,6 +374,7 @@ func (c *DeploymentDiscoveryController) patchDiscoveredStatus(
 		} else {
 			_ = s.SetDetailsKey(deploymentRuntimeDetailsKey, nil)
 		}
+		_ = s.SetDetailsKey(deploymentDiscoveryMissesKey, nil)
 	}))
 	if err != nil {
 		return fmt.Errorf("patch discovered Deployment status %s/%s: %w", deployment.Metadata.NamespaceOrDefault(), deployment.Metadata.Name, err)
@@ -329,26 +382,65 @@ func (c *DeploymentDiscoveryController) patchDiscoveredStatus(
 	return nil
 }
 
-func (c *DeploymentDiscoveryController) patchStaleStatus(ctx context.Context, deployment *v1alpha1.Deployment) error {
+// patchMissedStatus records one more consecutive miss for a discovered row.
+// Below the staleness threshold only the counter changes; at or past it the
+// Discovered and Ready conditions flip to False so list consumers can see the
+// workload is no longer observed on the provider.
+func (c *DeploymentDiscoveryController) patchMissedStatus(ctx context.Context, deployment *v1alpha1.Deployment, misses int) error {
 	now := time.Now().UTC()
 	generation := deployment.Metadata.Generation
 	err := c.deploymentStore().PatchStatus(ctx, deployment.Metadata.NamespaceOrDefault(), deployment.Metadata.Name, "", v1alpha1.StatusPatcher(func(s *v1alpha1.Status) {
 		if s.ObservedGeneration < generation {
 			s.ObservedGeneration = generation
 		}
+		_ = s.SetDetailsKey(deploymentDiscoveryMissesKey, misses)
+		if misses < deploymentDiscoveryStaleAfterMisses {
+			return
+		}
 		s.SetCondition(v1alpha1.Condition{
 			Type:               deploymentDiscoveryCondition,
 			Status:             v1alpha1.ConditionFalse,
 			Reason:             "ProviderMissing",
-			Message:            "not returned by latest discovery poll",
+			Message:            "not returned by recent discovery polls",
+			LastTransitionTime: now,
+			ObservedGeneration: generation,
+		})
+		s.SetCondition(v1alpha1.Condition{
+			Type:               "Ready",
+			Status:             v1alpha1.ConditionFalse,
+			Reason:             "ProviderMissing",
+			Message:            "no longer observed on the runtime",
 			LastTransitionTime: now,
 			ObservedGeneration: generation,
 		})
 	}))
 	if err != nil {
-		return fmt.Errorf("patch stale discovered Deployment status %s/%s: %w", deployment.Metadata.NamespaceOrDefault(), deployment.Metadata.Name, err)
+		return fmt.Errorf("patch missed discovered Deployment status %s/%s: %w", deployment.Metadata.NamespaceOrDefault(), deployment.Metadata.Name, err)
 	}
 	return nil
+}
+
+// deleteDiscoveredDeployment hard-deletes a discovered row. Discovered rows
+// never carry the controller finalizer, so Delete removes them in one step; a
+// concurrent deletion is treated as success.
+func (c *DeploymentDiscoveryController) deleteDiscoveredDeployment(ctx context.Context, deployment *v1alpha1.Deployment) error {
+	namespace := deployment.Metadata.NamespaceOrDefault()
+	name := deployment.Metadata.Name
+	if err := c.deploymentStore().Delete(ctx, namespace, name, ""); err != nil && !errors.Is(err, pkgdb.ErrNotFound) {
+		return fmt.Errorf("delete discovered Deployment %s/%s: %w", namespace, name, err)
+	}
+	return nil
+}
+
+// discoveredMissCount reads the consecutive-miss counter persisted in status
+// details. Absent or malformed values count as zero misses.
+func discoveredMissCount(deployment *v1alpha1.Deployment) int {
+	var misses int
+	ok, err := deployment.Status.GetDetailsKey(deploymentDiscoveryMissesKey, &misses)
+	if err != nil || !ok || misses < 0 {
+		return 0
+	}
+	return misses
 }
 
 func (c *DeploymentDiscoveryController) runtimeStore() *v1alpha1store.Store {

--- a/internal/registry/controller/discovery_integration_test.go
+++ b/internal/registry/controller/discovery_integration_test.go
@@ -52,7 +52,7 @@ func TestDeploymentDiscoveryController_MaterializesDiscoveredDeployment(t *testi
 	require.Equal(t, "agent-123", runtimeMetadata["remoteId"])
 }
 
-func TestDeploymentDiscoveryController_MarksMissingRowsStale(t *testing.T) {
+func TestDeploymentDiscoveryController_MarksRowsStaleAfterConsecutiveMisses(t *testing.T) {
 	ctx := context.Background()
 	stores := newControllerTestStores(t)
 	seedRuntime(t, stores, "local")
@@ -64,17 +64,126 @@ func TestDeploymentDiscoveryController_MarksMissingRowsStale(t *testing.T) {
 	_, err := discovery.Sync(ctx)
 	require.NoError(t, err)
 
+	name := discoveredDeploymentName("local", v1alpha1.KindAgent, "external-agent", "unknown", "default")
+
+	// Misses below the staleness threshold only bump the counter; the
+	// conditions stay True (provider list APIs are eventually consistent).
 	adapter.results = nil
+	for miss := 1; miss < deploymentDiscoveryStaleAfterMisses; miss++ {
+		result, err := discovery.Sync(ctx)
+		require.NoError(t, err)
+		require.Zero(t, result.Stale, "miss %d should not mark the row stale", miss)
+		require.Zero(t, result.Removed)
+		deployment := loadDeployment(t, stores, name)
+		require.Equal(t, v1alpha1.ConditionTrue, deployment.Status.GetCondition(deploymentDiscoveryCondition).Status)
+		require.Equal(t, miss, discoveredMissCount(deployment))
+	}
+
 	result, err := discovery.Sync(ctx)
 	require.NoError(t, err)
 	require.Equal(t, 1, result.Stale)
+	require.Zero(t, result.Removed)
 
-	name := discoveredDeploymentName("local", v1alpha1.KindAgent, "external-agent", "unknown", "default")
 	deployment := loadDeployment(t, stores, name)
 	condition := deployment.Status.GetCondition(deploymentDiscoveryCondition)
 	require.NotNil(t, condition)
 	require.Equal(t, v1alpha1.ConditionFalse, condition.Status)
 	require.Equal(t, "ProviderMissing", condition.Reason)
+	ready := deployment.Status.GetCondition("Ready")
+	require.NotNil(t, ready)
+	require.Equal(t, v1alpha1.ConditionFalse, ready.Status)
+}
+
+func TestDeploymentDiscoveryController_DeletesRowsAfterRepeatedMisses(t *testing.T) {
+	ctx := context.Background()
+	stores := newControllerTestStores(t)
+	seedRuntime(t, stores, "local")
+	adapter := &discoveryTestAdapter{results: []types.DiscoveryResult{{
+		TargetKind: v1alpha1.KindAgent,
+		Name:       "external-agent",
+	}}}
+	discovery := newDeploymentDiscoveryTestController(stores, adapter)
+	_, err := discovery.Sync(ctx)
+	require.NoError(t, err)
+
+	name := discoveredDeploymentName("local", v1alpha1.KindAgent, "external-agent", "unknown", "default")
+
+	adapter.results = nil
+	for miss := 1; miss < deploymentDiscoveryDeleteAfterMisses; miss++ {
+		result, err := discovery.Sync(ctx)
+		require.NoError(t, err)
+		require.Zero(t, result.Removed, "miss %d should not delete the row", miss)
+		loadDeployment(t, stores, name)
+	}
+
+	result, err := discovery.Sync(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 1, result.Removed)
+	requireDeploymentMissing(t, stores, name)
+}
+
+func TestDeploymentDiscoveryController_DeletesRowsWhenRuntimeRemoved(t *testing.T) {
+	ctx := context.Background()
+	stores := newControllerTestStores(t)
+	seedRuntime(t, stores, "local")
+	adapter := &discoveryTestAdapter{results: []types.DiscoveryResult{{
+		TargetKind: v1alpha1.KindAgent,
+		Name:       "external-agent",
+	}}}
+	discovery := newDeploymentDiscoveryTestController(stores, adapter)
+	_, err := discovery.Sync(ctx)
+	require.NoError(t, err)
+
+	require.NoError(t, stores[v1alpha1.KindRuntime].Delete(ctx, "default", "local", ""))
+
+	result, err := discovery.Sync(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 1, result.Removed)
+	require.Zero(t, result.Stale)
+
+	name := discoveredDeploymentName("local", v1alpha1.KindAgent, "external-agent", "unknown", "default")
+	requireDeploymentMissing(t, stores, name)
+}
+
+func TestDeploymentDiscoveryController_ReobservedRowResetsMissCounter(t *testing.T) {
+	ctx := context.Background()
+	stores := newControllerTestStores(t)
+	seedRuntime(t, stores, "local")
+	results := []types.DiscoveryResult{{
+		TargetKind: v1alpha1.KindAgent,
+		Name:       "external-agent",
+	}}
+	adapter := &discoveryTestAdapter{results: results}
+	discovery := newDeploymentDiscoveryTestController(stores, adapter)
+	_, err := discovery.Sync(ctx)
+	require.NoError(t, err)
+
+	name := discoveredDeploymentName("local", v1alpha1.KindAgent, "external-agent", "unknown", "default")
+
+	// Two misses, then the workload reappears: the counter must reset so the
+	// next miss streak starts from scratch.
+	adapter.results = nil
+	for range 2 {
+		_, err := discovery.Sync(ctx)
+		require.NoError(t, err)
+	}
+	require.Equal(t, 2, discoveredMissCount(loadDeployment(t, stores, name)))
+
+	adapter.results = results
+	_, err = discovery.Sync(ctx)
+	require.NoError(t, err)
+	deployment := loadDeployment(t, stores, name)
+	require.Zero(t, discoveredMissCount(deployment))
+	require.Equal(t, v1alpha1.ConditionTrue, deployment.Status.GetCondition(deploymentDiscoveryCondition).Status)
+
+	adapter.results = nil
+	for range 2 {
+		_, err := discovery.Sync(ctx)
+		require.NoError(t, err)
+	}
+	deployment = loadDeployment(t, stores, name)
+	require.Equal(t, 2, discoveredMissCount(deployment))
+	require.Equal(t, v1alpha1.ConditionTrue, deployment.Status.GetCondition(deploymentDiscoveryCondition).Status)
 }
 
 func TestDeploymentDiscoveryController_ErrorDoesNotMarkRowsStale(t *testing.T) {
@@ -100,6 +209,7 @@ func TestDeploymentDiscoveryController_ErrorDoesNotMarkRowsStale(t *testing.T) {
 	condition := deployment.Status.GetCondition(deploymentDiscoveryCondition)
 	require.NotNil(t, condition)
 	require.Equal(t, v1alpha1.ConditionTrue, condition.Status)
+	require.Zero(t, discoveredMissCount(deployment), "errored polls must not count as misses")
 }
 
 func TestDeploymentDiscoveryController_SkipsAdaptersWithoutDiscoverySource(t *testing.T) {

--- a/pkg/registry/v1alpha1store/store.go
+++ b/pkg/registry/v1alpha1store/store.go
@@ -559,29 +559,42 @@ func (s *Store) ApplyPatch(ctx context.Context, namespace, name, tag string, pat
 			where += " AND tag=$3"
 		}
 
+		// Columns whose mutator produced the value already stored are left out
+		// of the SET list; a patch that changes nothing skips the UPDATE
+		// entirely so periodic re-asserts (e.g. discovery status polls) don't
+		// churn updated_at, WAL, and audit surfaces.
 		if patch.Status != nil {
 			newJSON, err := buildStatusPatch(statusJSON, patch.Status)
 			if err != nil {
 				return err
 			}
-			args = append(args, newJSON)
-			setClauses = append(setClauses, fmt.Sprintf("status=$%d", len(args)))
+			if !equalSpecJSON(statusJSON, newJSON) {
+				args = append(args, newJSON)
+				setClauses = append(setClauses, fmt.Sprintf("status=$%d", len(args)))
+			}
 		}
 		if patch.Annotations != nil {
 			newJSON, err := buildAnnotationsPatch(annotationsJSON, patch.Annotations)
 			if err != nil {
 				return err
 			}
-			args = append(args, newJSON)
-			setClauses = append(setClauses, fmt.Sprintf("annotations=$%d", len(args)))
+			if !equalJSONMap(annotationsJSON, newJSON) {
+				args = append(args, newJSON)
+				setClauses = append(setClauses, fmt.Sprintf("annotations=$%d", len(args)))
+			}
 		}
 		if patch.Finalizers != nil {
 			newJSON, err := buildFinalizersPatch(finalizersJSON, patch.Finalizers)
 			if err != nil {
 				return err
 			}
-			args = append(args, newJSON)
-			setClauses = append(setClauses, fmt.Sprintf("finalizers=$%d", len(args)))
+			if !equalSpecJSON(finalizersJSON, newJSON) {
+				args = append(args, newJSON)
+				setClauses = append(setClauses, fmt.Sprintf("finalizers=$%d", len(args)))
+			}
+		}
+		if len(setClauses) == 0 {
+			return nil
 		}
 
 		if _, err := tx.Exec(ctx,

--- a/pkg/registry/v1alpha1store/store_test.go
+++ b/pkg/registry/v1alpha1store/store_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -196,6 +197,40 @@ func TestStore_PatchStatusNotFound(t *testing.T) {
 
 	err := store.PatchStatus(ctx, testNS, "nope", "1", v1alpha1.StatusPatcher(func(*v1alpha1.Status) {}))
 	require.ErrorIs(t, err, pkgdb.ErrNotFound)
+}
+
+// TestStore_ApplyPatchSkipsUnchangedWrites verifies that re-asserting the
+// same status content leaves the row untouched: periodic controllers (e.g.
+// deployment discovery) re-patch on every poll, and an unconditional UPDATE
+// would churn updated_at and WAL with no content change.
+func TestStore_ApplyPatchSkipsUnchangedWrites(t *testing.T) {
+	pool := NewTestPool(t)
+	store := NewStore(pool, TestSchema(), testTable)
+	ctx := context.Background()
+
+	upsertAgent(t, store, "steady", v1alpha1.AgentSpec{Title: "alpha"}, nil)
+
+	patch := v1alpha1.StatusPatcher(func(s *v1alpha1.Status) {
+		s.SetCondition(v1alpha1.Condition{Type: "Ready", Status: v1alpha1.ConditionTrue, Reason: "Converged"})
+	})
+	require.NoError(t, store.PatchStatus(ctx, testNS, "steady", DefaultTag(), patch))
+
+	updatedAt := func() time.Time {
+		var ts time.Time
+		require.NoError(t, pool.QueryRow(ctx, fmt.Sprintf(
+			`SELECT updated_at FROM %s WHERE namespace=$1 AND name=$2 AND tag=$3`, store.qualified),
+			testNS, "steady", DefaultTag()).Scan(&ts))
+		return ts
+	}
+
+	before := updatedAt()
+	require.NoError(t, store.PatchStatus(ctx, testNS, "steady", DefaultTag(), patch))
+	require.True(t, before.Equal(updatedAt()), "no-op status patch must not rewrite the row")
+
+	require.NoError(t, store.PatchStatus(ctx, testNS, "steady", DefaultTag(), v1alpha1.StatusPatcher(func(s *v1alpha1.Status) {
+		s.SetCondition(v1alpha1.Condition{Type: "Ready", Status: v1alpha1.ConditionFalse, Reason: "Failed"})
+	})))
+	require.False(t, before.Equal(updatedAt()), "a real status change must update the row")
 }
 
 func TestStore_GetNotFound(t *testing.T) {


### PR DESCRIPTION
# Description

**Motivation:** Follow-up to #535 from the post-merge review of unmanaged deployment discovery. Discovered Deployment rows previously lived forever:

- A workload that disappeared from the provider only got its `Discovered` condition flipped to False — the row itself was never cleaned up, so phantom deployments accumulated in the default list (which intentionally includes discovered rows).
- Rows whose Runtime was deleted were never even marked stale: the stale loop only considered runtimes that completed a discovery pass, so orphaned rows kept `Discovered=True` / `Ready=True` indefinitely.
- Staleness flipped on the *first* successful poll that omitted a row, so eventually-consistent provider list APIs (notably AWS AgentCore) caused condition flapping.
- The discovery controller re-asserted an identical status on every poll, and `Store.ApplyPatch` unconditionally ran the UPDATE — bumping `updated_at` (and polluting `ORDER BY updated_at` lists) for every discovered row every minute.

**What changed:**

- The discovery controller tracks consecutive missed polls per discovered row in status details (`discoveryMisses`). `Discovered` and `Ready` flip to False after 3 consecutive misses; the row is deleted after 5. The counter resets when the workload is observed again, and errored polls still do not count as misses.
- Discovered rows whose Runtime row no longer exists are deleted immediately — no future poll could ever confirm them again. Rows whose Runtime exists but could not be polled (discovery errored, or the adapter does not implement discovery) are left untouched.
- `Store.ApplyPatch` now compares each patched column against the stored value (canonical JSON comparison) and skips the UPDATE when nothing changed. The public watch trigger already suppressed status-no-op notifications, and the control-plane trigger already ignored status-only writes, so this is behavior-preserving for watchers and controllers — it just stops the `updated_at`/WAL churn.

# Change Type

/kind fix

# Changelog

```release-note
Discovered (unmanaged) Deployment rows are now garbage-collected: rows missing from 5 consecutive discovery polls, or whose Runtime has been deleted, are removed, and their Discovered/Ready conditions flip to False after 3 consecutive misses instead of the first one.
```

# Additional Notes

- Thresholds are constants (`deploymentDiscoveryStaleAfterMisses = 3`, `deploymentDiscoveryDeleteAfterMisses = 5`); at the 1-minute resync interval that is ~3/~5 minutes of grace.
- Discovered rows never carry the controller finalizer, so deletion is a one-step hard delete; a concurrent delete is treated as success.
- RBAC/ownership for discovered rows remains a separate design-track follow-up and is intentionally not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)