### PR TITLE
feat(controller): expose dependency evidence in Deployment status details

### DIFF
--- a/internal/registry/controller/reconciler.go
+++ b/internal/registry/controller/reconciler.go
@@ -24,8 +24,9 @@ const (
 )
 
 type deploymentControllerDetails struct {
-	LastAppliedFingerprint string `json:"lastAppliedFingerprint,omitempty"`
-	LastForceToken         string `json:"lastForceToken,omitempty"`
+	LastAppliedFingerprint string                          `json:"lastAppliedFingerprint,omitempty"`
+	LastForceToken         string                          `json:"lastForceToken,omitempty"`
+	Dependencies           []types.ApplyDependencySnapshot `json:"dependencies,omitempty"`
 }
 
 func (c *DeploymentController) processQueueItem(
@@ -101,13 +102,14 @@ func (c *DeploymentController) apply(ctx context.Context, deployment *v1alpha1.D
 		Runtime:    runtime,
 		Getter:     c.Getter,
 	}
-	fingerprint, err := desiredApplyFingerprint(ctx, adapter, input)
+	fingerprintResult, err := desiredApplyFingerprint(ctx, adapter, input)
 	if err != nil {
 		if errors.Is(err, v1alpha1.ErrDanglingRef) {
 			return c.blockReference(ctx, deployment, err)
 		}
 		return "", "", err
 	}
+	fingerprint := fingerprintResult.Fingerprint
 	forceToken := deploymentForceToken(deployment)
 	if skip, err := shouldSkipApply(deployment, fingerprint, forceToken); err != nil {
 		return "", "", err
@@ -121,7 +123,7 @@ func (c *DeploymentController) apply(ctx context.Context, deployment *v1alpha1.D
 		}
 		return "", "", fmt.Errorf("adapter %q apply: %w", adapter.Type(), err)
 	}
-	if err := c.persistApplyResult(ctx, deployment, result, fingerprint, forceToken); err != nil {
+	if err := c.persistApplyResult(ctx, deployment, result, fingerprint, forceToken, fingerprintResult.Dependencies); err != nil {
 		return "", "", err
 	}
 	return "success", "deployment applied", nil
@@ -184,7 +186,7 @@ func (c *DeploymentController) blockReference(ctx context.Context, deployment *v
 			Message:            message,
 			ObservedGeneration: deployment.Metadata.Generation,
 		}},
-	}, "", ""); err != nil {
+	}, "", "", nil); err != nil {
 		return "", "", err
 	}
 	return "blocked", message, nil
@@ -260,13 +262,14 @@ func (c *DeploymentController) persistApplyResult(
 	result *types.ApplyResult,
 	fingerprint string,
 	forceToken string,
+	dependencies []types.ApplyDependencySnapshot,
 ) error {
 	patch := v1alpha1store.PatchOpts{
 		Finalizers: ensureFinalizer(DeploymentControllerFinalizer),
 	}
 	if result == nil {
 		if fingerprint != "" {
-			patch.Status = deploymentControllerStatusPatch(deployment, nil, fingerprint, forceToken)
+			patch.Status = deploymentControllerStatusPatch(deployment, nil, fingerprint, forceToken, dependencies)
 		}
 		if err := c.deploymentStore().ApplyPatch(ctx, deployment.Metadata.NamespaceOrDefault(), deployment.Metadata.Name, "", patch); err != nil {
 			return fmt.Errorf("persist apply result: %w", err)
@@ -274,7 +277,7 @@ func (c *DeploymentController) persistApplyResult(
 		return nil
 	}
 	if len(result.Conditions) > 0 || len(result.Details) > 0 || fingerprint != "" {
-		patch.Status = deploymentControllerStatusPatch(deployment, result, fingerprint, forceToken)
+		patch.Status = deploymentControllerStatusPatch(deployment, result, fingerprint, forceToken, dependencies)
 	}
 	if len(result.RuntimeMetadata) > 0 {
 		patch.Annotations = func(annotations map[string]string) map[string]string {
@@ -296,6 +299,7 @@ func deploymentControllerStatusPatch(
 	result *types.ApplyResult,
 	fingerprint string,
 	forceToken string,
+	dependencies []types.ApplyDependencySnapshot,
 ) func(current json.RawMessage) (json.RawMessage, error) {
 	return v1alpha1.StatusPatcher(func(s *v1alpha1.Status) {
 		if s.ObservedGeneration < deployment.Metadata.Generation {
@@ -313,6 +317,7 @@ func deploymentControllerStatusPatch(
 			_ = s.SetDetailsKey(deploymentControllerDetailsKey, deploymentControllerDetails{
 				LastAppliedFingerprint: fingerprint,
 				LastForceToken:         forceToken,
+				Dependencies:           dependencies,
 			})
 		}
 	})
@@ -389,15 +394,28 @@ func adapterSupportsKind(adapter types.DeploymentAdapter, kind string) bool {
 	return adapter != nil && slices.Contains(adapter.SupportedTargetKinds(), kind)
 }
 
-func desiredApplyFingerprint(ctx context.Context, adapter types.DeploymentAdapter, input types.ApplyInput) (string, error) {
+type desiredApplyFingerprintResult struct {
+	Fingerprint  string
+	Dependencies []types.ApplyDependencySnapshot
+}
+
+func desiredApplyFingerprint(ctx context.Context, adapter types.DeploymentAdapter, input types.ApplyInput) (desiredApplyFingerprintResult, error) {
 	if fingerprinter, ok := adapter.(types.DeploymentDesiredFingerprinter); ok {
-		return fingerprinter.DesiredFingerprint(ctx, input)
+		fingerprint, err := fingerprinter.DesiredFingerprint(ctx, input)
+		return desiredApplyFingerprintResult{Fingerprint: fingerprint}, err
 	}
 	adapterType := ""
 	if adapter != nil {
 		adapterType = adapter.Type()
 	}
-	return types.DefaultApplyFingerprint(ctx, input, types.ApplyFingerprintOptions{AdapterType: adapterType})
+	result, err := types.DefaultApplyFingerprintResult(ctx, input, types.ApplyFingerprintOptions{AdapterType: adapterType})
+	if err != nil {
+		return desiredApplyFingerprintResult{}, err
+	}
+	return desiredApplyFingerprintResult{
+		Fingerprint:  result.Fingerprint,
+		Dependencies: result.Dependencies,
+	}, nil
 }
 
 func shouldSkipApply(deployment *v1alpha1.Deployment, fingerprint string, forceToken string) (bool, error) {

--- a/internal/registry/controller/reconciler_integration_test.go
+++ b/internal/registry/controller/reconciler_integration_test.go
@@ -228,6 +228,18 @@ func TestDeploymentController_ReappliesAgentDeploymentWhenReferencedMCPServerCha
 	require.Equal(t, 1, processed)
 	require.Equal(t, int32(1), adapter.applyCalls.Load())
 
+	applied := loadDeployment(t, stores, "assistant-deploy")
+	var firstDetails deploymentControllerDetails
+	ok, err := applied.Status.GetDetailsKey(deploymentControllerDetailsKey, &firstDetails)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Len(t, firstDetails.Dependencies, 1)
+	require.Equal(t, v1alpha1.KindMCPServer, firstDetails.Dependencies[0].Kind)
+	require.Equal(t, "default", firstDetails.Dependencies[0].Namespace)
+	require.Equal(t, "weather", firstDetails.Dependencies[0].Name)
+	require.NotEmpty(t, firstDetails.Dependencies[0].MaterialHash)
+	firstDependencyHash := firstDetails.Dependencies[0].MaterialHash
+
 	seedMCPServerWithIdentifier(t, stores, "weather", "ghcr.io/example/weather:2.0.0")
 	_, err = controller.HandleEvent(ctx, v1alpha1store.ControlPlaneEvent{
 		Key: v1alpha1store.ResourceKey{
@@ -245,6 +257,16 @@ func TestDeploymentController_ReappliesAgentDeploymentWhenReferencedMCPServerCha
 		return err == nil && adapter.applyCalls.Load() == 2
 	}, time.Second, 10*time.Millisecond)
 	require.Equal(t, 1, processed)
+
+	reapplied := loadDeployment(t, stores, "assistant-deploy")
+	var secondDetails deploymentControllerDetails
+	ok, err = reapplied.Status.GetDetailsKey(deploymentControllerDetailsKey, &secondDetails)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Len(t, secondDetails.Dependencies, 1)
+	require.Equal(t, "weather", secondDetails.Dependencies[0].Name)
+	require.NotEqual(t, firstDependencyHash, secondDetails.Dependencies[0].MaterialHash,
+		"dependency material hash should change after the referenced MCPServer spec changes")
 }
 
 func TestDeploymentController_DeleteWaitsForRemoveThenPurgesFinalizedRow(t *testing.T) {

--- a/pkg/types/fingerprint.go
+++ b/pkg/types/fingerprint.go
@@ -26,6 +26,25 @@ type ApplyFingerprintOptions struct {
 	Extra        any
 }
 
+// ApplyDependencySnapshot is the operator-visible identity of one resolved
+// resource that influenced a Deployment apply fingerprint.
+type ApplyDependencySnapshot struct {
+	Kind         string `json:"kind"`
+	Namespace    string `json:"namespace,omitempty"`
+	Name         string `json:"name"`
+	Tag          string `json:"tag,omitempty"`
+	UID          string `json:"uid,omitempty"`
+	Generation   int64  `json:"generation,omitempty"`
+	MaterialHash string `json:"materialHash,omitempty"`
+}
+
+// ApplyFingerprintResult carries the fingerprint plus the resolved dependency
+// evidence used to build it.
+type ApplyFingerprintResult struct {
+	Fingerprint  string
+	Dependencies []ApplyDependencySnapshot
+}
+
 // DefaultApplyFingerprint returns a deterministic fingerprint of the resolved
 // desired apply input. It intentionally excludes status, labels, annotations,
 // finalizers, timestamps, and other controller bookkeeping. The fingerprint is
@@ -34,20 +53,31 @@ type ApplyFingerprintOptions struct {
 // branch's HEAD moves, and operators should change the spec or use the
 // controller force token when they want a rebuild from the new HEAD.
 func DefaultApplyFingerprint(ctx context.Context, in ApplyInput, opts ApplyFingerprintOptions) (string, error) {
+	result, err := DefaultApplyFingerprintResult(ctx, in, opts)
+	if err != nil {
+		return "", err
+	}
+	return result.Fingerprint, nil
+}
+
+// DefaultApplyFingerprintResult returns the same deterministic fingerprint as
+// DefaultApplyFingerprint, plus snapshots of resolved dependency resources
+// that participated in the fingerprint payload.
+func DefaultApplyFingerprintResult(ctx context.Context, in ApplyInput, opts ApplyFingerprintOptions) (ApplyFingerprintResult, error) {
 	if in.Deployment == nil {
-		return "", fmt.Errorf("fingerprint: deployment is required")
+		return ApplyFingerprintResult{}, fmt.Errorf("fingerprint: deployment is required")
 	}
 	if in.Target == nil {
-		return "", fmt.Errorf("fingerprint: target is required")
+		return ApplyFingerprintResult{}, fmt.Errorf("fingerprint: target is required")
 	}
 	if in.Runtime == nil {
-		return "", fmt.Errorf("fingerprint: runtime is required")
+		return ApplyFingerprintResult{}, fmt.Errorf("fingerprint: runtime is required")
 	}
 
 	deps := append([]v1alpha1.Object(nil), opts.Dependencies...)
 	defaultDeps, err := defaultApplyDependencies(ctx, in)
 	if err != nil {
-		return "", err
+		return ApplyFingerprintResult{}, err
 	}
 	deps = append(deps, defaultDeps...)
 
@@ -61,28 +91,33 @@ func DefaultApplyFingerprint(ctx context.Context, in ApplyInput, opts ApplyFinge
 		Extra:        opts.Extra,
 	}
 	if payload.Deployment, err = objectFingerprint(v1alpha1.KindDeployment, in.Deployment); err != nil {
-		return "", err
+		return ApplyFingerprintResult{}, err
 	}
 	if payload.Target, err = objectFingerprint("", in.Target); err != nil {
-		return "", err
+		return ApplyFingerprintResult{}, err
 	}
 	if payload.Runtime, err = objectFingerprint(v1alpha1.KindRuntime, in.Runtime); err != nil {
-		return "", err
+		return ApplyFingerprintResult{}, err
 	}
+	snapshots := make([]ApplyDependencySnapshot, 0, len(deps))
 	for _, dep := range deps {
 		fp, err := objectFingerprint("", dep)
 		if err != nil {
-			return "", err
+			return ApplyFingerprintResult{}, err
 		}
 		payload.Dependencies = append(payload.Dependencies, fp)
+		snapshots = append(snapshots, dependencySnapshot(fp))
 	}
 
 	encoded, err := json.Marshal(payload)
 	if err != nil {
-		return "", fmt.Errorf("fingerprint: marshal payload: %w", err)
+		return ApplyFingerprintResult{}, fmt.Errorf("fingerprint: marshal payload: %w", err)
 	}
 	sum := sha256.Sum256(encoded)
-	return "sha256:" + hex.EncodeToString(sum[:]), nil
+	return ApplyFingerprintResult{
+		Fingerprint:  "sha256:" + hex.EncodeToString(sum[:]),
+		Dependencies: snapshots,
+	}, nil
 }
 
 type applyFingerprintPayload struct {
@@ -133,6 +168,26 @@ func objectFingerprint(defaultKind string, obj v1alpha1.Object) (fingerprintObje
 		Generation: meta.Generation,
 		Spec:       spec,
 	}, nil
+}
+
+func dependencySnapshot(fp fingerprintObject) ApplyDependencySnapshot {
+	return ApplyDependencySnapshot{
+		Kind:         fp.Kind,
+		Namespace:    fp.Namespace,
+		Name:         fp.Name,
+		Tag:          fp.Tag,
+		UID:          fp.UID,
+		Generation:   fp.Generation,
+		MaterialHash: materialHash(fp.Spec),
+	}
+}
+
+func materialHash(spec json.RawMessage) string {
+	if len(spec) == 0 {
+		return ""
+	}
+	sum := sha256.Sum256(spec)
+	return "sha256:" + hex.EncodeToString(sum[:])
 }
 
 func defaultApplyDependencies(ctx context.Context, in ApplyInput) ([]v1alpha1.Object, error) {

--- a/pkg/types/fingerprint_test.go
+++ b/pkg/types/fingerprint_test.go
@@ -64,6 +64,45 @@ func TestDefaultApplyFingerprintIncludesAgentMCPServerDependency(t *testing.T) {
 	}
 }
 
+func TestDefaultApplyFingerprintResultIncludesDependencySnapshot(t *testing.T) {
+	in := testApplyInput()
+	in.Target = &v1alpha1.Agent{
+		TypeMeta: v1alpha1.TypeMeta{Kind: v1alpha1.KindAgent},
+		Metadata: v1alpha1.ObjectMeta{
+			Namespace: "default",
+			Name:      "assistant",
+		},
+		Spec: v1alpha1.AgentSpec{
+			MCPServers: []v1alpha1.ResourceRef{{Name: "weather"}},
+		},
+	}
+
+	in.Getter = func(context.Context, v1alpha1.ResourceRef) (v1alpha1.Object, error) {
+		return testMCPServer("ghcr.io/example/weather:1.0.0"), nil
+	}
+
+	result, err := DefaultApplyFingerprintResult(context.Background(), in, ApplyFingerprintOptions{AdapterType: "test"})
+	if err != nil {
+		t.Fatalf("DefaultApplyFingerprintResult: %v", err)
+	}
+	if result.Fingerprint == "" {
+		t.Fatalf("fingerprint is empty")
+	}
+	if len(result.Dependencies) != 1 {
+		t.Fatalf("dependencies = %+v, want one MCPServer dependency", result.Dependencies)
+	}
+	dep := result.Dependencies[0]
+	if dep.Kind != v1alpha1.KindMCPServer || dep.Namespace != "default" || dep.Name != "weather" {
+		t.Fatalf("dependency identity mismatch: %+v", dep)
+	}
+	if dep.UID != "mcp-uid" || dep.Generation != 1 {
+		t.Fatalf("dependency version mismatch: %+v", dep)
+	}
+	if dep.MaterialHash == "" {
+		t.Fatalf("dependency material hash is empty: %+v", dep)
+	}
+}
+
 func testApplyInput() ApplyInput {
 	return ApplyInput{
 		Deployment: &v1alpha1.Deployment{


### PR DESCRIPTION
# Description

**Motivation:** Dependency-scoped reconcile invalidation needs operator-visible proof before the Deployment controller can safely replace its full-scan fan-out. Today there is no way to see *which* resolved dependency versions an applied deployment was actually built from.

**What changed:**
- `pkg/types`: added `DefaultApplyFingerprintResult`, which returns the existing deterministic apply fingerprint plus `ApplyDependencySnapshot`s (kind, namespace, name, tag, UID, generation, material hash) for each resolved dependency that fed the hash. `DefaultApplyFingerprint` is now a thin wrapper, so existing callers are unchanged.
- `internal/registry/controller`: the Deployment controller persists those snapshots under its existing status details key (`deploymentControllerDetailsKey`) after a successful apply, alongside `lastAppliedFingerprint`. Evidence always reflects the last applied fingerprint.
- Tests: unit coverage for the snapshot path, and an integration assertion that changing a referenced MCPServer spec produces a new dependency material hash in the deployment's status details.

Design notes:
- Material hashes are stored instead of full dependency specs to keep Deployment status small while remaining explainable.
- Snapshots are derived from the same resolved-dependency path that already feeds the fingerprint, and the fingerprint intentionally excludes status — so persisting evidence cannot re-trigger reconciliation (no status feedback loop).
- Full-scan fan-out remains the correctness baseline: direct refs alone would miss transitive Agent → MCPServer edges. Targeted dependency queries must not replace it until tests prove direct and transitive invalidation completeness.

# Change Type

/kind feature

# Changelog

```release-note
The Deployment controller now records dependency evidence (kind, namespace, name, tag, UID, generation, and a material hash of each resolved dependency) in the Deployment's controller status details after each successful apply, making it possible to see which dependency versions an applied deployment was built from.
```

# Additional Notes

Known gap (deferred): adapters that implement `DeploymentDesiredFingerprinter` (custom fingerprints) do not yet emit dependency evidence — only the default fingerprint path populates snapshots.

This is the sole unmerged commit from the `ilackarms/followup-dependency-reconciliation` branch; the rest of that branch's history merged via #517. That stale branch can be deleted once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)