### PR TITLE
internal: Preserve deployment get output

### DIFF
--- a/internal/cli/declarative/declarative.go
+++ b/internal/cli/declarative/declarative.go
@@ -91,79 +91,36 @@ func init() {
 	// endpoints that don't exist. The Get / Delete / List closures match
 	// what typedKind would otherwise produce; ListTags / DeleteAllTags are
 	// intentionally omitted so the dispatch layer rejects --all-tags cleanly.
-	scheme.Register(&scheme.Kind{
-		Kind:         "runtime",
-		Plural:       "runtimes",
-		Aliases:      []string{"Runtime"},
-		TableColumns: []scheme.Column{{Header: "NAME"}, {Header: "TYPE"}},
-		ToYAMLFunc:   func(item any) any { return item },
-		RowFunc: func(item any) []string {
-			runtime, ok := item.(*v1alpha1.Runtime)
-			if !ok {
-				return []string{"<invalid>"}
-			}
-			return runtimeRow(runtime)
-		},
-		Get: func(ctx context.Context, c *client.Client, name, _ string) (any, error) {
-			ref, err := parseResourceLookupRef(name)
-			if err != nil {
-				return nil, err
-			}
-			return client.GetTyped(ctx, c, v1alpha1.KindRuntime, ref.Namespace, ref.Name, "", func() *v1alpha1.Runtime { return &v1alpha1.Runtime{} })
-		},
-		ListFunc: func(ctx context.Context, c *client.Client, opts scheme.ListOpts) ([]any, error) {
-			return listAny(ctx, c, v1alpha1.KindRuntime, opts, func() *v1alpha1.Runtime { return &v1alpha1.Runtime{} })
-		},
-		Delete: func(ctx context.Context, c *client.Client, name, tag string) error {
-			return deleteAny(ctx, c, v1alpha1.KindRuntime, name, tag, func() *v1alpha1.Runtime { return &v1alpha1.Runtime{} })
-		},
-	})
+	scheme.Register(
+		mutableTypedKind(
+			"runtime", "runtimes", []string{"Runtime"},
+			[]scheme.Column{{Header: "NAME"}, {Header: "TYPE"}},
+			v1alpha1.KindRuntime,
+			func() *v1alpha1.Runtime { return &v1alpha1.Runtime{} },
+			runtimeRow,
+		),
+	)
 
 	// Deployment is registered manually because it is a mutable namespace/name
 	// object: the server's deployment store does not expose /tags or
 	// DeleteAllTags endpoints. Explicit get/delete accept either NAME or
 	// NAMESPACE/NAME; ListTags / DeleteAllTags are intentionally omitted so
 	// the dispatch layer rejects --all-tags cleanly.
-	scheme.Register(&scheme.Kind{
-		Kind:    "deployment",
-		Plural:  "deployments",
-		Aliases: []string{"Deployment"},
-		Get: func(ctx context.Context, c *client.Client, name, _ string) (any, error) {
-			ref, err := parseResourceLookupRef(name)
-			if err != nil {
-				return nil, err
-			}
-			deployment, err := client.GetTyped(ctx, c, v1alpha1.KindDeployment, ref.Namespace, ref.Name, "", func() *v1alpha1.Deployment { return &v1alpha1.Deployment{} })
-			if err != nil {
-				return nil, err
-			}
-			return cliCommon.DeploymentRecordFromObject(deployment), nil
-		},
-		Delete: func(ctx context.Context, c *client.Client, name, tag string) error {
-			return deleteAny(ctx, c, v1alpha1.KindDeployment, name, tag, func() *v1alpha1.Deployment { return &v1alpha1.Deployment{} })
-		},
-		ListFunc: func(ctx context.Context, c *client.Client, _ scheme.ListOpts) ([]any, error) {
-			return listDeploymentAny(ctx, c)
-		},
-		RowFunc: func(item any) []string {
-			deployment, ok := item.(*cliCommon.DeploymentRecord)
-			if !ok {
-				return []string{"<invalid>"}
-			}
-			return deploymentRow(deployment)
-		},
-		ToYAMLFunc: func(item any) any {
-			deployment, ok := item.(*cliCommon.DeploymentRecord)
-			if !ok {
-				return nil
-			}
-			return deploymentToDocument(deployment)
-		},
-		TableColumns: []scheme.Column{
-			{Header: "NAME"}, {Header: "TARGET"}, {Header: "VERSION"},
-			{Header: "TYPE"}, {Header: "RUNTIME"}, {Header: "STATUS"},
-		},
-	})
+	scheme.Register(
+		mutableTypedKind(
+			"deployment", "deployments", []string{"Deployment"},
+			[]scheme.Column{
+				{Header: "NAME"}, {Header: "TARGET"}, {Header: "VERSION"},
+				{Header: "TYPE"}, {Header: "RUNTIME"}, {Header: "STATUS"},
+			},
+			v1alpha1.KindDeployment,
+			func() *v1alpha1.Deployment { return &v1alpha1.Deployment{} },
+			func(deployment *v1alpha1.Deployment) []string {
+				return deploymentRow(cliCommon.DeploymentRecordFromObject(deployment))
+			},
+			withMutableListFunc(listDeploymentResources),
+		),
+	)
 }
 
 // typedKind builds a scheme.Kind whose Get / List / Delete dispatch
@@ -214,4 +171,63 @@ func typedKind[T v1alpha1.Object](
 			return deleteAllTagsAny(ctx, c, canonicalKind, name, newObj)
 		},
 	}
+}
+
+// mutableTypedKind is typedKind for namespace/name resources such as Runtime
+// and Deployment. These kinds use the generic v1alpha1 CRUD surface but do not
+// expose /tags, so the tag-specific callbacks are intentionally nil.
+type mutableTypedKindOption func(*scheme.Kind)
+
+// withMutableListFunc is an option to override the default ListFunc for a
+// mutableTypedKind.
+func withMutableListFunc(fn scheme.ListFunc) mutableTypedKindOption {
+	return func(k *scheme.Kind) {
+		k.ListFunc = fn
+	}
+}
+
+// mutableTypedKind builds a scheme.Kind for mutable namespace/name resources which
+// do not support tagging.
+func mutableTypedKind[T v1alpha1.Object](
+	cliName, plural string,
+	aliases []string,
+	columns []scheme.Column,
+	canonicalKind string,
+	newObj func() T,
+	row func(T) []string,
+	opts ...mutableTypedKindOption,
+) *scheme.Kind {
+	k := &scheme.Kind{
+		Kind:         cliName,
+		Plural:       plural,
+		Aliases:      aliases,
+		TableColumns: columns,
+		ToYAMLFunc:   func(item any) any { return item },
+		RowFunc: func(item any) []string {
+			t, ok := item.(T)
+			if !ok {
+				return []string{"<invalid>"}
+			}
+			return row(t)
+		},
+		Get: func(ctx context.Context, c *client.Client, name, _ string) (any, error) {
+			ref, err := parseResourceLookupRef(name)
+			if err != nil {
+				return nil, err
+			}
+			return client.GetTyped(ctx, c, canonicalKind, ref.Namespace, ref.Name, "", newObj)
+		},
+		ListFunc: func(ctx context.Context, c *client.Client, opts scheme.ListOpts) ([]any, error) {
+			return listAny(ctx, c, canonicalKind, opts, newObj)
+		},
+		Delete: func(ctx context.Context, c *client.Client, name, tag string) error {
+			return deleteAny(ctx, c, canonicalKind, name, tag, newObj)
+		},
+	}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(k)
+		}
+	}
+	return k
 }

--- a/internal/cli/declarative/deployment_get_test.go
+++ b/internal/cli/declarative/deployment_get_test.go
@@ -67,8 +67,25 @@ func deploymentTestServerV1Alpha1(t *testing.T, deployments []v1alpha1.Deploymen
 			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 			return
 		}
+		items := deployments
+		switch r.URL.Query().Get("origin") {
+		case v1alpha1.DeploymentOriginManaged:
+			items = nil
+			for _, d := range deployments {
+				if d.Metadata.Annotations[v1alpha1.DeploymentOriginAnnotation] != v1alpha1.DeploymentOriginDiscovered {
+					items = append(items, d)
+				}
+			}
+		case v1alpha1.DeploymentOriginDiscovered:
+			items = nil
+			for _, d := range deployments {
+				if d.Metadata.Annotations[v1alpha1.DeploymentOriginAnnotation] == v1alpha1.DeploymentOriginDiscovered {
+					items = append(items, d)
+				}
+			}
+		}
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(map[string]any{"items": deployments})
+		_ = json.NewEncoder(w).Encode(map[string]any{"items": items})
 	})
 	mux.HandleFunc("/v0/deployments/", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
@@ -162,12 +179,15 @@ func TestDeploymentGet_NotFoundError(t *testing.T) {
 		"missing deployment should surface a not-found error")
 }
 
-// (4) List mode (no name arg) returns every deployment — exercises the shared
-// ListFunc path and guards against the Get wiring accidentally short-circuiting list.
-func TestDeploymentGet_ListReturnsAll(t *testing.T) {
+// (4) List mode (no name arg) returns registry-managed deployments, excluding
+// provider-discovered inventory rows.
+func TestDeploymentGet_ListReturnsManagedDeployments(t *testing.T) {
 	deployments := []v1alpha1.Deployment{
 		deploymentFixture("aws-v1", "summarizer", "1.0.0", "my-aws", "agent", "deployed"),
 		deploymentFixture("gcp-v1", "other", "1.0.0", "my-gcp", "agent", "pending"),
+	}
+	deployments[1].Metadata.Annotations = map[string]string{
+		v1alpha1.DeploymentOriginAnnotation: v1alpha1.DeploymentOriginDiscovered,
 	}
 	srv := deploymentTestServerV1Alpha1(t, deployments)
 	setupClientForServer(t, srv)
@@ -179,7 +199,7 @@ func TestDeploymentGet_ListReturnsAll(t *testing.T) {
 	require.NoError(t, cmd.Execute())
 
 	assert.Contains(t, out.String(), "summarizer")
-	assert.Contains(t, out.String(), "other")
+	assert.NotContains(t, out.String(), "other")
 }
 
 // (5) `-o yaml` emits the declarative envelope (apiVersion/kind/metadata/spec)
@@ -189,8 +209,9 @@ func TestDeploymentGet_ListReturnsAll(t *testing.T) {
 func TestDeploymentGet_YAMLOutputIncludesStatus(t *testing.T) {
 	deployment := deploymentFixture("aws-v1", "summarizer", "1.0.0", "my-aws", "agent", "deployed")
 	deployment.Spec.Env = map[string]string{"GOOGLE_API_KEY": "xxx"}
+	deployment.Spec.DeploymentRefs = []v1alpha1.DeploymentRef{{Name: "summarizer-tools"}}
 	deployment.Metadata.Annotations = map[string]string{
-		"runtimes.agentregistry.solo.io/remoteId": "runtime-abc",
+		"reconcile.agentregistry.dev/force": "2026-06-16T12:00:00Z",
 	}
 	srv := deploymentTestServerV1Alpha1(t, []v1alpha1.Deployment{deployment})
 	setupClientForServer(t, srv)
@@ -206,6 +227,9 @@ func TestDeploymentGet_YAMLOutputIncludesStatus(t *testing.T) {
 	// Envelope — apply expects these top-level keys.
 	assert.Contains(t, got, "apiVersion: ar.dev/v1alpha1")
 	assert.Contains(t, got, "kind: Deployment")
+	assert.Contains(t, got, "name: aws-v1")
+	assert.Contains(t, got, "annotations:")
+	assert.Contains(t, got, "reconcile.agentregistry.dev/force: \"2026-06-16T12:00:00Z\"")
 	assert.Contains(t, got, "name: summarizer")
 	assert.Contains(t, got, "tag: 1.0.0")
 
@@ -215,15 +239,15 @@ func TestDeploymentGet_YAMLOutputIncludesStatus(t *testing.T) {
 	assert.Contains(t, got, "name: my-aws")
 	assert.Contains(t, got, "targetRef:")
 	assert.Contains(t, got, "kind: Agent")
+	assert.Contains(t, got, "deploymentRefs:")
+	assert.Contains(t, got, "name: summarizer-tools")
 	assert.Contains(t, got, "GOOGLE_API_KEY: xxx")
 
-	// Status block — server-managed runtime state, available for debugging.
+	// Status block — canonical v1alpha1 status, available for debugging.
 	assert.Contains(t, got, "status:")
-	assert.Contains(t, got, "id: default/aws-v1")
-	assert.Contains(t, got, "phase: deployed")
-	assert.Contains(t, got, "origin: managed")
-	assert.Contains(t, got, "remoteId: runtime-abc",
-		"runtimeMetadata nested map should be emitted under .status")
+	assert.Contains(t, got, "conditions:")
+	assert.Contains(t, got, "type: Ready")
+	assert.Contains(t, got, "status: \"True\"")
 
 	// Spec block still must NOT contain status fields (structural check:
 	// the line immediately following `spec:` must not be the status keys).

--- a/internal/cli/declarative/resources.go
+++ b/internal/cli/declarative/resources.go
@@ -2,10 +2,8 @@ package declarative
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
-	"time"
 
 	cliCommon "github.com/agentregistry-dev/agentregistry/internal/cli/common"
 	"github.com/agentregistry-dev/agentregistry/internal/cli/scheme"
@@ -13,22 +11,6 @@ import (
 	"github.com/agentregistry-dev/agentregistry/pkg/api/v1alpha1"
 	"github.com/agentregistry-dev/agentregistry/pkg/printer"
 )
-
-// deploymentStatus is the shape emitted under .status when a deployment is
-// rendered as YAML/JSON. Intentionally a CLI projection rather than the raw
-// v1alpha1.Status conditions block so imperative users keep the compact fields
-// they already consume while apply decode still ignores incoming status.
-type deploymentStatus struct {
-	ID              string               `json:"id,omitempty" yaml:"id,omitempty"`
-	Phase           string               `json:"phase,omitempty" yaml:"phase,omitempty"`
-	Origin          string               `json:"origin,omitempty" yaml:"origin,omitempty"`
-	Error           string               `json:"error,omitempty" yaml:"error,omitempty"`
-	RuntimeMetadata map[string]any       `json:"runtimeMetadata,omitempty" yaml:"runtimeMetadata,omitempty"`
-	DeployedAt      time.Time            `json:"deployedAt,omitempty" yaml:"deployedAt,omitempty"`
-	UpdatedAt       time.Time            `json:"updatedAt,omitempty" yaml:"updatedAt,omitempty"`
-	Conditions      []v1alpha1.Condition `json:"conditions,omitempty" yaml:"conditions,omitempty"`
-	Details         json.RawMessage      `json:"details,omitempty" yaml:"details,omitempty"`
-}
 
 // listAny lists rows of the given kind. The zero scheme.ListOpts returns
 // every (namespace, name, tag) row of the kind — same shape as a raw
@@ -124,71 +106,28 @@ func deleteAny[T v1alpha1.Object](ctx context.Context, c *client.Client, kind, n
 	return c.Delete(ctx, kind, ref.Namespace, ref.Name, targetTag)
 }
 
-func listDeploymentAny(ctx context.Context, c *client.Client) ([]any, error) {
-	deployments, err := cliCommon.ListDeployments(ctx, c)
+func listDeploymentResources(ctx context.Context, c *client.Client, _ scheme.ListOpts) ([]any, error) {
+	items, err := client.ListAllTyped(
+		ctx,
+		c,
+		v1alpha1.KindDeployment,
+		client.ListOpts{
+			Namespace:          v1alpha1.DefaultNamespace,
+			Limit:              200,
+			Origin:             v1alpha1.DeploymentOriginManaged,
+			IncludeTerminating: true,
+		},
+		func() *v1alpha1.Deployment { return &v1alpha1.Deployment{} },
+	)
 	if err != nil {
 		return nil, err
 	}
-	out := make([]any, 0, len(deployments))
-	for _, dep := range deployments {
-		out = append(out, dep)
+
+	out := make([]any, 0, len(items))
+	for _, item := range items {
+		out = append(out, item)
 	}
 	return out, nil
-}
-
-func deploymentToDocument(dep *cliCommon.DeploymentRecord) any {
-	if dep == nil {
-		return nil
-	}
-
-	targetKind := v1alpha1.KindAgent
-	if dep.ResourceType == "mcp" {
-		targetKind = v1alpha1.KindMCPServer
-	}
-
-	// metadata is the Deployment row's identity, NOT the target's. Two
-	// deployments of the same target/tag against different runtimes
-	// are distinct rows; collapsing them onto target identity here
-	// (previous behavior) made get-then-apply round-trips clobber the
-	// wrong row and made delete by metadata identity impossible.
-	return struct {
-		APIVersion string                  `json:"apiVersion" yaml:"apiVersion"`
-		Kind       string                  `json:"kind" yaml:"kind"`
-		Metadata   v1alpha1.ObjectMeta     `json:"metadata" yaml:"metadata"`
-		Spec       v1alpha1.DeploymentSpec `json:"spec" yaml:"spec"`
-		Status     deploymentStatus        `json:"status,omitempty" yaml:"status,omitempty"`
-	}{
-		APIVersion: v1alpha1.GroupVersion,
-		Kind:       v1alpha1.KindDeployment,
-		Metadata: v1alpha1.ObjectMeta{
-			Namespace: dep.Namespace,
-			Name:      dep.Name,
-		},
-		Spec: v1alpha1.DeploymentSpec{
-			TargetRef: v1alpha1.ResourceRef{
-				Kind: targetKind,
-				Name: dep.TargetName,
-				Tag:  dep.TargetTag,
-			},
-			RuntimeRef: v1alpha1.ResourceRef{
-				Kind: v1alpha1.KindRuntime,
-				Name: dep.RuntimeID,
-			},
-			Env:           dep.Env,
-			RuntimeConfig: dep.RuntimeConfig,
-		},
-		Status: deploymentStatus{
-			ID:              dep.ID,
-			Phase:           dep.Status,
-			Origin:          dep.Origin,
-			Error:           dep.Error,
-			RuntimeMetadata: dep.RuntimeMetadata,
-			DeployedAt:      dep.CreatedAt,
-			UpdatedAt:       dep.UpdatedAt,
-			Conditions:      dep.Conditions,
-			Details:         dep.Details,
-		},
-	}
 }
 
 func agentRow(agent *v1alpha1.Agent) []string {

--- a/internal/cli/declarative/runtime_get_test.go
+++ b/internal/cli/declarative/runtime_get_test.go
@@ -63,14 +63,17 @@ func runtimeFixture(name, runtimeType string, config map[string]any) v1alpha1.Ru
 	}
 }
 
-// (1) `-o yaml` emits the declarative envelope and strips server-managed fields
-// (id, timestamps) so the output round-trips through `arctl apply -f`.
-func TestRuntimeGet_YAMLOutputRoundTrips(t *testing.T) {
+// (1) `-o yaml` emits the canonical v1alpha1 envelope without projecting
+// metadata or spec through a CLI-specific DTO.
+func TestRuntimeGet_YAMLOutputPreservesCanonicalEnvelope(t *testing.T) {
 	runtimes := []v1alpha1.Runtime{
 		runtimeFixture("my-kagent", "Kagent", map[string]any{
 			"kagentUrl": "http://kagent-controller.kagent:8083",
 			"namespace": "kagent",
 		}),
+	}
+	runtimes[0].Metadata.Annotations = map[string]string{
+		"reconcile.agentregistry.dev/force": "2026-06-16T12:00:00Z",
 	}
 	srv := runtimeTestServer(t, runtimes)
 	setupClientForServer(t, srv)
@@ -86,13 +89,12 @@ func TestRuntimeGet_YAMLOutputRoundTrips(t *testing.T) {
 	assert.Contains(t, got, "apiVersion: ar.dev/v1alpha1")
 	assert.Contains(t, got, "kind: Runtime")
 	assert.Contains(t, got, "name: my-kagent")
+	assert.Contains(t, got, "annotations:")
+	assert.Contains(t, got, "reconcile.agentregistry.dev/force: \"2026-06-16T12:00:00Z\"")
 	// Declarative spec fields.
 	assert.Contains(t, got, "type: Kagent")
 	assert.Contains(t, got, "kagentUrl: http://kagent-controller.kagent:8083")
 	assert.Contains(t, got, "namespace: kagent")
-	// Server-managed fields must be stripped.
-	assert.NotContains(t, got, "createdAt", "spec must not leak server timestamps")
-	assert.NotContains(t, got, "updatedAt", "spec must not leak server timestamps")
 }
 
 // (2) Table output (default) still works — regression guard for the YAML-only change.


### PR DESCRIPTION
# Description

Fixes declarative CLI output for mutable v1alpha1 resources.

Deployment `get -o yaml` was using a CLI projection and reconstructing a
Deployment document from that DTO. That lost canonical fields such as
`metadata.annotations` and `spec.deploymentRefs`, even though the server
returned the full v1alpha1 resource. This change makes Runtime and Deployment
share typed namespace/name CRUD wiring so YAML and JSON output preserve the
canonical object shape.

Deployment still keeps its special table/list behavior: plain
`arctl get deployments` lists managed deployments only, excluding discovered
inventory rows, while table rows continue to use the compact deployment view.

# Change Type

/kind fix

# Changelog

```release-note
Fixed arctl deployment YAML output dropping canonical metadata and deploymentRefs fields.
```

# Additional Notes

Validated with focused CLI tests covering canonical Deployment YAML fields,
Runtime metadata preservation, and managed-only Deployment list output.
