### PR TITLE
add config for discovery settings

### DIFF
--- a/internal/registry/config/config.go
+++ b/internal/registry/config/config.go
@@ -61,6 +61,17 @@ type Config struct {
 	// ControllerRetentionPruneBatchLimit caps rows removed per retention pass so
 	// pruning cannot monopolize the database during startup or repair loops.
 	ControllerRetentionPruneBatchLimit int `env:"CONTROLLER_RETENTION_PRUNE_BATCH_LIMIT" envDefault:"500"`
+	// ControllerDiscoveryInterval is how often provider discovery snapshots are
+	// materialized into discovered Deployment rows. Provider-specific cache
+	// refreshes may have separate intervals.
+	ControllerDiscoveryInterval time.Duration `env:"CONTROLLER_DISCOVERY_INTERVAL" envDefault:"60s"`
+	// ControllerDiscoveryStaleAfterMisses is how many consecutive successful
+	// discovery polls may omit a discovered Deployment before it is marked
+	// not-ready/stale.
+	ControllerDiscoveryStaleAfterMisses int `env:"CONTROLLER_DISCOVERY_STALE_AFTER_MISSES" envDefault:"3"`
+	// ControllerDiscoveryDeleteAfterMisses is how many consecutive successful
+	// discovery polls may omit a discovered Deployment before it is deleted.
+	ControllerDiscoveryDeleteAfterMisses int `env:"CONTROLLER_DISCOVERY_DELETE_AFTER_MISSES" envDefault:"5"`
 
 	// SkipMigrations gates the server's Postgres migrator at startup.
 	// Set true when migrations are applied out-of-band (e.g. by

--- a/internal/registry/config/config_test.go
+++ b/internal/registry/config/config_test.go
@@ -46,11 +46,14 @@ func TestNewConfig_RuntimeDirRespectsEnvOverride(t *testing.T) {
 	}
 }
 
-func TestNewConfig_ControllerRetentionEnv(t *testing.T) {
+func TestNewConfig_ControllerEnv(t *testing.T) {
 	t.Setenv("AGENT_REGISTRY_RUNTIME_DIR", "/tmp/runtime")
 	t.Setenv("AGENT_REGISTRY_CONTROLLER_EVENT_RETENTION", "2h")
 	t.Setenv("AGENT_REGISTRY_CONTROLLER_EVENT_KEEP_AFTER_REVISION", "42")
 	t.Setenv("AGENT_REGISTRY_CONTROLLER_RETENTION_PRUNE_BATCH_LIMIT", "17")
+	t.Setenv("AGENT_REGISTRY_CONTROLLER_DISCOVERY_INTERVAL", "15s")
+	t.Setenv("AGENT_REGISTRY_CONTROLLER_DISCOVERY_STALE_AFTER_MISSES", "2")
+	t.Setenv("AGENT_REGISTRY_CONTROLLER_DISCOVERY_DELETE_AFTER_MISSES", "4")
 
 	cfg := NewConfig()
 
@@ -62,6 +65,15 @@ func TestNewConfig_ControllerRetentionEnv(t *testing.T) {
 	}
 	if cfg.ControllerRetentionPruneBatchLimit != 17 {
 		t.Fatalf("prune batch limit = %d, want 17", cfg.ControllerRetentionPruneBatchLimit)
+	}
+	if cfg.ControllerDiscoveryInterval != 15*time.Second {
+		t.Fatalf("discovery interval = %s, want 15s", cfg.ControllerDiscoveryInterval)
+	}
+	if cfg.ControllerDiscoveryStaleAfterMisses != 2 {
+		t.Fatalf("discovery stale misses = %d, want 2", cfg.ControllerDiscoveryStaleAfterMisses)
+	}
+	if cfg.ControllerDiscoveryDeleteAfterMisses != 4 {
+		t.Fatalf("discovery delete misses = %d, want 4", cfg.ControllerDiscoveryDeleteAfterMisses)
 	}
 }
 

--- a/internal/registry/controller/discovery.go
+++ b/internal/registry/controller/discovery.go
@@ -24,22 +24,24 @@ const (
 	// APIs (notably AWS) are eventually consistent, so a single missing poll
 	// is not evidence the workload is gone.
 	deploymentDiscoveryMissesKey = "discoveryMisses"
-	// deploymentDiscoveryStaleAfterMisses is how many consecutive misses it
+	// defaultDeploymentDiscoveryStaleAfterMisses is how many consecutive misses it
 	// takes before the Discovered/Ready conditions flip to False.
-	deploymentDiscoveryStaleAfterMisses = 3
-	// deploymentDiscoveryDeleteAfterMisses is how many consecutive misses it
+	defaultDeploymentDiscoveryStaleAfterMisses = 3
+	// defaultDeploymentDiscoveryDeleteAfterMisses is how many consecutive misses it
 	// takes before the row is deleted outright. Rows whose Runtime no longer
 	// exists skip the counter and are deleted immediately — no future poll
 	// could confirm them again.
-	deploymentDiscoveryDeleteAfterMisses = 5
+	defaultDeploymentDiscoveryDeleteAfterMisses = 5
 )
 
 // DeploymentDiscoveryController materializes adapter discovery snapshots into
 // persisted Deployment rows. It owns provider-observed state; the normal
 // DeploymentController skips these rows so they do not become desired state.
 type DeploymentDiscoveryController struct {
-	Stores   map[string]*v1alpha1store.Store
-	Adapters map[string]types.DeploymentAdapter
+	Stores            map[string]*v1alpha1store.Store
+	Adapters          map[string]types.DeploymentAdapter
+	StaleAfterMisses  int
+	DeleteAfterMisses int
 }
 
 // DeploymentDiscoverySyncResult summarizes one discovery materialization pass.
@@ -172,7 +174,7 @@ func (c *DeploymentDiscoveryController) Sync(ctx context.Context) (DeploymentDis
 			continue
 		}
 		misses := discoveredMissCount(deployment) + 1
-		if misses >= deploymentDiscoveryDeleteAfterMisses {
+		if misses >= c.deleteAfterMisses() {
 			if err := c.deleteDiscoveredDeployment(ctx, deployment); err != nil {
 				if firstErr == nil {
 					firstErr = err
@@ -188,7 +190,7 @@ func (c *DeploymentDiscoveryController) Sync(ctx context.Context) (DeploymentDis
 			}
 			continue
 		}
-		if misses >= deploymentDiscoveryStaleAfterMisses {
+		if misses >= c.staleAfterMisses() {
 			result.Stale++
 		}
 	}
@@ -394,7 +396,7 @@ func (c *DeploymentDiscoveryController) patchMissedStatus(ctx context.Context, d
 			s.ObservedGeneration = generation
 		}
 		_ = s.SetDetailsKey(deploymentDiscoveryMissesKey, misses)
-		if misses < deploymentDiscoveryStaleAfterMisses {
+		if misses < c.staleAfterMisses() {
 			return
 		}
 		s.SetCondition(v1alpha1.Condition{
@@ -441,6 +443,20 @@ func discoveredMissCount(deployment *v1alpha1.Deployment) int {
 		return 0
 	}
 	return misses
+}
+
+func (c *DeploymentDiscoveryController) staleAfterMisses() int {
+	if c != nil && c.StaleAfterMisses > 0 {
+		return c.StaleAfterMisses
+	}
+	return defaultDeploymentDiscoveryStaleAfterMisses
+}
+
+func (c *DeploymentDiscoveryController) deleteAfterMisses() int {
+	if c != nil && c.DeleteAfterMisses > 0 {
+		return c.DeleteAfterMisses
+	}
+	return defaultDeploymentDiscoveryDeleteAfterMisses
 }
 
 func (c *DeploymentDiscoveryController) runtimeStore() *v1alpha1store.Store {

--- a/internal/registry/controller/discovery_integration_test.go
+++ b/internal/registry/controller/discovery_integration_test.go
@@ -69,7 +69,7 @@ func TestDeploymentDiscoveryController_MarksRowsStaleAfterConsecutiveMisses(t *t
 	// Misses below the staleness threshold only bump the counter; the
 	// conditions stay True (provider list APIs are eventually consistent).
 	adapter.results = nil
-	for miss := 1; miss < deploymentDiscoveryStaleAfterMisses; miss++ {
+	for miss := 1; miss < defaultDeploymentDiscoveryStaleAfterMisses; miss++ {
 		result, err := discovery.Sync(ctx)
 		require.NoError(t, err)
 		require.Zero(t, result.Stale, "miss %d should not mark the row stale", miss)
@@ -109,7 +109,7 @@ func TestDeploymentDiscoveryController_DeletesRowsAfterRepeatedMisses(t *testing
 	name := discoveredDeploymentName("local", v1alpha1.KindAgent, "external-agent", "unknown", "default")
 
 	adapter.results = nil
-	for miss := 1; miss < deploymentDiscoveryDeleteAfterMisses; miss++ {
+	for miss := 1; miss < defaultDeploymentDiscoveryDeleteAfterMisses; miss++ {
 		result, err := discovery.Sync(ctx)
 		require.NoError(t, err)
 		require.Zero(t, result.Removed, "miss %d should not delete the row", miss)
@@ -117,6 +117,37 @@ func TestDeploymentDiscoveryController_DeletesRowsAfterRepeatedMisses(t *testing
 	}
 
 	result, err := discovery.Sync(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 1, result.Removed)
+	requireDeploymentMissing(t, stores, name)
+}
+
+func TestDeploymentDiscoveryController_UsesConfiguredMissThresholds(t *testing.T) {
+	ctx := context.Background()
+	stores := newControllerTestStores(t)
+	seedRuntime(t, stores, "local")
+	adapter := &discoveryTestAdapter{results: []types.DiscoveryResult{{
+		TargetKind: v1alpha1.KindAgent,
+		Name:       "external-agent",
+	}}}
+	discovery := newDeploymentDiscoveryTestController(stores, adapter)
+	discovery.StaleAfterMisses = 1
+	discovery.DeleteAfterMisses = 2
+	_, err := discovery.Sync(ctx)
+	require.NoError(t, err)
+
+	name := discoveredDeploymentName("local", v1alpha1.KindAgent, "external-agent", "unknown", "default")
+
+	adapter.results = nil
+	result, err := discovery.Sync(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 1, result.Stale)
+	require.Zero(t, result.Removed)
+	deployment := loadDeployment(t, stores, name)
+	require.Equal(t, 1, discoveredMissCount(deployment))
+	require.Equal(t, v1alpha1.ConditionFalse, deployment.Status.GetCondition(deploymentDiscoveryCondition).Status)
+
+	result, err = discovery.Sync(ctx)
 	require.NoError(t, err)
 	require.Equal(t, 1, result.Removed)
 	requireDeploymentMissing(t, stores, name)

--- a/internal/registry/controller/runner.go
+++ b/internal/registry/controller/runner.go
@@ -36,7 +36,10 @@ type ControllerHandle struct {
 
 // ControllerConfig controls optional controller maintenance loops.
 type ControllerConfig struct {
-	Retention RetentionPolicy
+	Retention                  RetentionPolicy
+	DiscoveryInterval          time.Duration
+	DiscoveryStaleAfterMisses  int
+	DiscoveryDeleteAfterMisses int
 }
 
 // StartDeploymentController constructs the Deployment controller, runs the
@@ -68,8 +71,10 @@ func StartDeploymentController(
 	}
 	controller.Wakeups = controlPlaneWakeups(ctx, pool)
 	discovery := &DeploymentDiscoveryController{
-		Stores:   stores,
-		Adapters: adapters,
+		Stores:            stores,
+		Adapters:          adapters,
+		StaleAfterMisses:  config.DiscoveryStaleAfterMisses,
+		DeleteAfterMisses: config.DiscoveryDeleteAfterMisses,
 	}
 
 	retention := &RetentionPruner{
@@ -86,7 +91,7 @@ func StartDeploymentController(
 		}
 	}()
 	go func() {
-		if err := discovery.Run(ctx, defaultControllerResyncInterval); err != nil && !errors.Is(err, context.Canceled) {
+		if err := discovery.Run(ctx, config.DiscoveryInterval); err != nil && !errors.Is(err, context.Canceled) {
 			logger.Error("deployment discovery controller stopped", "error", err)
 		}
 	}()

--- a/internal/registry/registry_app.go
+++ b/internal/registry/registry_app.go
@@ -251,6 +251,9 @@ func deploymentControllerConfig(cfg *config.Config) controller.ControllerConfig 
 			EventKeepAfterRev:  cfg.ControllerEventKeepAfterRevision,
 			BatchLimit:         cfg.ControllerRetentionPruneBatchLimit,
 		},
+		DiscoveryInterval:          cfg.ControllerDiscoveryInterval,
+		DiscoveryStaleAfterMisses:  cfg.ControllerDiscoveryStaleAfterMisses,
+		DiscoveryDeleteAfterMisses: cfg.ControllerDiscoveryDeleteAfterMisses,
 	}
 }
 

--- a/internal/registry/registry_app_test.go
+++ b/internal/registry/registry_app_test.go
@@ -12,9 +12,12 @@ import (
 
 func TestDeploymentControllerConfigMapsRetentionSettings(t *testing.T) {
 	cfg := &config.Config{
-		ControllerEventRetention:           2 * time.Hour,
-		ControllerEventKeepAfterRevision:   42,
-		ControllerRetentionPruneBatchLimit: 17,
+		ControllerEventRetention:             2 * time.Hour,
+		ControllerEventKeepAfterRevision:     42,
+		ControllerRetentionPruneBatchLimit:   17,
+		ControllerDiscoveryInterval:          15 * time.Second,
+		ControllerDiscoveryStaleAfterMisses:  2,
+		ControllerDiscoveryDeleteAfterMisses: 4,
 	}
 
 	got := deploymentControllerConfig(cfg)
@@ -22,6 +25,9 @@ func TestDeploymentControllerConfigMapsRetentionSettings(t *testing.T) {
 	require.Equal(t, 2*time.Hour, got.Retention.ControlPlaneEvents)
 	require.Equal(t, int64(42), got.Retention.EventKeepAfterRev)
 	require.Equal(t, 17, got.Retention.BatchLimit)
+	require.Equal(t, 15*time.Second, got.DiscoveryInterval)
+	require.Equal(t, 2, got.DiscoveryStaleAfterMisses)
+	require.Equal(t, 4, got.DiscoveryDeleteAfterMisses)
 }
 
 func TestBuildStoresAddsExtraStoreTables(t *testing.T) {


### PR DESCRIPTION
# Description

- **Motivation:** allow configuring discovery controller settings 
- **What changed:** add 3 new environment variables to control the sync time, miss rounds, and delete after miss rounds for the discovery controller

# Change Type

```
/kind feature
```

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
Added AGENT_REGISTRY_CONTROLLER_DISCOVERY_INTERVAL, AGENT_REGISTRY_CONTROLLER_DISCOVERY_STALE_AFTER_MISSES, and AGENT_REGISTRY_CONTROLLER_DISCOVERY_DELETE_AFTER_MISSES to tune discovered deployment refresh and removal timing.
```

# Additional Notes
