### PR TITLE
helm: handling release namespaces for all resources

### DIFF
--- a/charts/agentregistry/templates/configmap.yaml
+++ b/charts/agentregistry/templates/configmap.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "agentregistry.fullname" . }}-config
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "agentregistry.labels" . | nindent 4 }}
   {{- $annotations := include "agentregistry.annotations" (dict "annotations" dict "context" $) }}

--- a/charts/agentregistry/templates/deployment.yaml
+++ b/charts/agentregistry/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "agentregistry.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "agentregistry.labels" . | nindent 4 }}
   {{- $annotations := include "agentregistry.annotations" (dict "annotations" dict "context" $) }}

--- a/charts/agentregistry/templates/postgresql-secret.yaml
+++ b/charts/agentregistry/templates/postgresql-secret.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "agentregistry.fullname" . }}-postgresql
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "agentregistry.postgresql.labels" . | nindent 4 }}
   {{- $annotations := include "agentregistry.annotations" (dict "annotations" dict "context" $) }}

--- a/charts/agentregistry/templates/postgresql.yaml
+++ b/charts/agentregistry/templates/postgresql.yaml
@@ -6,6 +6,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ $fullname }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "agentregistry.postgresql.labels" . | nindent 4 }}
   {{- $annotations := include "agentregistry.annotations" (dict "annotations" dict "context" $) }}
@@ -24,6 +25,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ $fullname }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "agentregistry.postgresql.labels" . | nindent 4 }}
   {{- $annotations := include "agentregistry.annotations" (dict "annotations" dict "context" $) }}
@@ -112,6 +114,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ $fullname }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "agentregistry.postgresql.labels" . | nindent 4 }}
   {{- $annotations := include "agentregistry.annotations" (dict "annotations" dict "context" $) }}

--- a/charts/agentregistry/templates/secrets.yaml
+++ b/charts/agentregistry/templates/secrets.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "agentregistry.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "agentregistry.labels" . | nindent 4 }}
   {{- $annotations := include "agentregistry.annotations" (dict "annotations" dict "context" $) }}

--- a/charts/agentregistry/templates/service.yaml
+++ b/charts/agentregistry/templates/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "agentregistry.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "agentregistry.labels" . | nindent 4 }}
   {{- $annotations := include "agentregistry.annotations" (dict "annotations" .Values.service.annotations "context" $) }}

--- a/charts/agentregistry/templates/serviceaccount.yaml
+++ b/charts/agentregistry/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "agentregistry.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "agentregistry.labels" . | nindent 4 }}
   {{- $annotations := include "agentregistry.annotations" (dict "annotations" .Values.serviceAccount.annotations "context" $) }}

--- a/charts/agentregistry/tests/configmap_test.yaml
+++ b/charts/agentregistry/tests/configmap_test.yaml
@@ -16,6 +16,12 @@ tests:
           path: metadata.name
           value: RELEASE-NAME-agentregistry-config
 
+  - it: is created in the release namespace
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: NAMESPACE
+
   - it: has standard labels
     asserts:
       - isSubset:

--- a/charts/agentregistry/tests/deployment_test.yaml
+++ b/charts/agentregistry/tests/deployment_test.yaml
@@ -15,6 +15,9 @@ tests:
           path: metadata.name
           value: RELEASE-NAME-agentregistry
       - equal:
+          path: metadata.namespace
+          value: NAMESPACE
+      - equal:
           path: spec.replicas
           value: 1
 

--- a/charts/agentregistry/tests/postgresql_test.yaml
+++ b/charts/agentregistry/tests/postgresql_test.yaml
@@ -22,6 +22,9 @@ tests:
           path: metadata.name
           value: RELEASE-NAME-agentregistry-postgresql
       - equal:
+          path: metadata.namespace
+          value: NAMESPACE
+      - equal:
           path: spec.resources.requests.storage
           value: 5Gi
       - equal:
@@ -37,6 +40,9 @@ tests:
       - equal:
           path: metadata.name
           value: RELEASE-NAME-agentregistry-postgresql
+      - equal:
+          path: metadata.namespace
+          value: NAMESPACE
       - equal:
           path: spec.strategy.type
           value: Recreate
@@ -163,6 +169,9 @@ tests:
           path: metadata.name
           value: RELEASE-NAME-agentregistry-postgresql
       - equal:
+          path: metadata.namespace
+          value: NAMESPACE
+      - equal:
           path: spec.ports[0].port
           value: 5432
 
@@ -211,6 +220,9 @@ tests:
       - equal:
           path: metadata.name
           value: RELEASE-NAME-agentregistry-postgresql
+      - equal:
+          path: metadata.namespace
+          value: NAMESPACE
       - isNotNull:
           path: data["POSTGRES_PASSWORD"]
 

--- a/charts/agentregistry/tests/secrets_test.yaml
+++ b/charts/agentregistry/tests/secrets_test.yaml
@@ -18,6 +18,9 @@ tests:
           path: metadata.name
           value: RELEASE-NAME-agentregistry
       - equal:
+          path: metadata.namespace
+          value: NAMESPACE
+      - equal:
           path: type
           value: Opaque
       - isSubset:

--- a/charts/agentregistry/tests/service_test.yaml
+++ b/charts/agentregistry/tests/service_test.yaml
@@ -16,6 +16,12 @@ tests:
           path: metadata.name
           value: RELEASE-NAME-agentregistry
 
+  - it: is created in the release namespace
+    asserts:
+      - equal:
+          path: metadata.namespace
+          value: NAMESPACE
+
   - it: has standard labels
     asserts:
       - isSubset:


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don't apply.
-->

# Description

Added `namespace: {{ .Release.Namespace }}` to the metadata of the following resources to ensure they are deployed in the intended namespace:

This pull request updates multiple Kubernetes manifest templates in the `charts/agentregistry` Helm chart to explicitly set the `namespace` field in the metadata of all major resources. This ensures that resources are created in the correct namespace as specified by the Helm release, improving deployment consistency and reliability.

# Change Type

/kind fix

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
helm: inherit release namespace configuration for helm chart
```

