### PR TITLE
refactor(harness): drop unused deployment version selector

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -177,8 +177,6 @@ components:
           type: string
         type:
           type: string
-        version:
-          type: string
       required:
       - type
       type: object

--- a/pkg/api/v1alpha1/agent.go
+++ b/pkg/api/v1alpha1/agent.go
@@ -60,7 +60,7 @@ type AgentSource struct {
 }
 
 // HarnessCompatibility declares one harness family this Agent can run under.
-// Version/policy selection lives on Deployment so the same Agent can be rolled
+// Rollout policy selection lives on Deployment so the same Agent can be rolled
 // out with different compatible harnesses.
 type HarnessCompatibility struct {
 	// Type is the harness family, e.g. "claude-code", "codex", "opencode".

--- a/pkg/api/v1alpha1/agent.go
+++ b/pkg/api/v1alpha1/agent.go
@@ -29,7 +29,7 @@ type AgentSpec struct {
 	Source *AgentSource `json:"source,omitempty" yaml:"source,omitempty"`
 
 	// CompatibleHarnesses declares which coding harnesses this Agent can run
-	// under. The Deployment selects the concrete harness type/version for a
+	// under. The Deployment selects the concrete harness type for a
 	// rollout; Agent remains the portable compatibility contract.
 	CompatibleHarnesses []HarnessCompatibility `json:"compatibleHarnesses,omitempty" yaml:"compatibleHarnesses,omitempty"`
 

--- a/pkg/api/v1alpha1/agent_harness_validate_test.go
+++ b/pkg/api/v1alpha1/agent_harness_validate_test.go
@@ -139,3 +139,12 @@ func TestHarnessCompatibilityIsMatrixOnly(t *testing.T) {
 		}
 	}
 }
+
+// TestDeploymentHarnessDoesNotExposeVersion asserts deployment harness
+// selection stays limited to fields the deploy path actually consumes.
+func TestDeploymentHarnessDoesNotExposeVersion(t *testing.T) {
+	harnessType := reflect.TypeFor[DeploymentHarness]()
+	if _, ok := harnessType.FieldByName("Version"); ok {
+		t.Fatalf("DeploymentHarness must not expose Version until runtime image resolution uses it")
+	}
+}

--- a/pkg/api/v1alpha1/agent_harness_validate_test.go
+++ b/pkg/api/v1alpha1/agent_harness_validate_test.go
@@ -130,7 +130,7 @@ func TestCompositionRefKindDefaultingPersists(t *testing.T) {
 }
 
 // TestHarnessCompatibilityIsMatrixOnly asserts Agent compatibility is a
-// harness-type matrix; the deployment owns concrete version/policy selection.
+// harness-type matrix; the deployment owns concrete policy selection.
 func TestHarnessCompatibilityIsMatrixOnly(t *testing.T) {
 	harnessType := reflect.TypeFor[HarnessCompatibility]()
 	for _, removed := range []string{"Version", "Plugins", "Skills", "Instructions", "MCPServers"} {

--- a/pkg/api/v1alpha1/deployment.go
+++ b/pkg/api/v1alpha1/deployment.go
@@ -81,10 +81,6 @@ type DeploymentHarness struct {
 	// Type is the selected harness family, e.g. "claude-code", "codex".
 	Type string `json:"type" yaml:"type"`
 
-	// Version pins the selected harness version for this rollout. Empty asks the
-	// target Runtime to use its default for Type.
-	Version string `json:"version,omitempty" yaml:"version,omitempty"`
-
 	// PermissionMode controls the harness tool-permission posture, e.g.
 	// "default", "acceptEdits", "bypassPermissions". Empty defaults to
 	// "bypassPermissions" for headless harness runtimes (no interactive

--- a/pkg/api/v1alpha1/validation_test.go
+++ b/pkg/api/v1alpha1/validation_test.go
@@ -246,7 +246,6 @@ func TestDeploymentValidate_HarnessSelectionOK(t *testing.T) {
 			RuntimeRef: ResourceRef{Kind: KindRuntime, Name: "agentcore"},
 			Harness: &DeploymentHarness{
 				Type:           "claude-code",
-				Version:        "1.2.3",
 				PermissionMode: "acceptEdits",
 			},
 		},

--- a/pkg/types/fingerprint_test.go
+++ b/pkg/types/fingerprint_test.go
@@ -105,7 +105,7 @@ func TestDefaultApplyFingerprintResultIncludesDependencySnapshot(t *testing.T) {
 
 func TestDefaultApplyFingerprintIncludesAgentHarnessCompositionDependencies(t *testing.T) {
 	in := testApplyInput()
-	in.Deployment.Spec.Harness = &v1alpha1.DeploymentHarness{Type: "claude-code", Version: "1.2.3"}
+	in.Deployment.Spec.Harness = &v1alpha1.DeploymentHarness{Type: "claude-code"}
 	in.Target = &v1alpha1.Agent{
 		TypeMeta: v1alpha1.TypeMeta{Kind: v1alpha1.KindAgent},
 		Metadata: v1alpha1.ObjectMeta{

--- a/ui/lib/api/types.gen.ts
+++ b/ui/lib/api/types.gen.ts
@@ -79,7 +79,6 @@ export type Deployment = {
 export type DeploymentHarness = {
     permissionMode?: string;
     type: string;
-    version?: string;
 };
 
 export type DeploymentRef = {


### PR DESCRIPTION
# Description

Removes the unused `DeploymentHarness.version` selector from the harness API surface. The AgentCore harness deployment path resolved runner images by harness type only, and the runner did not consume the version value, so keeping the field implied behavior we did not actually implement.

This also regenerates the OSS OpenAPI schema and TypeScript client so the public contract no longer advertises `harness.version`.

# Change Type

/kind cleanup

# Changelog

```release-note
NONE
```

# Additional Notes

Validation:
- `go test ./pkg/api/v1alpha1`
- `go test ./pkg/types`
- `git diff --check -- pkg/api/v1alpha1/agent.go pkg/api/v1alpha1/deployment.go pkg/api/v1alpha1/agent_harness_validate_test.go pkg/api/v1alpha1/validation_test.go pkg/types/fingerprint_test.go openapi.yaml ui/lib/api/types.gen.ts`
