### PR TITLE
support deployment filtering

### DIFF
--- a/internal/cli/declarative/deployment_get_test.go
+++ b/internal/cli/declarative/deployment_get_test.go
@@ -179,27 +179,92 @@ func TestDeploymentGet_NotFoundError(t *testing.T) {
 		"missing deployment should surface a not-found error")
 }
 
-// (4) List mode (no name arg) returns registry-managed deployments, excluding
-// provider-discovered inventory rows.
-func TestDeploymentGet_ListReturnsManagedDeployments(t *testing.T) {
+// (4) --origin drives deployment list filtering. The table exercises the full
+// surface: the managed default (no flag / explicit), discovered, all, and the
+// validation/gating errors. The test server (deploymentTestServerV1Alpha1)
+// honors ?origin= the same way the real handler does.
+func TestDeploymentGet_OriginFiltering(t *testing.T) {
 	deployments := []v1alpha1.Deployment{
-		deploymentFixture("aws-v1", "summarizer", "1.0.0", "my-aws", "agent", "deployed"),
-		deploymentFixture("gcp-v1", "other", "1.0.0", "my-gcp", "agent", "pending"),
+		deploymentFixture("aws-v1", "managed-agent", "1.0.0", "my-aws", "agent", "deployed"),
+		deploymentFixture("foundry-v1", "discovered-agent", "1.0.0", "my-foundry", "agent", "pending"),
 	}
 	deployments[1].Metadata.Annotations = map[string]string{
 		v1alpha1.DeploymentOriginAnnotation: v1alpha1.DeploymentOriginDiscovered,
 	}
-	srv := deploymentTestServerV1Alpha1(t, deployments)
-	setupClientForServer(t, srv)
 
-	out := &bytes.Buffer{}
-	cmd := declarative.NewGetCmd(declarativeTestDeps(nil))
-	cmd.SetOut(out)
-	cmd.SetArgs([]string{"deployments"})
-	require.NoError(t, cmd.Execute())
+	tests := []struct {
+		name            string
+		args            []string
+		wantContains    []string
+		wantNotContains []string
+		wantErr         string // substring; empty means success expected
+	}{
+		{
+			name:            "default lists managed only",
+			args:            []string{"deployments"},
+			wantContains:    []string{"managed-agent"},
+			wantNotContains: []string{"discovered-agent"},
+		},
+		{
+			name:            "explicit managed lists managed only",
+			args:            []string{"deployments", "--origin", "managed"},
+			wantContains:    []string{"managed-agent"},
+			wantNotContains: []string{"discovered-agent"},
+		},
+		{
+			name:            "discovered lists discovered only",
+			args:            []string{"deployments", "--origin", "discovered"},
+			wantContains:    []string{"discovered-agent"},
+			wantNotContains: []string{"managed-agent"},
+		},
+		{
+			name:         "all lists both origins",
+			args:         []string{"deployments", "--origin", "all"},
+			wantContains: []string{"managed-agent", "discovered-agent"},
+		},
+		{
+			name:    "invalid value rejected",
+			args:    []string{"deployments", "--origin", "bogus"},
+			wantErr: "invalid --origin",
+		},
+		{
+			name:    "rejected for non-deployment kind",
+			args:    []string{"agents", "--origin", "managed"},
+			wantErr: "only supported for",
+		},
+		{
+			name:    "rejected when combined with a NAME",
+			args:    []string{"deployment", "aws-v1", "--origin", "managed"},
+			wantErr: "cannot be combined with a resource NAME",
+		},
+	}
 
-	assert.Contains(t, out.String(), "summarizer")
-	assert.NotContains(t, out.String(), "other")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := deploymentTestServerV1Alpha1(t, deployments)
+			setupClientForServer(t, srv)
+
+			out := &bytes.Buffer{}
+			cmd := declarative.NewGetCmd(declarativeTestDeps(nil))
+			cmd.SetOut(out)
+			cmd.SetArgs(tt.args)
+			err := cmd.Execute()
+
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+			for _, want := range tt.wantContains {
+				assert.Contains(t, out.String(), want)
+			}
+			for _, notWant := range tt.wantNotContains {
+				assert.NotContains(t, out.String(), notWant)
+			}
+		})
+	}
 }
 
 // (5) `-o yaml` emits the declarative envelope (apiVersion/kind/metadata/spec)

--- a/internal/cli/declarative/get.go
+++ b/internal/cli/declarative/get.go
@@ -159,14 +159,20 @@ type getFlags struct {
 	tag     string
 }
 
-// resolveOrigin validates and normalizes the CLI --origin value into the
-// form carried by scheme.ListOpts.Origin. "" (unset), managed, discovered,
-// and "all" all pass through (lowercased); the Deployment ListFunc resolves
-// their filter semantics. Any other value is a user error.
+// resolveOrigin validates the CLI --origin selector and normalizes it into
+// the server filter value carried by scheme.ListOpts.Origin: unset defaults
+// to managed (preserving historical `arctl get deployments` behavior), "all"
+// clears the filter to return both provenances, and managed/discovered pass
+// through. The Deployment ListFunc then uses the value verbatim. Any other
+// value is a user error.
 func resolveOrigin(origin string) (string, error) {
-	switch v := strings.ToLower(origin); v {
-	case "", v1alpha1.DeploymentOriginManaged, v1alpha1.DeploymentOriginDiscovered, "all":
-		return v, nil
+	switch strings.ToLower(origin) {
+	case "", v1alpha1.DeploymentOriginManaged:
+		return v1alpha1.DeploymentOriginManaged, nil
+	case v1alpha1.DeploymentOriginDiscovered:
+		return v1alpha1.DeploymentOriginDiscovered, nil
+	case "all":
+		return "", nil
 	default:
 		return "", fmt.Errorf("invalid --origin %q: must be managed, discovered, or all", origin)
 	}

--- a/internal/cli/declarative/get.go
+++ b/internal/cli/declarative/get.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/agentregistry-dev/agentregistry/internal/cli/scheme"
 	"github.com/agentregistry-dev/agentregistry/internal/client"
+	"github.com/agentregistry-dev/agentregistry/pkg/api/v1alpha1"
 	cliruntime "github.com/agentregistry-dev/agentregistry/pkg/cli/runtime"
 	"github.com/agentregistry-dev/agentregistry/pkg/printer"
 )
@@ -36,6 +37,8 @@ Examples:
   arctl get agent acme-summarizer --tag stable
   arctl get agent acme-summarizer --all-tags
   arctl get deployment team-a/acme-summarizer
+  arctl get deployments --origin discovered  # list discovered (unmanaged) deployments
+  arctl get deployments --origin all         # list managed and discovered
   arctl get skills -o json`,
 		Args:         cobra.RangeArgs(1, 2),
 		SilenceUsage: true,
@@ -47,6 +50,7 @@ Examples:
 	cmd.Flags().String("tag", "", "Tagged kinds only. With NAME: fetch one tag (defaults to latest). Without NAME: filter the list to this tag.")
 	cmd.Flags().Bool("latest", false, "List mode only: restrict to rows pinned to the literal 'latest' tag (equivalent to --tag latest).")
 	cmd.Flags().Bool("all-tags", false, "List every tag of NAME (tagged content kinds only)")
+	cmd.Flags().String("origin", "", "Deployments only: filter by provenance — managed, discovered, or all (defaults to managed when unset).")
 	return cmd
 }
 
@@ -56,6 +60,7 @@ func runGet(cmd *cobra.Command, deps cliruntime.Deps, args []string) error {
 	allTags, _ := cmd.Flags().GetBool("all-tags")
 	latest, _ := cmd.Flags().GetBool("latest")
 	tag, _ := cmd.Flags().GetString("tag")
+	origin, _ := cmd.Flags().GetString("origin")
 	allTagsFlag := "--all-tags"
 	tagFlag := "--tag"
 	latestFlag := "--latest"
@@ -70,7 +75,15 @@ func runGet(cmd *cobra.Command, deps cliruntime.Deps, args []string) error {
 		return fmt.Errorf("%s and %s are mutually exclusive", tagFlag, latestFlag)
 	}
 
+	originOpt, err := resolveOrigin(origin)
+	if err != nil {
+		return err
+	}
+
 	if args[0] == "all" {
+		if origin != "" {
+			return fmt.Errorf("--origin cannot be used with `get all`")
+		}
 		return runGetAllArg(cmd, deps, kinds, outputFormat, getFlags{
 			allTags: allTags,
 			latest:  latest,
@@ -99,6 +112,14 @@ func runGet(cmd *cobra.Command, deps cliruntime.Deps, args []string) error {
 		return fmt.Errorf("%s not supported for kind %q (resource is not tagged)", latestFlag, k.Kind)
 	}
 
+	// --origin filters Deployment provenance and is meaningless elsewhere.
+	if origin != "" && !strings.EqualFold(k.Kind, v1alpha1.KindDeployment) {
+		return fmt.Errorf("--origin is only supported for %q, not %q", v1alpha1.KindDeployment, k.Kind)
+	}
+	if origin != "" && len(args) == 2 {
+		return fmt.Errorf("--origin is a list filter and cannot be combined with a resource NAME")
+	}
+
 	if deps.Runtime == nil {
 		return fmt.Errorf("registry runtime not configured")
 	}
@@ -120,7 +141,7 @@ func runGet(cmd *cobra.Command, deps cliruntime.Deps, args []string) error {
 		return printItem(cmd, k, item, outputFormat)
 	}
 
-	listOpts := scheme.ListOpts{Tag: tag, LatestOnly: latest}
+	listOpts := scheme.ListOpts{Tag: tag, LatestOnly: latest, Origin: originOpt}
 	items, err := listItems(cmd.Context(), c, k, listOpts)
 	if err != nil {
 		return fmt.Errorf("listing %s: %w", kindPlural(k), err)
@@ -136,6 +157,19 @@ type getFlags struct {
 	allTags bool
 	latest  bool
 	tag     string
+}
+
+// resolveOrigin validates and normalizes the CLI --origin value into the
+// form carried by scheme.ListOpts.Origin. "" (unset), managed, discovered,
+// and "all" all pass through (lowercased); the Deployment ListFunc resolves
+// their filter semantics. Any other value is a user error.
+func resolveOrigin(origin string) (string, error) {
+	switch v := strings.ToLower(origin); v {
+	case "", v1alpha1.DeploymentOriginManaged, v1alpha1.DeploymentOriginDiscovered, "all":
+		return v, nil
+	default:
+		return "", fmt.Errorf("invalid --origin %q: must be managed, discovered, or all", origin)
+	}
 }
 
 func runGetAllArg(cmd *cobra.Command, deps cliruntime.Deps, kinds *scheme.Registry, outputFormat string, flags getFlags) error {

--- a/internal/cli/declarative/resources.go
+++ b/internal/cli/declarative/resources.go
@@ -106,7 +106,18 @@ func deleteAny[T v1alpha1.Object](ctx context.Context, c *client.Client, kind, n
 	return c.Delete(ctx, kind, ref.Namespace, ref.Name, targetTag)
 }
 
-func listDeploymentResources(ctx context.Context, c *client.Client, _ scheme.ListOpts) ([]any, error) {
+func listDeploymentResources(ctx context.Context, c *client.Client, opts scheme.ListOpts) ([]any, error) {
+	// Translate the CLI-facing origin into the server filter. Unset defaults
+	// to managed to preserve historical `arctl get deployments` behavior
+	// (and keep `get all` scoped to managed rows); "all" clears the filter
+	// so the server returns both provenances.
+	origin := opts.Origin
+	switch origin {
+	case "":
+		origin = v1alpha1.DeploymentOriginManaged
+	case "all":
+		origin = ""
+	}
 	items, err := client.ListAllTyped(
 		ctx,
 		c,
@@ -114,7 +125,7 @@ func listDeploymentResources(ctx context.Context, c *client.Client, _ scheme.Lis
 		client.ListOpts{
 			Namespace:          v1alpha1.DefaultNamespace,
 			Limit:              200,
-			Origin:             v1alpha1.DeploymentOriginManaged,
+			Origin:             origin,
 			IncludeTerminating: true,
 		},
 		func() *v1alpha1.Deployment { return &v1alpha1.Deployment{} },

--- a/internal/cli/declarative/resources.go
+++ b/internal/cli/declarative/resources.go
@@ -107,17 +107,9 @@ func deleteAny[T v1alpha1.Object](ctx context.Context, c *client.Client, kind, n
 }
 
 func listDeploymentResources(ctx context.Context, c *client.Client, opts scheme.ListOpts) ([]any, error) {
-	// Translate the CLI-facing origin into the server filter. Unset defaults
-	// to managed to preserve historical `arctl get deployments` behavior
-	// (and keep `get all` scoped to managed rows); "all" clears the filter
-	// so the server returns both provenances.
-	origin := opts.Origin
-	switch origin {
-	case "":
-		origin = v1alpha1.DeploymentOriginManaged
-	case "all":
-		origin = ""
-	}
+	// opts.Origin is already normalized to the server filter value by the get
+	// command (resolveOrigin): "" means both provenances, managed/discovered
+	// select one. The zero-value caller (`get all`) therefore lists both.
 	items, err := client.ListAllTyped(
 		ctx,
 		c,
@@ -125,7 +117,7 @@ func listDeploymentResources(ctx context.Context, c *client.Client, opts scheme.
 		client.ListOpts{
 			Namespace:          v1alpha1.DefaultNamespace,
 			Limit:              200,
-			Origin:             origin,
+			Origin:             opts.Origin,
 			IncludeTerminating: true,
 		},
 		func() *v1alpha1.Deployment { return &v1alpha1.Deployment{} },

--- a/internal/cli/scheme/registry.go
+++ b/internal/cli/scheme/registry.go
@@ -33,6 +33,12 @@ type ListOpts struct {
 	// LatestOnly restricts the list to the literal "latest" tag (tagged
 	// content kinds) or the latest mutable-object row.
 	LatestOnly bool
+	// Origin filters Deployment rows by provenance. Recognized values:
+	// "managed", "discovered", "all" (both), and "" (unset — the Deployment
+	// list defaults to managed to preserve historical behavior). The
+	// Deployment ListFunc translates these to the server filter; only the
+	// Deployment kind honors this — other kinds ignore it.
+	Origin string
 }
 
 type ListFunc func(context.Context, *client.Client, ListOpts) ([]any, error)


### PR DESCRIPTION
# Description

- **Motivation:** support list opts in deployment listing
- **What changed:** normalize origin for `arctl get deployments` to filter by discovered or managed or all

# Change Type

```
/kind feature
```

# Changelog

```release-note
arctl get deployments now supports an --origin flag to filter by managed, discovered, or all deployments.
```

# Additional Notes