### PR TITLE
feat(ui): first-class Plugin support in the registry UI

### DIFF
--- a/ui/app/page.tsx
+++ b/ui/app/page.tsx
@@ -22,17 +22,21 @@ import { ServerCard } from "@/components/server-card"
 import { SkillCard } from "@/components/skill-card"
 import { AgentCard } from "@/components/agent-card"
 import { PromptCard } from "@/components/prompt-card"
+import { PluginCard } from "@/components/plugin-card"
 import { ServerDetail } from "@/components/server-detail"
 import { SkillDetail } from "@/components/skill-detail"
 import { AgentDetail } from "@/components/agent-detail"
 import { PromptDetail } from "@/components/prompt-detail"
+import { PluginDetail } from "@/components/plugin-detail"
 import { Sheet, SheetContent, SheetTitle } from "@/components/ui/sheet"
 import { AddServerDialog } from "@/components/add-server-dialog"
 import { AddSkillDialog } from "@/components/add-skill-dialog"
 import { AddAgentDialog } from "@/components/add-agent-dialog"
 import { AddPromptDialog } from "@/components/add-prompt-dialog"
+import { AddPluginDialog } from "@/components/add-plugin-dialog"
 import { DeployDialog } from "@/components/deploy-dialog"
-import { listServersV0, listSkillsV0, listAgentsV0, listPromptsV0, ServerResponse, SkillResponse, AgentResponse, PromptResponse } from "@/lib/admin-api"
+import { listServersV0, listSkillsV0, listAgentsV0, listPromptsV0, listPluginsV0, ServerResponse, SkillResponse, AgentResponse, PromptResponse } from "@/lib/admin-api"
+import type { Plugin } from "@/lib/api/types.gen"
 import MCPIcon from "@/components/icons/mcp"
 import {
   Search,
@@ -43,6 +47,7 @@ import {
   ArrowUpDown,
   ChevronDown,
   FileText,
+  Blocks,
 } from "lucide-react"
 
 // Grouped server type
@@ -69,13 +74,21 @@ interface GroupedAgent extends AgentResponse {
   allTags: AgentResponse[]
 }
 
-type TabKey = "servers" | "skills" | "agents" | "prompts"
+// Grouped plugin type (envelope-shaped; plugins postdate the legacy flat types)
+interface GroupedPlugin {
+  plugin: Plugin
+  tagCount: number
+  allTags: Plugin[]
+}
+
+type TabKey = "servers" | "skills" | "agents" | "prompts" | "plugins"
 
 const TAB_CONFIG: { key: TabKey; label: string; icon: React.ReactNode }[] = [
   { key: "servers", label: "Servers", icon: <MCPIcon /> },
   { key: "skills", label: "Skills", icon: <Zap className="h-3.5 w-3.5" /> },
   { key: "agents", label: "Agents", icon: <Bot className="h-3.5 w-3.5" /> },
   { key: "prompts", label: "Prompts", icon: <FileText className="h-3.5 w-3.5" /> },
+  { key: "plugins", label: "Plugins", icon: <Blocks className="h-3.5 w-3.5" /> },
 ]
 
 export default function AdminPage() {
@@ -85,10 +98,12 @@ export default function AdminPage() {
   const [groupedSkills, setGroupedSkills] = useState<GroupedSkill[]>([])
   const [groupedAgents, setGroupedAgents] = useState<GroupedAgent[]>([])
   const [groupedPrompts, setGroupedPrompts] = useState<GroupedPrompt[]>([])
+  const [groupedPlugins, setGroupedPlugins] = useState<GroupedPlugin[]>([])
   const [filteredServers, setFilteredServers] = useState<GroupedServer[]>([])
   const [filteredSkills, setFilteredSkills] = useState<GroupedSkill[]>([])
   const [filteredAgents, setFilteredAgents] = useState<GroupedAgent[]>([])
   const [filteredPrompts, setFilteredPrompts] = useState<GroupedPrompt[]>([])
+  const [filteredPlugins, setFilteredPlugins] = useState<GroupedPlugin[]>([])
   const [searchQuery, setSearchQuery] = useState("")
   const [sortBy, setSortBy] = useState<"name" | "stars" | "date">("name")
   const [filterVerifiedOrg, setFilterVerifiedOrg] = useState(false)
@@ -97,12 +112,14 @@ export default function AdminPage() {
   const [addSkillDialogOpen, setAddSkillDialogOpen] = useState(false)
   const [addAgentDialogOpen, setAddAgentDialogOpen] = useState(false)
   const [addPromptDialogOpen, setAddPromptDialogOpen] = useState(false)
+  const [addPluginDialogOpen, setAddPluginDialogOpen] = useState(false)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [selectedServer, setSelectedServer] = useState<ServerResponse | null>(null)
   const [selectedSkill, setSelectedSkill] = useState<GroupedSkill | null>(null)
   const [selectedAgent, setSelectedAgent] = useState<GroupedAgent | null>(null)
   const [selectedPrompt, setSelectedPrompt] = useState<GroupedPrompt | null>(null)
+  const [selectedPlugin, setSelectedPlugin] = useState<GroupedPlugin | null>(null)
   const [deployServerTarget, setDeployServerTarget] = useState<ServerResponse | null>(null)
   const [deployAgentTarget, setDeployAgentTarget] = useState<AgentResponse | null>(null)
 
@@ -242,6 +259,35 @@ export default function AdminPage() {
     })
   }
 
+  const groupPluginsByName = (plugins: Plugin[]): GroupedPlugin[] => {
+    const grouped = new Map<string, Plugin[]>()
+
+    plugins.forEach((plugin) => {
+      const name = plugin.metadata.name
+      if (!grouped.has(name)) {
+        grouped.set(name, [])
+      }
+      grouped.get(name)!.push(plugin)
+    })
+
+    return Array.from(grouped.entries()).map(([, tags]) => {
+      const sortedTags = [...tags].sort((a, b) => {
+        const dateA = a.metadata.createdAt
+        const dateB = b.metadata.createdAt
+        if (dateA && dateB) {
+          return new Date(dateB).getTime() - new Date(dateA).getTime()
+        }
+        return (b.metadata.tag || '').localeCompare(a.metadata.tag || '')
+      })
+
+      return {
+        plugin: sortedTags[0],
+        tagCount: tags.length,
+        allTags: sortedTags,
+      }
+    })
+  }
+
   const fetchData = async () => {
     try {
       setLoading(true)
@@ -298,6 +344,19 @@ export default function AdminPage() {
       const groupedP = groupPromptsByName(allPrompts)
       setGroupedPrompts(groupedP)
 
+      const allPlugins: Plugin[] = []
+      let pluginCursor: string | undefined
+      do {
+        const { data: pluginData } = await listPluginsV0({
+          query: { cursor: pluginCursor, limit: 100 },
+          throwOnError: true,
+        })
+        allPlugins.push(...pluginData.plugins)
+        pluginCursor = pluginData.metadata.nextCursor
+      } while (pluginCursor)
+      const groupedPl = groupPluginsByName(allPlugins)
+      setGroupedPlugins(groupedPl)
+
       const grouped = groupServersByName(allServers)
       setGroupedServers(grouped)
     } catch (err) {
@@ -309,12 +368,13 @@ export default function AdminPage() {
 
   useEffect(() => { fetchData() }, [])
 
-  const isSheetOpen = !!(selectedServer || selectedSkill || selectedAgent || selectedPrompt)
+  const isSheetOpen = !!(selectedServer || selectedSkill || selectedAgent || selectedPrompt || selectedPlugin)
   const closeSheet = () => {
     setSelectedServer(null)
     setSelectedSkill(null)
     setSelectedAgent(null)
     setSelectedPrompt(null)
+    setSelectedPlugin(null)
   }
 
   // Filter and sort servers
@@ -386,12 +446,18 @@ export default function AdminPage() {
         prompt.description?.toLowerCase().includes(query) ||
         prompt.content?.toLowerCase().includes(query)
       ))
+      setFilteredPlugins(groupedPlugins.filter(({plugin}) =>
+        plugin.metadata.name.toLowerCase().includes(query) ||
+        plugin.spec.title?.toLowerCase().includes(query) ||
+        plugin.spec.description?.toLowerCase().includes(query)
+      ))
     } else {
       setFilteredSkills(groupedSkills)
       setFilteredAgents(groupedAgents)
       setFilteredPrompts(groupedPrompts)
+      setFilteredPlugins(groupedPlugins)
     }
-  }, [searchQuery, groupedSkills, groupedAgents, groupedPrompts])
+  }, [searchQuery, groupedSkills, groupedAgents, groupedPrompts, groupedPlugins])
 
   const getCount = (tab: TabKey) => {
     switch (tab) {
@@ -399,6 +465,7 @@ export default function AdminPage() {
       case "skills": return groupedSkills.length
       case "agents": return groupedAgents.length
       case "prompts": return groupedPrompts.length
+      case "plugins": return groupedPlugins.length
     }
   }
 
@@ -486,6 +553,10 @@ export default function AdminPage() {
                 <DropdownMenuItem onClick={() => setAddPromptDialogOpen(true)}>
                   <FileText className="mr-2 h-4 w-4" />
                   Prompt
+                </DropdownMenuItem>
+                <DropdownMenuItem onClick={() => setAddPluginDialogOpen(true)}>
+                  <Blocks className="mr-2 h-4 w-4" />
+                  Plugin
                 </DropdownMenuItem>
               </DropdownMenuContent>
             </DropdownMenu>
@@ -661,6 +732,32 @@ export default function AdminPage() {
               </div>
             )
           )}
+
+          {activeTab === "plugins" && (
+            filteredPlugins.length === 0 ? (
+              <EmptyState
+                icon={<Blocks className="h-8 w-8 text-muted-foreground" />}
+                title={groupedPlugins.length === 0 ? "No plugins in registry" : "No plugins match your filters"}
+                description={groupedPlugins.length === 0 ? "Register plugin bundles to get started" : "Try adjusting your search"}
+                action={groupedPlugins.length === 0 ? (
+                  <Button variant="outline" size="sm" className="gap-1.5" onClick={() => setAddPluginDialogOpen(true)}>
+                    <Plus className="h-3.5 w-3.5" /> Add Plugin
+                  </Button>
+                ) : undefined}
+              />
+            ) : (
+              <div className="divide-y">
+                {filteredPlugins.map((grouped, index) => (
+                  <PluginCard
+                    key={`${grouped.plugin.metadata.name}-${grouped.plugin.metadata.tag}-${index}`}
+                    plugin={grouped.plugin}
+                    tagCount={grouped.tagCount}
+                    onClick={() => setSelectedPlugin(grouped)}
+                  />
+                ))}
+              </div>
+            )
+          )}
         </div>
       </div>
 
@@ -668,6 +765,7 @@ export default function AdminPage() {
       <AddSkillDialog open={addSkillDialogOpen} onOpenChange={setAddSkillDialogOpen} onSkillAdded={fetchData} />
       <AddAgentDialog open={addAgentDialogOpen} onOpenChange={setAddAgentDialogOpen} onAgentAdded={() => {}} />
       <AddPromptDialog open={addPromptDialogOpen} onOpenChange={setAddPromptDialogOpen} onPromptAdded={fetchData} />
+      <AddPluginDialog open={addPluginDialogOpen} onOpenChange={setAddPluginDialogOpen} onPluginAdded={fetchData} />
 
       <DeployDialog
         open={!!deployServerTarget}
@@ -690,7 +788,8 @@ export default function AdminPage() {
             {selectedServer ? (selectedServer.server.title || selectedServer.server.name) :
              selectedAgent ? selectedAgent.agent.name :
              selectedSkill ? (selectedSkill.skill.title || selectedSkill.skill.name) :
-             selectedPrompt ? selectedPrompt.prompt.name : 'Details'}
+             selectedPrompt ? selectedPrompt.prompt.name :
+             selectedPlugin ? (selectedPlugin.plugin.spec.title || selectedPlugin.plugin.metadata.name) : 'Details'}
           </SheetTitle>
           {selectedServer && (
             <ServerDetail
@@ -701,6 +800,7 @@ export default function AdminPage() {
           {selectedSkill && <SkillDetail skill={selectedSkill} allTags={selectedSkill.allTags} />}
           {selectedAgent && <AgentDetail agent={selectedAgent} allTags={selectedAgent.allTags} />}
           {selectedPrompt && <PromptDetail prompt={selectedPrompt} allTags={selectedPrompt.allTags} />}
+          {selectedPlugin && <PluginDetail plugin={selectedPlugin.plugin} allTags={selectedPlugin.allTags} />}
         </SheetContent>
       </Sheet>
     </main>

--- a/ui/components/__tests__/add-plugin-dialog.test.tsx
+++ b/ui/components/__tests__/add-plugin-dialog.test.tsx
@@ -1,0 +1,120 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { AddPluginDialog } from "../add-plugin-dialog"
+import { createPluginV0 } from "@/lib/admin-api"
+
+vi.mock("@/lib/admin-api", () => ({
+  createPluginV0: vi.fn().mockResolvedValue({ data: {} }),
+}))
+
+const mockedCreate = vi.mocked(createPluginV0)
+
+function renderDialog(overrides?: Partial<Parameters<typeof AddPluginDialog>[0]>) {
+  const props = {
+    open: true,
+    onOpenChange: vi.fn(),
+    onPluginAdded: vi.fn(),
+    ...overrides,
+  }
+  render(<AddPluginDialog {...props} />)
+  return props
+}
+
+describe("AddPluginDialog", () => {
+  beforeEach(() => {
+    mockedCreate.mockClear()
+  })
+
+  it("renders the source-resolution expectation", () => {
+    renderDialog()
+    expect(screen.getByText("Add Plugin", { selector: "h2" })).toBeInTheDocument()
+    expect(screen.getByText(/controller resolves the source to a pinned commit/)).toBeInTheDocument()
+  })
+
+  it("submits a git-source plugin through the client", async () => {
+    const props = renderDialog()
+
+    await userEvent.type(screen.getByLabelText(/Plugin Name/), "repo-analyst")
+    await userEvent.type(screen.getByLabelText("Title"), "Repo Analyst")
+    await userEvent.type(screen.getByLabelText("Description"), "Analyze repos")
+    await userEvent.type(screen.getByLabelText("Harnesses"), "claude-code, codex")
+    await userEvent.type(screen.getByLabelText(/Repository URL/), "https://github.com/ilackarms/repo-analyst")
+    await userEvent.type(screen.getByLabelText("Branch"), "main")
+    await userEvent.type(screen.getByLabelText("Subfolder"), "plugins/repo-analyst")
+
+    await userEvent.click(screen.getByRole("button", { name: "Add Plugin" }))
+
+    expect(mockedCreate).toHaveBeenCalledOnce()
+    expect(mockedCreate).toHaveBeenCalledWith({
+      throwOnError: true,
+      body: {
+        name: "repo-analyst",
+        tag: "latest",
+        title: "Repo Analyst",
+        description: "Analyze repos",
+        harnesses: ["claude-code", "codex"],
+        source: {
+          type: "git",
+          git: {
+            repository: {
+              url: "https://github.com/ilackarms/repo-analyst",
+              branch: "main",
+              subfolder: "plugins/repo-analyst",
+            },
+          },
+        },
+      },
+    })
+    expect(props.onPluginAdded).toHaveBeenCalledOnce()
+    expect(props.onOpenChange).toHaveBeenCalledWith(false)
+  })
+
+  it("omits optional fields that are left empty", async () => {
+    renderDialog()
+
+    await userEvent.type(screen.getByLabelText(/Plugin Name/), "minimal-plugin")
+    await userEvent.type(screen.getByLabelText(/Repository URL/), "https://github.com/example/minimal")
+    await userEvent.click(screen.getByRole("button", { name: "Add Plugin" }))
+
+    expect(mockedCreate).toHaveBeenCalledWith({
+      throwOnError: true,
+      body: {
+        name: "minimal-plugin",
+        tag: "latest",
+        source: {
+          type: "git",
+          git: {
+            repository: {
+              url: "https://github.com/example/minimal",
+            },
+          },
+        },
+      },
+    })
+  })
+
+  it("rejects a name that is not a DNS-1123 subdomain", async () => {
+    const props = renderDialog()
+
+    await userEvent.type(screen.getByLabelText(/Plugin Name/), "Bad_Name!")
+    await userEvent.type(screen.getByLabelText(/Repository URL/), "https://github.com/example/repo")
+    await userEvent.click(screen.getByRole("button", { name: "Add Plugin" }))
+
+    expect(await screen.findByText(/DNS-1123 subdomain/)).toBeInTheDocument()
+    expect(mockedCreate).not.toHaveBeenCalled()
+    expect(props.onPluginAdded).not.toHaveBeenCalled()
+  })
+
+  it("shows the API error when the create fails", async () => {
+    mockedCreate.mockRejectedValueOnce(new Error("apply Plugin repo-analyst failed: boom"))
+    const props = renderDialog()
+
+    await userEvent.type(screen.getByLabelText(/Plugin Name/), "repo-analyst")
+    await userEvent.type(screen.getByLabelText(/Repository URL/), "https://github.com/example/repo")
+    await userEvent.click(screen.getByRole("button", { name: "Add Plugin" }))
+
+    expect(await screen.findByText(/failed: boom/)).toBeInTheDocument()
+    expect(props.onOpenChange).not.toHaveBeenCalledWith(false)
+  })
+})

--- a/ui/components/__tests__/plugin-card.test.tsx
+++ b/ui/components/__tests__/plugin-card.test.tsx
@@ -1,0 +1,124 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, it, expect, vi } from "vitest"
+import { PluginCard } from "../plugin-card"
+import type { Plugin } from "@/lib/api/types.gen"
+
+const mockPlugin: Plugin = {
+  apiVersion: "ar.dev/v1alpha1",
+  kind: "Plugin",
+  metadata: {
+    name: "repo-analyst",
+    namespace: "default",
+    tag: "latest",
+    createdAt: "2026-06-25T00:00:00Z",
+  },
+  spec: {
+    title: "Repo Analyst",
+    description: "Release notes, repo maps, and churn hotspot analysis.",
+    harnesses: ["claude-code"],
+    source: {
+      type: "git",
+      git: {
+        repository: {
+          url: "https://github.com/ilackarms/repo-analyst",
+        },
+      },
+    },
+  },
+  status: {
+    conditions: [{ type: "Ready", status: "True", reason: "Resolved" }],
+    resolvedSource: {
+      type: "git",
+      commit: "435bf0f7aa11223344556677889900aabbccddee",
+    },
+  },
+}
+
+describe("PluginCard", () => {
+  it("renders title as heading", () => {
+    render(<PluginCard plugin={mockPlugin} />)
+    expect(screen.getByText("Repo Analyst")).toBeInTheDocument()
+  })
+
+  it("renders description and tag", () => {
+    render(<PluginCard plugin={mockPlugin} />)
+    expect(screen.getByText("Release notes, repo maps, and churn hotspot analysis.")).toBeInTheDocument()
+    expect(screen.getByText("latest")).toBeInTheDocument()
+  })
+
+  it("falls back to name when title is not set", () => {
+    const noTitle: Plugin = {
+      ...mockPlugin,
+      spec: { ...mockPlugin.spec, title: undefined },
+    }
+    render(<PluginCard plugin={noTitle} />)
+    expect(screen.getByText("repo-analyst")).toBeInTheDocument()
+  })
+
+  it("shows Ready badge and short pinned commit when resolved", () => {
+    render(<PluginCard plugin={mockPlugin} />)
+    expect(screen.getByText("Ready")).toBeInTheDocument()
+    expect(screen.getByText("435bf0f")).toBeInTheDocument()
+  })
+
+  it("shows Resolving badge while the controller is progressing", () => {
+    const progressing: Plugin = {
+      ...mockPlugin,
+      status: {
+        conditions: [{ type: "Ready", status: "False", reason: "Progressing", message: "resolving plugin source" }],
+      },
+    }
+    render(<PluginCard plugin={progressing} />)
+    expect(screen.getByText("Resolving")).toBeInTheDocument()
+    expect(screen.queryByText("Ready")).not.toBeInTheDocument()
+  })
+
+  it("shows the failure reason when resolution failed", () => {
+    const failed: Plugin = {
+      ...mockPlugin,
+      status: {
+        conditions: [{ type: "Ready", status: "False", reason: "SourceUnresolvable", message: "repository not found" }],
+      },
+    }
+    render(<PluginCard plugin={failed} />)
+    expect(screen.getByText("SourceUnresolvable")).toBeInTheDocument()
+  })
+
+  it("shows Not resolved when there is no status yet", () => {
+    const noStatus: Plugin = { ...mockPlugin, status: undefined }
+    render(<PluginCard plugin={noStatus} />)
+    expect(screen.getByText("Not resolved")).toBeInTheDocument()
+  })
+
+  it("renders harness badges", () => {
+    render(<PluginCard plugin={mockPlugin} />)
+    expect(screen.getByText("claude-code")).toBeInTheDocument()
+  })
+
+  it("calls onClick when card is clicked", async () => {
+    const onClick = vi.fn()
+    render(<PluginCard plugin={mockPlugin} onClick={onClick} />)
+    await userEvent.click(screen.getByText("Repo Analyst"))
+    expect(onClick).toHaveBeenCalledOnce()
+  })
+
+  it("shows delete button when showDelete is true", () => {
+    const onDelete = vi.fn()
+    render(<PluginCard plugin={mockPlugin} showDelete onDelete={onDelete} />)
+    const buttons = screen.getAllByRole("button")
+    const deleteBtn = buttons.find(btn => btn.querySelector(".lucide-trash2"))
+    expect(deleteBtn).toBeTruthy()
+  })
+
+  it("calls onDelete without triggering onClick", async () => {
+    const onDelete = vi.fn()
+    const onClick = vi.fn()
+    render(<PluginCard plugin={mockPlugin} showDelete onDelete={onDelete} onClick={onClick} />)
+    const buttons = screen.getAllByRole("button")
+    const deleteBtn = buttons.find(btn => btn.querySelector(".lucide-trash2"))
+    await userEvent.click(deleteBtn!)
+    expect(onDelete).toHaveBeenCalledOnce()
+    expect(onClick).not.toHaveBeenCalled()
+  })
+})

--- a/ui/components/__tests__/plugin-detail.test.tsx
+++ b/ui/components/__tests__/plugin-detail.test.tsx
@@ -1,0 +1,150 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, it, expect } from "vitest"
+import { PluginDetail } from "../plugin-detail"
+import type { Plugin } from "@/lib/api/types.gen"
+
+const resolvedPlugin: Plugin = {
+  apiVersion: "ar.dev/v1alpha1",
+  kind: "Plugin",
+  metadata: {
+    name: "repo-analyst",
+    namespace: "default",
+    tag: "latest",
+  },
+  spec: {
+    title: "Repo Analyst",
+    description: "Release notes, repo maps, and churn hotspot analysis.",
+    harnesses: ["claude-code"],
+    source: {
+      type: "git",
+      git: {
+        repository: {
+          url: "https://github.com/ilackarms/repo-analyst",
+          branch: "main",
+        },
+      },
+    },
+  },
+  status: {
+    conditions: [{ type: "Ready", status: "True", reason: "Resolved" }],
+    resolvedSource: {
+      type: "git",
+      commit: "435bf0f7aa11223344556677889900aabbccddee",
+    },
+    manifest: {
+      name: "repo-analyst",
+      displayName: "Repo Analyst",
+      version: "1.0.0",
+      description: "Analyze any git repository.",
+      license: "Apache-2.0",
+      author: { name: "ilackarms", email: "dev@example.com" },
+      keywords: ["git", "analysis"],
+    },
+    inventory: {
+      skills: [
+        { name: "release-notes", description: "Draft release notes from merged PRs" },
+        { name: "repo-map", description: "Generate an architecture map" },
+      ],
+      commands: ["release-notes", "repo-map"],
+      agents: ["analyst"],
+      mcpServers: ["repo-index"],
+      hooks: [{ event: "PostToolUse", type: "command" }],
+      executables: ["scripts/scan.sh"],
+    },
+  },
+}
+
+describe("PluginDetail", () => {
+  it("renders title, name, and resolution state", () => {
+    render(<PluginDetail plugin={resolvedPlugin} />)
+    // title/name also appear in the manifest section, so match the header heading
+    expect(screen.getByRole("heading", { name: "Repo Analyst" })).toBeInTheDocument()
+    expect(screen.getAllByText("repo-analyst").length).toBeGreaterThanOrEqual(1)
+    expect(screen.getByText("Ready")).toBeInTheDocument()
+  })
+
+  it("renders the source pointer and pinned commit", () => {
+    render(<PluginDetail plugin={resolvedPlugin} />)
+    expect(screen.getByText("https://github.com/ilackarms/repo-analyst")).toBeInTheDocument()
+    expect(screen.getByText("main")).toBeInTheDocument()
+    // full pinned SHA in the source section, short form in quick info
+    expect(screen.getByText("435bf0f7aa11223344556677889900aabbccddee")).toBeInTheDocument()
+    expect(screen.getByText("435bf0f")).toBeInTheDocument()
+  })
+
+  it("renders the controller-parsed manifest", () => {
+    render(<PluginDetail plugin={resolvedPlugin} />)
+    expect(screen.getByText("Display Name")).toBeInTheDocument()
+    expect(screen.getByText("1.0.0")).toBeInTheDocument()
+    expect(screen.getByText("Apache-2.0")).toBeInTheDocument()
+    // author name also appears inside the repo URL, so anchor on the email
+    expect(screen.getByText(/dev@example.com/)).toBeInTheDocument()
+    // "git" appears as both the source type and a manifest keyword
+    expect(screen.getAllByText("git").length).toBeGreaterThanOrEqual(2)
+    expect(screen.getByText("analysis")).toBeInTheDocument()
+  })
+
+  it("renders inventory with hooks and executables called out prominently", async () => {
+    render(<PluginDetail plugin={resolvedPlugin} />)
+    await userEvent.click(screen.getByRole("button", { name: "Contents" }))
+
+    // governance risk surface
+    expect(screen.getByText("Runs code on install")).toBeInTheDocument()
+    expect(screen.getByText("PostToolUse")).toBeInTheDocument()
+    expect(screen.getByText("scripts/scan.sh")).toBeInTheDocument()
+
+    // inventory contents
+    expect(screen.getByText("release-notes")).toBeInTheDocument()
+    expect(screen.getByText("Draft release notes from merged PRs")).toBeInTheDocument()
+    expect(screen.getByText("/release-notes")).toBeInTheDocument()
+    expect(screen.getByText("analyst")).toBeInTheDocument()
+    expect(screen.getByText("repo-index")).toBeInTheDocument()
+  })
+
+  it("omits the risk callout when there are no hooks or executables", async () => {
+    const safe: Plugin = {
+      ...resolvedPlugin,
+      status: {
+        ...resolvedPlugin.status,
+        inventory: {
+          skills: [{ name: "release-notes" }],
+        },
+      },
+    }
+    render(<PluginDetail plugin={safe} />)
+    await userEvent.click(screen.getByRole("button", { name: "Contents" }))
+    expect(screen.queryByText("Runs code on install")).not.toBeInTheDocument()
+    expect(screen.getByText("release-notes")).toBeInTheDocument()
+  })
+
+  it("explains pending inventory while the source is unresolved", async () => {
+    const progressing: Plugin = {
+      ...resolvedPlugin,
+      status: {
+        conditions: [{ type: "Ready", status: "False", reason: "Progressing", message: "resolving plugin source" }],
+      },
+    }
+    render(<PluginDetail plugin={progressing} />)
+    expect(screen.getByText("Resolving source…")).toBeInTheDocument()
+    await userEvent.click(screen.getByRole("button", { name: "Contents" }))
+    expect(screen.getByText(/Inventory is populated by the controller/)).toBeInTheDocument()
+  })
+
+  it("surfaces the failure message when resolution failed", () => {
+    const failed: Plugin = {
+      ...resolvedPlugin,
+      status: {
+        conditions: [{
+          type: "Ready",
+          status: "False",
+          reason: "SourceUnresolvable",
+          message: "repository not found: https://github.com/example/nope",
+        }],
+      },
+    }
+    render(<PluginDetail plugin={failed} />)
+    expect(screen.getByText("SourceUnresolvable")).toBeInTheDocument()
+    expect(screen.getByText(/repository not found/)).toBeInTheDocument()
+  })
+})

--- a/ui/components/add-plugin-dialog.tsx
+++ b/ui/components/add-plugin-dialog.tsx
@@ -1,0 +1,274 @@
+"use client"
+
+import { useState } from "react"
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Textarea } from "@/components/ui/textarea"
+import { createPluginV0, type PluginJson } from "@/lib/admin-api"
+import { isValidDNSSubdomain, DNS_SUBDOMAIN_HELP } from "@/lib/validators"
+
+interface AddPluginDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onPluginAdded: () => void
+}
+
+export function AddPluginDialog({ open, onOpenChange, onPluginAdded }: AddPluginDialogProps) {
+  const [name, setName] = useState("")
+  const [title, setTitle] = useState("")
+  const [description, setDescription] = useState("")
+  const [tag, setTag] = useState("latest")
+  const [harnesses, setHarnesses] = useState("")
+  const [repositoryUrl, setRepositoryUrl] = useState("")
+  const [branch, setBranch] = useState("")
+  const [commit, setCommit] = useState("")
+  const [subfolder, setSubfolder] = useState("")
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const resetForm = () => {
+    setName("")
+    setTitle("")
+    setDescription("")
+    setTag("latest")
+    setHarnesses("")
+    setRepositoryUrl("")
+    setBranch("")
+    setCommit("")
+    setSubfolder("")
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError(null)
+    setLoading(true)
+
+    try {
+      // Validate required fields
+      if (!name.trim()) {
+        throw new Error("Plugin name is required")
+      }
+      if (!isValidDNSSubdomain(name.trim())) {
+        throw new Error("Plugin name must be DNS-1123 subdomain: lowercase alphanumeric, hyphens, and dots; max 253 chars; each dot-separated segment must start and end with alphanumeric")
+      }
+      if (!tag.trim()) {
+        throw new Error("Tag is required")
+      }
+      const trimmedRepositoryUrl = repositoryUrl.trim()
+      if (!trimmedRepositoryUrl) {
+        throw new Error("Repository URL is required")
+      }
+
+      const harnessList = harnesses
+        .split(",")
+        .map((h) => h.trim())
+        .filter(Boolean)
+
+      // Construct the PluginJSON object. Spec is user intent only — the
+      // Plugin controller resolves the source pointer to a pinned
+      // commit/digest and writes the manifest + inventory into status.
+      const pluginData: PluginJson = {
+        name: name.trim(),
+        tag: tag.trim(),
+        ...(title.trim() ? { title: title.trim() } : {}),
+        ...(description.trim() ? { description: description.trim() } : {}),
+        ...(harnessList.length > 0 ? { harnesses: harnessList } : {}),
+        source: {
+          type: "git",
+          git: {
+            repository: {
+              url: trimmedRepositoryUrl,
+              ...(branch.trim() ? { branch: branch.trim() } : {}),
+              ...(commit.trim() ? { commit: commit.trim() } : {}),
+              ...(subfolder.trim() ? { subfolder: subfolder.trim() } : {}),
+            },
+          },
+        },
+      }
+
+      // Create the plugin
+      await createPluginV0({ body: pluginData, throwOnError: true })
+
+      resetForm()
+
+      // Notify parent and close dialog
+      onPluginAdded()
+      onOpenChange(false)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to add plugin")
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const handleCancel = () => {
+    resetForm()
+    setError(null)
+    onOpenChange(false)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-2xl max-h-[80vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>Add Plugin</DialogTitle>
+          <DialogDescription>
+            Register a plugin bundle from a git source. The registry hosts nothing —
+            the controller resolves the source to a pinned commit, then scans it for
+            the plugin manifest and inventory (skills, commands, agents, hooks).
+          </DialogDescription>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit} className="space-y-4 py-4">
+          <div className="space-y-2">
+            <Label htmlFor="plugin-name">
+              Plugin Name <span className="text-red-500">*</span>
+            </Label>
+            <Input
+              id="plugin-name"
+              placeholder="my-plugin"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              disabled={loading}
+              required
+            />
+            <p className="text-xs text-muted-foreground">{DNS_SUBDOMAIN_HELP}</p>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="plugin-title">Title</Label>
+            <Input
+              id="plugin-title"
+              placeholder="My Plugin"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              disabled={loading}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="plugin-description">Description</Label>
+            <Textarea
+              id="plugin-description"
+              placeholder="A description of what this plugin provides"
+              rows={3}
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              disabled={loading}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="plugin-tag">
+              Tag <span className="text-red-500">*</span>
+            </Label>
+            <Input
+              id="plugin-tag"
+              placeholder="latest"
+              value={tag}
+              onChange={(e) => setTag(e.target.value)}
+              disabled={loading}
+              required
+            />
+            <p className="text-xs text-muted-foreground">
+              e.g., &quot;latest&quot;, &quot;1.0.0&quot;, &quot;v2.3.1&quot;
+            </p>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="plugin-harnesses">Harnesses</Label>
+            <Input
+              id="plugin-harnesses"
+              placeholder="claude-code, codex"
+              value={harnesses}
+              onChange={(e) => setHarnesses(e.target.value)}
+              disabled={loading}
+            />
+            <p className="text-xs text-muted-foreground">
+              Comma-separated harness formats this bundle carries native manifests for
+            </p>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="plugin-repository-url">
+              Repository URL <span className="text-red-500">*</span>
+            </Label>
+            <Input
+              id="plugin-repository-url"
+              placeholder="https://github.com/username/repo"
+              value={repositoryUrl}
+              onChange={(e) => setRepositoryUrl(e.target.value)}
+              disabled={loading}
+              type="url"
+              required
+            />
+            <p className="text-xs text-muted-foreground">
+              Link to the plugin&apos;s Git repository (GitHub, GitLab, Bitbucket, etc.)
+            </p>
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label htmlFor="plugin-branch">Branch</Label>
+              <Input
+                id="plugin-branch"
+                placeholder="main"
+                value={branch}
+                onChange={(e) => setBranch(e.target.value)}
+                disabled={loading}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="plugin-commit">Commit</Label>
+              <Input
+                id="plugin-commit"
+                placeholder="abc1234…"
+                value={commit}
+                onChange={(e) => setCommit(e.target.value)}
+                disabled={loading}
+              />
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="plugin-subfolder">Subfolder</Label>
+            <Input
+              id="plugin-subfolder"
+              placeholder="plugins/my-plugin"
+              value={subfolder}
+              onChange={(e) => setSubfolder(e.target.value)}
+              disabled={loading}
+            />
+            <p className="text-xs text-muted-foreground">
+              Path to the plugin inside a monorepo (optional)
+            </p>
+          </div>
+
+          <p className="text-xs text-muted-foreground rounded-md bg-muted p-3">
+            Branch and commit are optional — if omitted, the remote default branch is
+            used. Whatever ref you supply, the controller resolves it to a concrete
+            commit SHA and pins it in the plugin&apos;s status so the published tag is
+            reproducible.
+          </p>
+
+          {error && (
+            <div className="rounded-md bg-red-50 p-3 text-sm text-red-800">
+              {error}
+            </div>
+          )}
+
+          <div className="flex justify-end gap-2">
+            <Button type="button" variant="outline" onClick={handleCancel} disabled={loading}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={loading}>
+              {loading ? "Adding..." : "Add Plugin"}
+            </Button>
+          </div>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/ui/components/plugin-card.stories.tsx
+++ b/ui/components/plugin-card.stories.tsx
@@ -1,0 +1,167 @@
+import type { Meta, StoryObj } from "@storybook/react-vite"
+import { PluginCard } from "./plugin-card"
+import type { Plugin } from "@/lib/api/types.gen"
+
+const resolvedPlugin: Plugin = {
+  apiVersion: "ar.dev/v1alpha1",
+  kind: "Plugin",
+  metadata: {
+    name: "repo-analyst",
+    namespace: "default",
+    tag: "latest",
+    createdAt: "2026-06-25T00:00:00Z",
+  },
+  spec: {
+    title: "Repo Analyst",
+    description:
+      "Release notes, repo maps, and churn hotspot analysis for any git repository. Bundles three skills, three commands, and a sub-agent.",
+    harnesses: ["claude-code"],
+    source: {
+      type: "git",
+      git: {
+        repository: {
+          url: "https://github.com/ilackarms/repo-analyst",
+        },
+      },
+    },
+  },
+  status: {
+    conditions: [
+      {
+        type: "Ready",
+        status: "True",
+        reason: "Resolved",
+      },
+    ],
+    resolvedSource: {
+      type: "git",
+      commit: "435bf0f7aa11223344556677889900aabbccddee",
+    },
+    manifest: {
+      name: "repo-analyst",
+      displayName: "Repo Analyst",
+      version: "1.0.0",
+    },
+    inventory: {
+      skills: [
+        { name: "release-notes", description: "Draft release notes from merged PRs" },
+        { name: "repo-map", description: "Generate an architecture map of the repo" },
+        { name: "churn-hotspots", description: "Find high-churn risk areas" },
+      ],
+      commands: ["release-notes", "repo-map", "churn-hotspots"],
+      agents: ["analyst"],
+    },
+  },
+}
+
+const progressingPlugin: Plugin = {
+  apiVersion: "ar.dev/v1alpha1",
+  kind: "Plugin",
+  metadata: {
+    name: "fresh-plugin",
+    namespace: "default",
+    tag: "0.1.0",
+  },
+  spec: {
+    description: "Just registered — the controller has not resolved the source yet.",
+    source: {
+      type: "git",
+      git: {
+        repository: {
+          url: "https://github.com/example/fresh-plugin",
+          branch: "main",
+        },
+      },
+    },
+  },
+  status: {
+    conditions: [
+      {
+        type: "Ready",
+        status: "False",
+        reason: "Progressing",
+        message: "resolving plugin source",
+      },
+    ],
+  },
+}
+
+const failedPlugin: Plugin = {
+  apiVersion: "ar.dev/v1alpha1",
+  kind: "Plugin",
+  metadata: {
+    name: "broken-plugin",
+    namespace: "default",
+    tag: "latest",
+  },
+  spec: {
+    title: "Broken Plugin",
+    description: "The source pointer could not be resolved.",
+    source: {
+      type: "git",
+      git: {
+        repository: {
+          url: "https://github.com/example/does-not-exist",
+        },
+      },
+    },
+  },
+  status: {
+    conditions: [
+      {
+        type: "Ready",
+        status: "False",
+        reason: "SourceUnresolvable",
+        message: "repository not found: https://github.com/example/does-not-exist",
+      },
+    ],
+  },
+}
+
+const meta: Meta<typeof PluginCard> = {
+  title: "Components/PluginCard",
+  component: PluginCard,
+  tags: ["autodocs"],
+  decorators: [
+    (Story) => (
+      <div style={{ maxWidth: 500 }}>
+        <Story />
+      </div>
+    ),
+  ],
+}
+
+export default meta
+type Story = StoryObj<typeof PluginCard>
+
+export const Resolved: Story = {
+  args: {
+    plugin: resolvedPlugin,
+  },
+}
+
+export const Progressing: Story = {
+  args: {
+    plugin: progressingPlugin,
+  },
+}
+
+export const Failed: Story = {
+  args: {
+    plugin: failedPlugin,
+  },
+}
+
+export const WithDelete: Story = {
+  args: {
+    plugin: resolvedPlugin,
+    showDelete: true,
+  },
+}
+
+export const MultipleTags: Story = {
+  args: {
+    plugin: resolvedPlugin,
+    tagCount: 3,
+  },
+}

--- a/ui/components/plugin-card.tsx
+++ b/ui/components/plugin-card.tsx
@@ -1,0 +1,149 @@
+"use client"
+
+import type { Plugin } from "@/lib/api/types.gen"
+import { getPinnedRevision, getPluginRepoUrl, getPluginResolution } from "@/lib/plugin-utils"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
+import { AlertCircle, Blocks, CheckCircle2, Github, GitCommitHorizontal, Loader2, Trash2 } from "lucide-react"
+
+interface PluginCardProps {
+  plugin: Plugin
+  onDelete?: (plugin: Plugin) => void
+  showDelete?: boolean
+  showExternalLinks?: boolean
+  onClick?: () => void
+  tagCount?: number
+}
+
+function ResolutionBadge({ plugin }: { plugin: Plugin }) {
+  const resolution = getPluginResolution(plugin)
+
+  switch (resolution.state) {
+    case "ready":
+      return (
+        <Badge variant="outline" className="gap-1 text-xs font-normal text-green-700 dark:text-green-400 border-green-600/30">
+          <CheckCircle2 className="h-3 w-3" /> Ready
+        </Badge>
+      )
+    case "progressing":
+      return (
+        <Badge variant="outline" className="gap-1 text-xs font-normal text-amber-700 dark:text-amber-400 border-amber-600/30">
+          <Loader2 className="h-3 w-3 animate-spin" /> Resolving
+        </Badge>
+      )
+    case "failed":
+      return (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Badge variant="outline" className="gap-1 text-xs font-normal text-destructive border-destructive/30">
+              <AlertCircle className="h-3 w-3" /> {resolution.label}
+            </Badge>
+          </TooltipTrigger>
+          {resolution.message && (
+            <TooltipContent className="max-w-xs">{resolution.message}</TooltipContent>
+          )}
+        </Tooltip>
+      )
+    default:
+      return (
+        <Badge variant="outline" className="gap-1 text-xs font-normal text-muted-foreground">
+          Not resolved
+        </Badge>
+      )
+  }
+}
+
+export function PluginCard({ plugin, onDelete, showDelete = false, showExternalLinks = true, onClick, tagCount }: PluginCardProps) {
+  const { metadata, spec } = plugin
+  const pinnedRevision = getPinnedRevision(plugin)
+  const repoUrl = getPluginRepoUrl(plugin)
+
+  const formatDate = (dateString: string) => {
+    try {
+      return new Date(dateString).toLocaleDateString('en-US', {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric',
+      })
+    } catch {
+      return dateString
+    }
+  }
+
+  return (
+    <TooltipProvider>
+      <div
+        className="group flex items-start gap-3.5 py-4 px-2 -mx-2 rounded-md cursor-pointer transition-colors hover:bg-muted/50"
+        onClick={() => onClick?.()}
+      >
+        <div className="w-10 h-10 rounded bg-primary/8 flex items-center justify-center flex-shrink-0 mt-0.5">
+          <Blocks className="h-4 w-4 text-primary" />
+        </div>
+
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 mb-0.5">
+            <h3 className="text-lg font-semibold truncate">{spec.title || metadata.name}</h3>
+            <ResolutionBadge plugin={plugin} />
+          </div>
+
+          <p className="text-[15px] text-muted-foreground line-clamp-1 mb-2">
+            {spec.description}
+          </p>
+
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-muted-foreground">
+            {metadata.tag && <span className="font-mono">{metadata.tag}</span>}
+            {tagCount && tagCount > 1 && (
+              <span className="text-primary text-xs">+{tagCount - 1}</span>
+            )}
+
+            {pinnedRevision && (
+              <span className="flex items-center gap-1 font-mono text-xs">
+                <GitCommitHorizontal className="h-3.5 w-3.5" />
+                {pinnedRevision}
+              </span>
+            )}
+
+            {spec.harnesses?.map((harness) => (
+              <Badge key={harness} variant="secondary" className="text-[10px] px-1.5 py-0 h-4 font-normal">
+                {harness}
+              </Badge>
+            ))}
+
+            {metadata.createdAt && (
+              <span>{formatDate(metadata.createdAt)}</span>
+            )}
+          </div>
+        </div>
+
+        <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity shrink-0">
+          {showExternalLinks && repoUrl && (
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-7 w-7"
+              onClick={(e) => { e.stopPropagation(); window.open(repoUrl, '_blank') }}
+            >
+              <Github className="h-3.5 w-3.5" />
+            </Button>
+          )}
+          {showDelete && onDelete && (
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-7 w-7 text-destructive hover:text-destructive hover:bg-destructive/10"
+              onClick={(e) => { e.stopPropagation(); onDelete(plugin) }}
+            >
+              <Trash2 className="h-3.5 w-3.5" />
+            </Button>
+          )}
+        </div>
+      </div>
+    </TooltipProvider>
+  )
+}

--- a/ui/components/plugin-detail.tsx
+++ b/ui/components/plugin-detail.tsx
@@ -1,0 +1,432 @@
+"use client"
+
+import { useState } from "react"
+import type { Plugin } from "@/lib/api/types.gen"
+import { getPinnedRevision, getPluginRepoUrl, getPluginResolution } from "@/lib/plugin-utils"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import {
+  AlertCircle,
+  AlertTriangle,
+  Blocks,
+  Bot,
+  Calendar,
+  Check,
+  CheckCircle2,
+  Code,
+  Copy,
+  ExternalLink,
+  GitCommitHorizontal,
+  History,
+  Loader2,
+  Terminal,
+  Webhook,
+  Zap,
+} from "lucide-react"
+import MCPIcon from "@/components/icons/mcp"
+
+interface PluginDetailProps {
+  plugin: Plugin
+  allTags?: Plugin[]
+}
+
+function ResolutionSummary({ plugin }: { plugin: Plugin }) {
+  const resolution = getPluginResolution(plugin)
+
+  switch (resolution.state) {
+    case "ready":
+      return (
+        <span className="flex items-center gap-1.5 px-2.5 py-1 bg-muted rounded text-sm text-green-700 dark:text-green-400">
+          <CheckCircle2 className="h-3 w-3" /> Ready
+        </span>
+      )
+    case "progressing":
+      return (
+        <span className="flex items-center gap-1.5 px-2.5 py-1 bg-muted rounded text-sm text-amber-700 dark:text-amber-400">
+          <Loader2 className="h-3 w-3 animate-spin" /> Resolving source…
+        </span>
+      )
+    case "failed":
+      return (
+        <span className="flex items-center gap-1.5 px-2.5 py-1 bg-destructive/10 rounded text-sm text-destructive">
+          <AlertCircle className="h-3 w-3" /> {resolution.label}
+        </span>
+      )
+    default:
+      return (
+        <span className="flex items-center gap-1.5 px-2.5 py-1 bg-muted rounded text-sm text-muted-foreground">
+          Not resolved
+        </span>
+      )
+  }
+}
+
+function SectionHeading({ children }: { children: React.ReactNode }) {
+  return (
+    <h3 className="text-sm font-semibold uppercase tracking-wider text-muted-foreground mb-2">
+      {children}
+    </h3>
+  )
+}
+
+function InfoRow({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="flex items-center justify-between gap-4 text-xs">
+      <span className="text-muted-foreground shrink-0">{label}</span>
+      <span className="min-w-0 text-right break-all">{children}</span>
+    </div>
+  )
+}
+
+export function PluginDetail({ plugin, allTags: allTagsProp }: PluginDetailProps) {
+  const [activeTab, setActiveTab] = useState("overview")
+  const [jsonCopied, setJsonCopied] = useState(false)
+  const [selectedTag, setSelectedTag] = useState<Plugin>(plugin)
+
+  const allTags = allTagsProp || [plugin]
+
+  const { metadata, spec, status } = selectedTag
+  const resolution = getPluginResolution(selectedTag)
+  const pinnedRevision = getPinnedRevision(selectedTag)
+  const repoUrl = getPluginRepoUrl(selectedTag)
+  const gitRepository = spec.source?.git?.repository
+  const manifest = status?.manifest
+  const inventory = status?.inventory
+  const hooks = inventory?.hooks ?? []
+  const executables = inventory?.executables ?? []
+  const skills = inventory?.skills ?? []
+  const commands = inventory?.commands ?? []
+  const agents = inventory?.agents ?? []
+  const mcpServers = inventory?.mcpServers ?? []
+  const hasInventory =
+    hooks.length > 0 || executables.length > 0 || skills.length > 0 ||
+    commands.length > 0 || agents.length > 0 || mcpServers.length > 0
+
+  const handleTagChange = (tag: string) => {
+    const newTag = allTags.find((v) => v.metadata.tag === tag)
+    if (newTag) setSelectedTag(newTag)
+  }
+
+  const handleCopyJson = async () => {
+    try {
+      await navigator.clipboard.writeText(JSON.stringify(selectedTag, null, 2))
+      setJsonCopied(true)
+      setTimeout(() => setJsonCopied(false), 2000)
+    } catch (err) {
+      console.error('Failed to copy JSON:', err)
+    }
+  }
+
+  const formatDate = (dateString: string) => {
+    try {
+      return new Date(dateString).toLocaleString('en-US', {
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit',
+      })
+    } catch {
+      return dateString
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-start gap-4">
+        <div className="w-12 h-12 rounded bg-primary/8 flex items-center justify-center flex-shrink-0">
+          <Blocks className="h-6 w-6 text-primary" />
+        </div>
+        <div className="flex-1 min-w-0">
+          <h1 className="text-2xl font-bold truncate mb-1">{spec.title || metadata.name}</h1>
+          <p className="text-[15px] text-muted-foreground">{metadata.name}</p>
+        </div>
+      </div>
+
+      {/* Tag selector */}
+      {allTags.length > 1 && (
+        <div className="flex items-center gap-3 px-3 py-2 bg-accent/50 border border-primary/10 rounded-md">
+          <History className="h-4 w-4 text-muted-foreground" />
+          <span className="text-sm">{allTags.length} tags</span>
+          <Select value={selectedTag.metadata.tag} onValueChange={handleTagChange}>
+            <SelectTrigger className="w-[160px] h-7 text-sm">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {allTags.map((tag) => (
+                <SelectItem key={tag.metadata.tag} value={tag.metadata.tag ?? ""}>
+                  {tag.metadata.tag}
+                  {tag.metadata.tag === plugin.metadata.tag && " (latest)"}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      )}
+
+      {/* Quick info */}
+      <div className="flex flex-wrap gap-2">
+        <ResolutionSummary plugin={selectedTag} />
+        {metadata.tag && (
+          <span className="flex items-center gap-1.5 px-2.5 py-1 bg-muted rounded text-sm">
+            <span className="font-mono">{metadata.tag}</span>
+            {allTags.length > 1 && (
+              <Badge variant="secondary" className="text-[10px] px-1 py-0 h-3.5">{allTags.length} total</Badge>
+            )}
+          </span>
+        )}
+        {pinnedRevision && (
+          <span className="flex items-center gap-1.5 px-2.5 py-1 bg-muted rounded text-sm font-mono">
+            <GitCommitHorizontal className="h-3 w-3 text-muted-foreground" />
+            {pinnedRevision}
+          </span>
+        )}
+        {metadata.createdAt && (
+          <span className="flex items-center gap-1.5 px-2.5 py-1 bg-muted rounded text-sm">
+            <Calendar className="h-3 w-3 text-muted-foreground" />
+            {formatDate(metadata.createdAt)}
+          </span>
+        )}
+      </div>
+
+      {/* Resolution failure detail */}
+      {resolution.state === "failed" && resolution.message && (
+        <div className="rounded-md border border-destructive/30 bg-destructive/10 p-3 text-sm text-destructive">
+          {resolution.message}
+        </div>
+      )}
+
+      <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">
+        <TabsList className="mb-4">
+          <TabsTrigger value="overview">Overview</TabsTrigger>
+          <TabsTrigger value="contents">Contents</TabsTrigger>
+          <TabsTrigger value="raw">Raw</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="overview" className="space-y-6">
+          {spec.description && (
+            <section>
+              <SectionHeading>Description</SectionHeading>
+              <p className="text-[15px] leading-relaxed">{spec.description}</p>
+            </section>
+          )}
+
+          {spec.harnesses && spec.harnesses.length > 0 && (
+            <section>
+              <SectionHeading>Harnesses</SectionHeading>
+              <div className="flex flex-wrap gap-1.5">
+                {spec.harnesses.map((harness) => (
+                  <Badge key={harness} variant="secondary" className="font-normal">{harness}</Badge>
+                ))}
+              </div>
+            </section>
+          )}
+
+          <section>
+            <SectionHeading>Source</SectionHeading>
+            <div className="space-y-1.5 text-sm">
+              {spec.source?.type && <InfoRow label="Type">{spec.source.type}</InfoRow>}
+              {repoUrl && (
+                <InfoRow label="Repository">
+                  <a
+                    href={repoUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-primary hover:underline inline-flex items-center gap-1"
+                  >
+                    {repoUrl} <ExternalLink className="h-2.5 w-2.5" />
+                  </a>
+                </InfoRow>
+              )}
+              {gitRepository?.branch && <InfoRow label="Branch">{gitRepository.branch}</InfoRow>}
+              {gitRepository?.commit && <InfoRow label="Commit"><span className="font-mono">{gitRepository.commit}</span></InfoRow>}
+              {gitRepository?.subfolder && <InfoRow label="Subfolder"><span className="font-mono">{gitRepository.subfolder}</span></InfoRow>}
+              {spec.source?.oci?.reference && <InfoRow label="OCI Reference"><span className="font-mono">{spec.source.oci.reference}</span></InfoRow>}
+              {status?.resolvedSource?.commit && (
+                <InfoRow label="Pinned Commit"><span className="font-mono">{status.resolvedSource.commit}</span></InfoRow>
+              )}
+              {status?.resolvedSource?.digest && (
+                <InfoRow label="Pinned Digest"><span className="font-mono">{status.resolvedSource.digest}</span></InfoRow>
+              )}
+            </div>
+            {!status?.resolvedSource && resolution.state !== "failed" && (
+              <p className="text-xs text-muted-foreground mt-2">
+                The controller resolves this source to a pinned commit and scans its
+                manifest and inventory. Refresh to see resolution progress.
+              </p>
+            )}
+          </section>
+
+          {manifest && (
+            <section>
+              <SectionHeading>Manifest</SectionHeading>
+              <div className="space-y-1.5 text-sm">
+                <InfoRow label="Name"><span className="font-mono">{manifest.name}</span></InfoRow>
+                {manifest.displayName && <InfoRow label="Display Name">{manifest.displayName}</InfoRow>}
+                {manifest.version && <InfoRow label="Version"><span className="font-mono">{manifest.version}</span></InfoRow>}
+                {manifest.description && <InfoRow label="Description">{manifest.description}</InfoRow>}
+                {manifest.author?.name && (
+                  <InfoRow label="Author">
+                    {manifest.author.name}
+                    {manifest.author.email && <span className="text-muted-foreground"> &lt;{manifest.author.email}&gt;</span>}
+                  </InfoRow>
+                )}
+                {manifest.license && <InfoRow label="License">{manifest.license}</InfoRow>}
+                {manifest.homepage && (
+                  <InfoRow label="Homepage">
+                    <a
+                      href={manifest.homepage}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-primary hover:underline inline-flex items-center gap-1"
+                    >
+                      {manifest.homepage} <ExternalLink className="h-2.5 w-2.5" />
+                    </a>
+                  </InfoRow>
+                )}
+              </div>
+              {manifest.keywords && manifest.keywords.length > 0 && (
+                <div className="flex flex-wrap gap-1.5 mt-2">
+                  {manifest.keywords.map((keyword) => (
+                    <Badge key={keyword} variant="outline" className="text-xs font-normal">{keyword}</Badge>
+                  ))}
+                </div>
+              )}
+            </section>
+          )}
+        </TabsContent>
+
+        <TabsContent value="contents" className="space-y-6">
+          {/* Governance risk surface: hooks and executables run arbitrary code
+              on the consumer's machine, so they lead the inventory. */}
+          {(hooks.length > 0 || executables.length > 0) && (
+            <div className="rounded-md border border-amber-500/40 bg-amber-500/10 p-4 space-y-4">
+              <div className="flex items-center gap-2 text-sm font-semibold text-amber-700 dark:text-amber-400">
+                <AlertTriangle className="h-4 w-4" />
+                Runs code on install
+              </div>
+              <p className="text-xs text-muted-foreground">
+                This plugin registers lifecycle hooks and/or ships executables. Review
+                them before deploying — they execute with the harness&apos;s permissions.
+              </p>
+              {hooks.length > 0 && (
+                <div>
+                  <h4 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-1.5 flex items-center gap-1.5">
+                    <Webhook className="h-3.5 w-3.5" /> Hooks ({hooks.length})
+                  </h4>
+                  <ul className="space-y-1">
+                    {hooks.map((hook, i) => (
+                      <li key={`${hook.event}-${i}`} className="text-sm flex items-center gap-2">
+                        <span className="font-mono">{hook.event}</span>
+                        {hook.type && <Badge variant="outline" className="text-[10px] px-1 py-0 h-4 font-normal">{hook.type}</Badge>}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+              {executables.length > 0 && (
+                <div>
+                  <h4 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-1.5 flex items-center gap-1.5">
+                    <Terminal className="h-3.5 w-3.5" /> Executables ({executables.length})
+                  </h4>
+                  <ul className="space-y-1">
+                    {executables.map((exe) => (
+                      <li key={exe} className="text-sm font-mono">{exe}</li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+            </div>
+          )}
+
+          {skills.length > 0 && (
+            <section>
+              <SectionHeading>
+                <span className="inline-flex items-center gap-1.5"><Zap className="h-3.5 w-3.5" /> Skills ({skills.length})</span>
+              </SectionHeading>
+              <ul className="space-y-2">
+                {skills.map((skill) => (
+                  <li key={skill.name} className="text-sm">
+                    <span className="font-mono font-medium">{skill.name}</span>
+                    {skill.description && (
+                      <p className="text-muted-foreground text-xs mt-0.5">{skill.description}</p>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            </section>
+          )}
+
+          {commands.length > 0 && (
+            <section>
+              <SectionHeading>
+                <span className="inline-flex items-center gap-1.5"><Terminal className="h-3.5 w-3.5" /> Commands ({commands.length})</span>
+              </SectionHeading>
+              <div className="flex flex-wrap gap-1.5">
+                {commands.map((command) => (
+                  <Badge key={command} variant="secondary" className="font-mono font-normal">/{command}</Badge>
+                ))}
+              </div>
+            </section>
+          )}
+
+          {agents.length > 0 && (
+            <section>
+              <SectionHeading>
+                <span className="inline-flex items-center gap-1.5"><Bot className="h-3.5 w-3.5" /> Agents ({agents.length})</span>
+              </SectionHeading>
+              <div className="flex flex-wrap gap-1.5">
+                {agents.map((agent) => (
+                  <Badge key={agent} variant="secondary" className="font-mono font-normal">{agent}</Badge>
+                ))}
+              </div>
+            </section>
+          )}
+
+          {mcpServers.length > 0 && (
+            <section>
+              <SectionHeading>
+                <span className="inline-flex items-center gap-1.5">
+                  <span className="h-3.5 w-3.5 flex items-center justify-center"><MCPIcon /></span> MCP Servers ({mcpServers.length})
+                </span>
+              </SectionHeading>
+              <div className="flex flex-wrap gap-1.5">
+                {mcpServers.map((server) => (
+                  <Badge key={server} variant="secondary" className="font-mono font-normal">{server}</Badge>
+                ))}
+              </div>
+            </section>
+          )}
+
+          {!hasInventory && (
+            <p className="text-sm text-muted-foreground">
+              {resolution.state === "ready"
+                ? "The controller found no skills, commands, agents, hooks, MCP servers, or executables in this bundle."
+                : "Inventory is populated by the controller once the source is resolved and scanned."}
+            </p>
+          )}
+        </TabsContent>
+
+        <TabsContent value="raw">
+          <div className="rounded-lg border p-4">
+            <div className="flex items-center justify-between mb-3">
+              <h3 className="text-sm font-semibold flex items-center gap-2">
+                <Code className="h-4 w-4" />
+                Raw JSON
+              </h3>
+              <Button variant="outline" size="sm" onClick={handleCopyJson} className="gap-1.5 h-7 text-xs">
+                {jsonCopied ? <><Check className="h-3 w-3" /> Copied</> : <><Copy className="h-3 w-3" /> Copy</>}
+              </Button>
+            </div>
+            <pre className="bg-muted p-3 rounded-md overflow-x-auto text-xs leading-relaxed">
+              {JSON.stringify(selectedTag, null, 2)}
+            </pre>
+          </div>
+        </TabsContent>
+      </Tabs>
+    </div>
+  )
+}

--- a/ui/lib/__tests__/plugin-utils.test.ts
+++ b/ui/lib/__tests__/plugin-utils.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from "vitest"
+import { getPinnedRevision, getPluginRepoUrl, getPluginResolution } from "../plugin-utils"
+import type { Plugin } from "@/lib/api/types.gen"
+
+function makePlugin(status?: Plugin["status"]): Plugin {
+  return {
+    apiVersion: "ar.dev/v1alpha1",
+    kind: "Plugin",
+    metadata: { name: "p", namespace: "default", tag: "latest" },
+    spec: {
+      source: {
+        type: "git",
+        git: { repository: { url: "https://github.com/example/p" } },
+      },
+    },
+    status,
+  }
+}
+
+describe("getPluginResolution", () => {
+  const cases: {
+    name: string
+    status: Plugin["status"]
+    wantState: string
+    wantLabel: string
+  }[] = [
+    {
+      name: "no status at all",
+      status: undefined,
+      wantState: "unknown",
+      wantLabel: "Not resolved",
+    },
+    {
+      name: "no Ready condition",
+      status: { conditions: [{ type: "Other", status: "True" }] },
+      wantState: "unknown",
+      wantLabel: "Not resolved",
+    },
+    {
+      name: "Ready=True",
+      status: { conditions: [{ type: "Ready", status: "True", reason: "Resolved" }] },
+      wantState: "ready",
+      wantLabel: "Resolved",
+    },
+    {
+      name: "Ready=False progressing",
+      status: { conditions: [{ type: "Ready", status: "False", reason: "Progressing", message: "resolving plugin source" }] },
+      wantState: "progressing",
+      wantLabel: "Progressing",
+    },
+    {
+      name: "Ready=False terminal failure",
+      status: { conditions: [{ type: "Ready", status: "False", reason: "SourceInvalid", message: "no plugin.json" }] },
+      wantState: "failed",
+      wantLabel: "SourceInvalid",
+    },
+  ]
+
+  for (const tc of cases) {
+    it(tc.name, () => {
+      const got = getPluginResolution(makePlugin(tc.status))
+      expect(got.state).toBe(tc.wantState)
+      expect(got.label).toBe(tc.wantLabel)
+    })
+  }
+
+  it("carries the condition message through for failures", () => {
+    const got = getPluginResolution(makePlugin({
+      conditions: [{ type: "Ready", status: "False", reason: "SourceUnresolvable", message: "repo not found" }],
+    }))
+    expect(got.message).toBe("repo not found")
+  })
+})
+
+describe("getPinnedRevision", () => {
+  it("returns undefined when unresolved", () => {
+    expect(getPinnedRevision(makePlugin())).toBeUndefined()
+  })
+
+  it("shortens a git commit", () => {
+    const plugin = makePlugin({ resolvedSource: { type: "git", commit: "435bf0f7aa11223344556677889900aabbccddee" } })
+    expect(getPinnedRevision(plugin)).toBe("435bf0f")
+  })
+
+  it("shortens an OCI digest", () => {
+    const plugin = makePlugin({ resolvedSource: { type: "oci", digest: "sha256:abcdef0123456789" } })
+    expect(getPinnedRevision(plugin)).toBe("abcdef0")
+  })
+})
+
+describe("getPluginRepoUrl", () => {
+  it("reads the git repository url", () => {
+    expect(getPluginRepoUrl(makePlugin())).toBe("https://github.com/example/p")
+  })
+
+  it("returns undefined for non-git sources", () => {
+    const plugin = makePlugin()
+    plugin.spec.source = { type: "oci", oci: { reference: "ghcr.io/x/y@sha256:abc" } }
+    expect(getPluginRepoUrl(plugin)).toBeUndefined()
+  })
+})

--- a/ui/lib/admin-api.ts
+++ b/ui/lib/admin-api.ts
@@ -20,6 +20,7 @@ export {
   listSkillsV0,
   listAgentsV0,
   listPromptsV0,
+  listPluginsV0,
   toServerResponse,
   toSkillResponse,
   toAgentResponse,
@@ -27,6 +28,7 @@ export {
   createServerV0,
   createSkillV0,
   createPromptV0,
+  createPluginV0,
   deployServer,
 } from './ui-shims'
 export type {
@@ -38,5 +40,6 @@ export type {
   SkillJson,
   PromptJson,
   AgentJson,
+  PluginJson,
   DeployServerBody,
 } from './ui-shims'

--- a/ui/lib/plugin-utils.ts
+++ b/ui/lib/plugin-utils.ts
@@ -1,0 +1,54 @@
+// Helpers for reading controller-written Plugin status.
+//
+// Readiness contract (see pkg/api/v1alpha1/plugin.go): consumers MUST treat
+// the absence of a Ready=True condition (or resolvedSource == nil) as "not
+// yet resolved". The controller sets Ready=False/Progressing on first
+// observe, Ready=True/Resolved once pinned and scanned, and Ready=False with
+// a specific reason (SourceUnresolvable, SourceUnsupported, SourceInvalid)
+// on failure.
+
+import type { Condition, Plugin } from "@/lib/api/types.gen"
+
+export type PluginResolutionState = "ready" | "progressing" | "failed" | "unknown"
+
+export interface PluginResolution {
+  state: PluginResolutionState
+  /** Short human label, e.g. "Resolved", "Progressing", "SourceInvalid". */
+  label: string
+  /** Failure/progress detail from the condition message, if any. */
+  message?: string
+  condition?: Condition
+}
+
+export function getReadyCondition(plugin: Plugin): Condition | undefined {
+  return plugin.status?.conditions?.find((c) => c.type === "Ready") ?? undefined
+}
+
+export function getPluginResolution(plugin: Plugin): PluginResolution {
+  const condition = getReadyCondition(plugin)
+  if (!condition) {
+    return { state: "unknown", label: "Not resolved" }
+  }
+  if (condition.status === "True") {
+    return { state: "ready", label: condition.reason || "Resolved", condition }
+  }
+  const label = condition.reason || "Not ready"
+  const state: PluginResolutionState = condition.reason === "Progressing" ? "progressing" : "failed"
+  return { state, label, message: condition.message, condition }
+}
+
+/** Short (7-char) form of the pinned commit SHA, if the source is resolved. */
+export function getPinnedRevision(plugin: Plugin): string | undefined {
+  const resolved = plugin.status?.resolvedSource
+  if (!resolved) return undefined
+  if (resolved.commit) return resolved.commit.slice(0, 7)
+  if (resolved.digest) {
+    const hex = resolved.digest.replace(/^sha256:/, "")
+    return hex.slice(0, 7)
+  }
+  return undefined
+}
+
+export function getPluginRepoUrl(plugin: Plugin): string | undefined {
+  return plugin.spec.source?.git?.repository?.url ?? undefined
+}

--- a/ui/lib/ui-shims.ts
+++ b/ui/lib/ui-shims.ts
@@ -24,6 +24,8 @@ import type {
   Deployment,
   McpServer,
   McpServerSpec,
+  Plugin,
+  PluginSpec,
   Prompt,
   PromptSpec,
   Skill,
@@ -34,6 +36,7 @@ import {
   applyDeployment as applyDeploymentRaw,
   listAgents as listAgentsRaw,
   listMcpservers as listMcpserversRaw,
+  listPlugins as listPluginsRaw,
   listPrompts as listPromptsRaw,
   listSkills as listSkillsRaw,
 } from "@/lib/api/sdk.gen"
@@ -208,6 +211,25 @@ export async function listPromptsV0(opts?: LegacyListOpts): Promise<{
   }
 }
 
+// Plugins postdate the v1alpha1 refactor, so there is no legacy flat shape to
+// reconstruct — plugin components consume the K8s-style envelope directly
+// (spec + controller-written status). Only the list-call ergonomics (cursor
+// query + all-namespaces default) are shimmed to match the other kinds.
+export async function listPluginsV0(opts?: LegacyListOpts): Promise<{
+  data: { plugins: Plugin[]; metadata: LegacyListMetadata }
+}> {
+  const { data } = await listPluginsRaw({
+    throwOnError: true,
+    query: withAllNamespaces(opts?.query),
+  })
+  return {
+    data: {
+      plugins: data?.items ?? [],
+      metadata: { nextCursor: data?.nextCursor },
+    },
+  }
+}
+
 // ----------------------------------------------------------------------------
 // Create-function shims. Legacy callers pass a flat `{name: "ns/name", tag,
 // description, ...spec}` JSON. Wrap the spec in a K8s envelope, and apply the
@@ -231,6 +253,11 @@ export interface PromptJson extends PromptSpec {
 }
 
 export interface AgentJson extends AgentSpec {
+  name: string
+  tag: string
+}
+
+export interface PluginJson extends PluginSpec {
   name: string
   tag: string
 }
@@ -294,6 +321,24 @@ export async function createSkillV0(opts: LegacyCreateOpts<SkillJson>): Promise<
   }
   await applySingleDoc(envelope)
   return { data: toSkillResponse(envelope) }
+}
+
+// createPluginV0 applies a Plugin envelope through the shared declarative
+// endpoint. The spec is user intent only (title/description/harnesses +
+// source pointer); the Plugin controller resolves and pins the source out of
+// band and writes status.resolvedSource/manifest/inventory.
+export async function createPluginV0(opts: LegacyCreateOpts<PluginJson>): Promise<{
+  data: Plugin
+}> {
+  const spec = stripLegacy(opts.body) as PluginSpec
+  const envelope: Plugin = {
+    apiVersion: "ar.dev/v1alpha1",
+    kind: "Plugin",
+    metadata: { namespace: "default", name: opts.body.name, tag: opts.body.tag },
+    spec,
+  }
+  await applySingleDoc(envelope)
+  return { data: envelope }
 }
 
 export async function createPromptV0(opts: LegacyCreateOpts<PromptJson>): Promise<{


### PR DESCRIPTION
# Description

**Motivation:** The Plugin kind (`ar.dev/v1alpha1`, #554) is fully usable from `arctl apply`, but had zero surface in the Next.js UI — plugins could not be registered, browsed, or inspected without the CLI.

**What changed:** Adds first-class Plugin support to the catalog UI, following the existing skill/agent/prompt/server component patterns:

- **Add-plugin dialog** (`add-plugin-dialog.tsx`): name, title, description, harnesses, and a git source (repository URL + optional branch/commit/subfolder), applied through the shared declarative `/v0/apply` endpoint via the generated client. The dialog explains that the controller resolves the pointer to a pinned commit and scans the bundle out of band.
- **Catalog card** (`plugin-card.tsx`): Plugins tab alongside the other kinds, grouped by name with tag counts. The card surfaces resolution state from status — a Ready badge (green), a Resolving spinner while `Ready=False/Progressing`, or the failure reason (e.g. `SourceUnresolvable`) with the condition message in a tooltip — plus the short pinned commit and harness badges.
- **Detail page** (`plugin-detail.tsx`): renders the server-derived content — `status.resolvedSource` (full pinned commit/digest), the parsed `status.manifest` (displayName, version, description, author, license, homepage, keywords), and the `status.inventory`. Hooks and executables are the governance risk surface, so they lead the Contents tab in a prominent "Runs code on install" callout ahead of skills, commands, agents, and MCP servers. Resolution failures show the controller's error message inline.
- **Status helpers** (`lib/plugin-utils.ts`): implement the readiness contract documented on `PluginStatus` (absence of `Ready=True` ⇒ not yet resolved).
- **Shims** (`lib/ui-shims.ts`): `listPluginsV0`/`createPluginV0`. Plugins postdate the legacy flat response shape, so plugin components consume the v1alpha1 envelope (spec + status) directly; only the list-call ergonomics are shimmed.
- **Tests + stories:** vitest coverage for the card (all resolution states), detail (manifest, inventory, risk callout, failure banner), dialog (payload shape, DNS-1123 validation, API error surfacing), and status helpers; Storybook stories for the card.

**Verified live** against a local server built from this branch with the real fixture `github.com/ilackarms/repo-analyst` registered both via `curl` to `/v0/apply` and through the new dialog: the controller pinned the commit and the UI rendered the full manifest and inventory (3 skills, 3 commands, 1 agent); a second commit-pinned tag registered through the dialog grouped correctly (+1 tag count, tag selector); a plugin with a nonexistent repo rendered the `SourceUnresolvable` failure state. `cd ui && npm test` (75 passed), `make lint-ui` (0 errors), `tsc --noEmit` clean.

# Change Type

/kind feature

# Changelog

```release-note
The registry UI now supports Plugins: register a plugin from a git source, browse plugins in the catalog with their resolution status and pinned commit, and inspect the controller-derived manifest and inventory (skills, commands, agents, and the hook/executable risk surface).
```

# Additional Notes

- No backend changes; the UI consumes the existing generated TS client (`listPlugins` + `/v0/apply`).
- Deleting plugins from the UI is intentionally out of scope, matching the other kinds (the card supports `showDelete` for future use, like `SkillCard`).
