### PR TITLE
arctl get all includes discovered deployments by default

### DIFF
--- a/internal/cli/declarative/deployment_get_test.go
+++ b/internal/cli/declarative/deployment_get_test.go
@@ -267,7 +267,30 @@ func TestDeploymentGet_OriginFiltering(t *testing.T) {
 	}
 }
 
-// (5) `-o yaml` emits the declarative envelope (apiVersion/kind/metadata/spec)
+// (5) `get all` always lists managed-only deployments; there is no flag to
+// include discovered ones (use `get deployments --origin all/discovered`).
+func TestGetAll_DeploymentOriginDefaults(t *testing.T) {
+	deployments := []v1alpha1.Deployment{
+		deploymentFixture("aws-v1", "managed-agent", "1.0.0", "my-aws", "agent", "deployed"),
+		deploymentFixture("foundry-v1", "discovered-agent", "1.0.0", "my-foundry", "agent", "pending"),
+	}
+	deployments[1].Metadata.Annotations = map[string]string{
+		v1alpha1.DeploymentOriginAnnotation: v1alpha1.DeploymentOriginDiscovered,
+	}
+	srv := deploymentTestServerV1Alpha1(t, deployments)
+	setupClientForServer(t, srv)
+
+	out := &bytes.Buffer{}
+	cmd := declarative.NewGetCmd(declarativeTestDeps(nil))
+	cmd.SetOut(out)
+	cmd.SetArgs([]string{"all"})
+	require.NoError(t, cmd.Execute())
+
+	assert.Contains(t, out.String(), "managed-agent")
+	assert.NotContains(t, out.String(), "discovered-agent")
+}
+
+// (6) `-o yaml` emits the declarative envelope (apiVersion/kind/metadata/spec)
 // plus a .status block with server-managed runtime state. Spec itself stays
 // clean so `get -o yaml | apply -f -` round-trips without leaking server
 // fields back into the stored spec.

--- a/internal/cli/declarative/get.go
+++ b/internal/cli/declarative/get.go
@@ -233,7 +233,11 @@ func runGetAll(cmd *cobra.Command, kinds *scheme.Registry, c *client.Client, out
 	allKinds := kinds.All()
 	first := true
 	for _, k := range allKinds {
-		items, err := listItems(cmd.Context(), c, k, scheme.ListOpts{})
+		opts := scheme.ListOpts{}
+		if strings.EqualFold(k.Kind, v1alpha1.KindDeployment) {
+			opts.Origin = v1alpha1.DeploymentOriginManaged
+		}
+		items, err := listItems(cmd.Context(), c, k, opts)
 		if errors.Is(err, errNotListable) {
 			continue
 		}

--- a/internal/cli/declarative/resources.go
+++ b/internal/cli/declarative/resources.go
@@ -109,7 +109,7 @@ func deleteAny[T v1alpha1.Object](ctx context.Context, c *client.Client, kind, n
 func listDeploymentResources(ctx context.Context, c *client.Client, opts scheme.ListOpts) ([]any, error) {
 	// opts.Origin is already normalized to the server filter value by the get
 	// command (resolveOrigin): "" means both provenances, managed/discovered
-	// select one. The zero-value caller (`get all`) therefore lists both.
+	// select one. `get all` always passes "managed".
 	items, err := client.ListAllTyped(
 		ctx,
 		c,


### PR DESCRIPTION
# Description

- **Motivation:** `arctl get all` doesn't support the origin filter for deployments so it always lists deployments from all origins
- **What changed:** update get all to always pass origin managed to the deployment lister

# Change Type

```
/kind fix
```

# Changelog

```release-note
`arctl get all` no longer shows discovered deployments by default, matching `arctl get deployments`.
```

# Additional Notes
