### PR TITLE
feat(cli): add Kiro IDE config path to arctl configure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ internal/registry/api/ui/dist/
 .vscode/
 .idea/
 .cursor/
+.kiro/
 *.swp
 *.swo
 *~

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Move from discovery to usage without reinventing the same delivery path for ever
 
 Make approved artifacts easier to consume from the tools developers already use.
 
-- Generate configuration for Claude Desktop, Cursor, and VS Code
+- Generate configuration for Claude Desktop, Cursor, Kiro IDE, and VS Code
 - Pair with agentgateway for a consistent access layer to deployed MCP infrastructure
 - Reduce manual setup for AI clients and shared environments
 

--- a/internal/cli/configure/configure.go
+++ b/internal/cli/configure/configure.go
@@ -17,6 +17,7 @@ var clientConfigurers = map[string]ClientConfigurer{
 	"vscode":      &VSCodeConfigurer{},
 	"cursor":      &CursorConfigurer{},
 	"claude-code": &ClaudeCodeConfigurer{},
+	"kiro":        &KiroConfigurer{},
 }
 
 func NewCommand(deps cliruntime.Deps) *cobra.Command {

--- a/internal/cli/configure/kiro.go
+++ b/internal/cli/configure/kiro.go
@@ -1,0 +1,48 @@
+package configure
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+// KiroConfigurer handles Kiro MCP configuration
+type KiroConfigurer struct{}
+
+// kiroServerConfig represents a Kiro MCP server configuration
+type kiroServerConfig struct {
+	URL string `json:"url"`
+}
+
+// kiroConfig represents the Kiro MCP configuration file structure
+type kiroConfig struct {
+	MCPServers map[string]kiroServerConfig `json:"mcpServers"`
+}
+
+func (c *KiroConfigurer) GetConfigPath() (string, error) {
+	return ".kiro/settings/mcp.json", nil
+}
+
+func (c *KiroConfigurer) CreateConfig(url string, configPath string) (any, error) {
+	config := kiroConfig{
+		MCPServers: make(map[string]kiroServerConfig),
+	}
+
+	// Read existing config if it exists
+	if data, err := os.ReadFile(configPath); err == nil {
+		if err := json.Unmarshal(data, &config); err != nil {
+			return config, fmt.Errorf("failed to parse existing config: %w", err)
+		}
+	}
+
+	// Add or update the ARCTL server
+	config.MCPServers["ARCTL"] = kiroServerConfig{
+		URL: url,
+	}
+
+	return config, nil
+}
+
+func (c *KiroConfigurer) GetClientName() string {
+	return "Kiro agentic IDE"
+}

--- a/internal/cli/configure/kiro_test.go
+++ b/internal/cli/configure/kiro_test.go
@@ -1,0 +1,129 @@
+package configure
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestKiroConfigurer_GetConfigPath(t *testing.T) {
+	configurer := &KiroConfigurer{}
+	path, err := configurer.GetConfigPath()
+
+	if err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+
+	expected := ".kiro/settings/mcp.json"
+	if path != expected {
+		t.Errorf("Expected path %s, got %s", expected, path)
+	}
+}
+
+func TestKiroConfigurer_GetClientName(t *testing.T) {
+	configurer := &KiroConfigurer{}
+	name := configurer.GetClientName()
+
+	expected := "Kiro agentic IDE"
+	if name != expected {
+		t.Errorf("Expected name %s, got %s", expected, name)
+	}
+}
+
+func TestKiroConfigurer_CreateConfig(t *testing.T) {
+	// Create a temporary directory for testing
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, ".kiro", "settings", "mcp.json")
+
+	configurer := &KiroConfigurer{}
+	url := "http://localhost:8080/mcp"
+
+	// Test creating a new config
+	config, err := configurer.CreateConfig(url, configPath)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	// Verify the config structure
+	kiroConfig, ok := config.(kiroConfig)
+	if !ok {
+		t.Fatal("Expected config to be of type kiroConfig")
+	}
+
+	if len(kiroConfig.MCPServers) != 1 {
+		t.Errorf("Expected 1 server, got %d", len(kiroConfig.MCPServers))
+	}
+
+	arctlServer, exists := kiroConfig.MCPServers["ARCTL"]
+	if !exists {
+		t.Fatal("Expected ARCTL server to exist")
+	}
+
+	if arctlServer.URL != url {
+		t.Errorf("Expected URL %s, got %s", url, arctlServer.URL)
+	}
+}
+
+func TestKiroConfigurer_CreateConfig_MergesExisting(t *testing.T) {
+	// Create a temporary directory for testing
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, "mcp.json")
+
+	// Create an existing config with another server
+	existingConfig := kiroConfig{
+		MCPServers: map[string]kiroServerConfig{
+			"existing-server": {
+				URL: "http://existing.com",
+			},
+		},
+	}
+
+	data, err := json.MarshalIndent(existingConfig, "", "  ")
+	if err != nil {
+		t.Fatalf("Failed to marshal existing config: %v", err)
+	}
+
+	if err := os.WriteFile(configPath, data, 0644); err != nil {
+		t.Fatalf("Failed to write existing config: %v", err)
+	}
+
+	// Now create config with arctl
+	configurer := &KiroConfigurer{}
+	url := "http://localhost:8080/mcp"
+
+	config, err := configurer.CreateConfig(url, configPath)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	// Verify both servers exist
+	kiroConfig, ok := config.(kiroConfig)
+	if !ok {
+		t.Fatal("Expected config to be of type kiroConfig")
+	}
+
+	if len(kiroConfig.MCPServers) != 2 {
+		t.Errorf("Expected 2 servers, got %d", len(kiroConfig.MCPServers))
+	}
+
+	// Check existing server is preserved
+	existingServer, exists := kiroConfig.MCPServers["existing-server"]
+	if !exists {
+		t.Fatal("Expected existing-server to be preserved")
+	}
+
+	if existingServer.URL != "http://existing.com" {
+		t.Errorf("Existing server URL changed unexpectedly")
+	}
+
+	// Check arctl server was added
+	arctlServer, exists := kiroConfig.MCPServers["ARCTL"]
+	if !exists {
+		t.Fatal("Expected ARCTL server to exist")
+	}
+
+	if arctlServer.URL != url {
+		t.Errorf("Expected arctl URL %s, got %s", url, arctlServer.URL)
+	}
+}


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don't apply.
-->

# Description

<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

**Motivation:** `arctl configure` supports creating a MCP config file for VS Code, Cursor, and Claude Code. [Kiro](https://kiro.dev) is another common IDE, but is not currently supported.

**What changed:**
  - Added `internal/cli/configure/kiro.go` and added `kiro` to `clientConfigurers` in `internal/cli/configure/configure.go`.
  - Added unit test under `internal/cli/configure/kiro_test.go` based on `vscode_test.go`
  - 
    ```
    $ go test -run TestKiroConfigurer ./internal/cli/configure 
    ok      github.com/agentregistry-dev/agentregistry/internal/cli/configure       0.271s
    ```
  - Updated `README.md` to reference Kiro
  - Added `.kiro/` to `.gitignore`

**Verified live**:
  - Deployed local MCP by following official docs: https://aregistry.ai/docs/mcp/
  - Built CLI locally: `make build-cli`
  - Added workspace level Kiro to config with `bin/arctl configure kiro`
  - Opened folder in Kiro and confirmed `Kiro panel -> MCP Servers` was populated and connects successfully

**Example**:

MCP Server in the UI:

<img width="302" height="125" alt="Screenshot 2026-07-13 at 3 59 47 PM" src="https://github.com/user-attachments/assets/76d79e88-fec4-4cbf-87b5-0b09fc0eb601" />

Tool Usage:

<img width="449" height="369" alt="Screenshot 2026-07-13 at 4 06 34 PM" src="https://github.com/user-attachments/assets/44dc9875-20dd-4a83-a5d2-f5d653d226c6" />

# Change Type

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bump
/kind cleanup
/kind design
/kind deprecation
/kind documentation
/kind feature
/kind fix
/kind flake
/kind install
```
-->

/kind feature

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
feat(cli): arctl configure now supports adding MCP configuration for Kiro agentic IDE
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->

- No changes to UI or backend, only the `arctl configure` CLI
- More Context for Kiro:
  - https://kiro.dev/docs/mcp/configuration/#configuration-file-structure
  - https://kiro.dev/docs/mcp/configuration/#configuration-locations