### PR TITLE
Add health endpoint to MCP server

### DIFF
--- a/internal/registry/registry_app.go
+++ b/internal/registry/registry_app.go
@@ -515,10 +515,18 @@ func startMCPServer(
 	if authnProvider != nil {
 		handler = mcpAuthnMiddleware(authnProvider)(handler)
 	}
+	// Mount the MCP handler under a mux that reserves /healthz for a 200-OK liveness probe.
+	// The bridge listener otherwise has no plain-HTTP endpoint that returns 200 (a bare GET
+	// yields 400).
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	mux.Handle("/", handler)
 	addr := ":" + strconv.Itoa(int(cfg.MCPPort))
 	srv := &http.Server{
 		Addr:              addr,
-		Handler:           handler,
+		Handler:           mux,
 		ReadHeaderTimeout: 10 * time.Second,
 	}
 	go func() {


### PR DESCRIPTION
# Description

A small mux handler to add a health endpoint to the MCP server. The MCP server normally does not have a health endpoint callable by environmetns (e.g. kube health checks) and any bare `GET` requests get a `400` response.

This isn't bad, but it's cleaner to have this simple endpoint.

# Change Type

```
/kind feature
```

# Changelog

```release-note
Add `/healthz` endpoint to the registry MCP server.
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
