### PR TITLE
feat(model): fingerprint referenced Models

### DIFF
--- a/pkg/types/fingerprint.go
+++ b/pkg/types/fingerprint.go
@@ -235,17 +235,39 @@ func materialHash(parts ...json.RawMessage) string {
 
 func defaultApplyDependencies(ctx context.Context, in ApplyInput) ([]v1alpha1.Object, error) {
 	agent, ok := in.Target.(*v1alpha1.Agent)
-	if !ok || agent == nil {
-		return nil, nil
-	}
+	hasModelRef := in.Deployment != nil && in.Deployment.Spec.ModelRef != nil
+	hasAgentRefs := ok && agent != nil &&
+		(len(agent.Spec.MCPServers) > 0 || hasHarnessCompositionRefs(in.Deployment, agent))
 	if in.Getter == nil {
-		if len(agent.Spec.MCPServers) > 0 || hasHarnessCompositionRefs(in.Deployment, agent) {
-			return nil, fmt.Errorf("fingerprint: getter required to resolve Agent dependency refs")
+		if hasModelRef || hasAgentRefs {
+			return nil, fmt.Errorf("fingerprint: getter required to resolve dependency refs")
 		}
 		return nil, nil
 	}
-	deps := make([]v1alpha1.Object, 0, len(agent.Spec.MCPServers)+len(agent.Spec.Plugins)+len(agent.Spec.Skills)+1)
+	dependencyCapacity := 0
+	if hasModelRef {
+		dependencyCapacity++
+	}
+	if ok && agent != nil {
+		dependencyCapacity += len(agent.Spec.MCPServers) + len(agent.Spec.Plugins) + len(agent.Spec.Skills) + 1
+	}
+	deps := make([]v1alpha1.Object, 0, dependencyCapacity)
 	var err error
+	if hasModelRef {
+		modelRef := in.Deployment.Spec.ModelRef
+		deps, err = appendResolvedRefs(ctx, deps, in.Getter, in.Deployment.Metadata.NamespaceOrDefault(), []v1alpha1.ResourceRef{{
+			Kind:      v1alpha1.KindModel,
+			Namespace: modelRef.Namespace,
+			Name:      modelRef.Name,
+			Tag:       modelRef.Tag,
+		}}, v1alpha1.KindModel, "deployment spec.modelRef")
+		if err != nil {
+			return nil, err
+		}
+	}
+	if !ok || agent == nil {
+		return deps, nil
+	}
 	deps, err = appendResolvedRefs(ctx, deps, in.Getter, agent.Metadata.NamespaceOrDefault(), agent.Spec.MCPServers, v1alpha1.KindMCPServer, "target spec.mcpServers")
 	if err != nil {
 		return nil, err

--- a/pkg/types/fingerprint_test.go
+++ b/pkg/types/fingerprint_test.go
@@ -103,9 +103,49 @@ func TestDefaultApplyFingerprintResultIncludesDependencySnapshot(t *testing.T) {
 	}
 }
 
+func TestDefaultApplyFingerprintResultIncludesModelDependency(t *testing.T) {
+	in := testApplyInput()
+	in.Deployment.Metadata.Namespace = "team-a"
+	in.Deployment.Spec.ModelRef = &v1alpha1.ModelRef{Name: "approved-model"}
+
+	modelID := "us.anthropic.claude-sonnet-4-6"
+	in.Getter = func(_ context.Context, ref v1alpha1.ResourceRef) (v1alpha1.Object, error) {
+		if ref.Kind != v1alpha1.KindModel || ref.Namespace != "team-a" || ref.Name != "approved-model" || ref.Tag != "" {
+			t.Fatalf("model ref = %+v, want team-a/approved-model with implicit latest tag", ref)
+		}
+		return testModel("team-a", "approved-model", "latest", modelID), nil
+	}
+
+	first, err := DefaultApplyFingerprintResult(context.Background(), in, ApplyFingerprintOptions{AdapterType: "test"})
+	if err != nil {
+		t.Fatalf("DefaultApplyFingerprintResult: %v", err)
+	}
+	if len(first.Dependencies) != 1 {
+		t.Fatalf("dependencies = %+v, want one Model dependency", first.Dependencies)
+	}
+	dep := first.Dependencies[0]
+	if dep.Kind != v1alpha1.KindModel || dep.Namespace != "team-a" || dep.Name != "approved-model" || dep.Tag != "latest" {
+		t.Fatalf("model dependency identity mismatch: %+v", dep)
+	}
+	if dep.UID != "model-uid" || dep.Generation != 1 || dep.MaterialHash == "" {
+		t.Fatalf("model dependency version mismatch: %+v", dep)
+	}
+
+	modelID = "us.anthropic.claude-opus-4-8"
+	second, err := DefaultApplyFingerprintResult(context.Background(), in, ApplyFingerprintOptions{AdapterType: "test"})
+	if err != nil {
+		t.Fatalf("DefaultApplyFingerprintResult after Model change: %v", err)
+	}
+	if second.Fingerprint == first.Fingerprint {
+		t.Fatalf("fingerprint did not change after resolved Model spec changed: %s", second.Fingerprint)
+	}
+}
+
 func TestDefaultApplyFingerprintIncludesAgentHarnessCompositionDependencies(t *testing.T) {
 	in := testApplyInput()
+	in.Deployment.Metadata.Namespace = "team-a"
 	in.Deployment.Spec.Harness = &v1alpha1.DeploymentHarness{Type: "claude-code"}
+	in.Deployment.Spec.ModelRef = &v1alpha1.ModelRef{Name: "approved-model"}
 	in.Target = &v1alpha1.Agent{
 		TypeMeta: v1alpha1.TypeMeta{Kind: v1alpha1.KindAgent},
 		Metadata: v1alpha1.ObjectMeta{
@@ -139,6 +179,8 @@ func TestDefaultApplyFingerprintIncludesAgentHarnessCompositionDependencies(t *t
 			return testPrompt(ref.Namespace, ref.Name, "Write concise rollout notes."), nil
 		case v1alpha1.KindMCPServer:
 			return testMCPServerInNamespace(ref.Namespace, ref.Name, "ghcr.io/example/search:1.0.0"), nil
+		case v1alpha1.KindModel:
+			return testModel(ref.Namespace, ref.Name, "latest", "us.anthropic.claude-sonnet-4-6"), nil
 		default:
 			t.Fatalf("unexpected dependency ref: %+v", ref)
 			return nil, nil
@@ -149,8 +191,8 @@ func TestDefaultApplyFingerprintIncludesAgentHarnessCompositionDependencies(t *t
 	if err != nil {
 		t.Fatalf("DefaultApplyFingerprintResult: %v", err)
 	}
-	if len(first.Dependencies) != 4 {
-		t.Fatalf("dependencies = %+v, want Plugin, Skill, Prompt, and MCPServer", first.Dependencies)
+	if len(first.Dependencies) != 5 {
+		t.Fatalf("dependencies = %+v, want Model, Plugin, Skill, Prompt, and MCPServer", first.Dependencies)
 	}
 	for _, dep := range first.Dependencies {
 		if dep.Namespace != "team-a" {
@@ -280,6 +322,23 @@ func testPrompt(namespace, name, content string) *v1alpha1.Prompt {
 			Generation: 1,
 		},
 		Spec: v1alpha1.PromptSpec{Content: content},
+	}
+}
+
+func testModel(namespace, name, tag, modelID string) *v1alpha1.Model {
+	return &v1alpha1.Model{
+		TypeMeta: v1alpha1.TypeMeta{Kind: v1alpha1.KindModel},
+		Metadata: v1alpha1.ObjectMeta{
+			Namespace:  namespace,
+			Name:       name,
+			Tag:        tag,
+			UID:        "model-uid",
+			Generation: 1,
+		},
+		Spec: v1alpha1.ModelSpec{
+			Provider: v1alpha1.ModelProviderBedrock,
+			Model:    modelID,
+		},
 	}
 }
 


### PR DESCRIPTION
# Description

Include `Deployment.spec.modelRef` in the default resolved dependency set used for apply fingerprinting. A referenced Model's identity, generation, and spec now participate in the fingerprint while the existing MCPServer, Plugin, Skill, and Prompt dependency snapshots remain intact.

This is the narrow prerequisite for enterprise AgentCore runtime translation to use the selected Model without adopting the legacy adapter fingerprinter hook, which returns only a fingerprint string and would lose operator-visible dependency evidence.

# Change Type

/kind feature

# Changelog

```release-note
Deployment apply fingerprints now include changes to referenced Models.
```

# Additional Notes

Validation:

- `go test -race ./pkg/types`
- `make test-unit` (1,228 tests)
- `make lint`
- clean-commit `make verify`
- `git diff --check`
