### PR TITLE
chore: simplify fingerprint dependency collection

### DIFF
--- a/pkg/types/fingerprint.go
+++ b/pkg/types/fingerprint.go
@@ -244,14 +244,7 @@ func defaultApplyDependencies(ctx context.Context, in ApplyInput) ([]v1alpha1.Ob
 		}
 		return nil, nil
 	}
-	dependencyCapacity := 0
-	if hasModelRef {
-		dependencyCapacity++
-	}
-	if ok && agent != nil {
-		dependencyCapacity += len(agent.Spec.MCPServers) + len(agent.Spec.Plugins) + len(agent.Spec.Skills) + 1
-	}
-	deps := make([]v1alpha1.Object, 0, dependencyCapacity)
+	deps := make([]v1alpha1.Object, 0)
 	var err error
 	if hasModelRef {
 		modelRef := in.Deployment.Spec.ModelRef


### PR DESCRIPTION
# Description

Follow up on the readability nit from #585 by removing the hand-maintained
dependency-capacity calculation. Dependency collection now starts with a
straightforward empty slice; behavior is unchanged.

# Change Type

/kind cleanup

# Changelog

```release-note
NONE
```

# Additional Notes

Validation:

- `go test ./pkg/types`
- `git diff --check`
- `make verify`
