### PR TITLE
fix uv sync failures

### DIFF
--- a/internal/cli/frameworks/builtin/adk-python/templates/pyproject.toml.tmpl
+++ b/internal/cli/frameworks/builtin/adk-python/templates/pyproject.toml.tmpl
@@ -19,4 +19,10 @@ dependencies = [
   "kagent-adk=={{.KagentADKPyVersion}}",
 {{- end}}
 ]
-requires-python = ">=3.13"
+# <3.14: google-adk's opentelemetry-resourcedetector-gcp transitive has no 3.14 wheels.
+requires-python = ">=3.13,<3.14"
+
+[tool.uv]
+# google-adk 1.25.1 needs opentelemetry-resourcedetector-gcp from a pre-release-only
+# range; pin the known-good alpha so a live resolve can't randomly break the build.
+constraint-dependencies = ["opentelemetry-resourcedetector-gcp==1.12.0a0"]


### PR DESCRIPTION
# Description

- **Motivation:** fix uv sync failures 
```
  Dockerfile:15
  --------------------
    13 |     COPY .python-version .python-version
    14 |
    15 | >>> RUN uv sync
    16 |
    17 |     ENV OTEL_SERVICE_NAME=demo
  --------------------
  ERROR: failed to build: failed to solve: process "/bin/sh -c uv sync" did not complete successfully: exit code: 1
  Error: framework build: exit status 1
```
- **What changed:** pin otel collector version

# Change Type

```
/kind fix
```

# Changelog

```release-note
Fixes `arctl init` ADK Python agents failing to build due to a dependency resolution error.
```

# Additional Notes

