### PR TITLE
api: allow custom OpenAPI schema naming

### DIFF
--- a/internal/registry/api/router/router.go
+++ b/internal/registry/api/router/router.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"reflect"
 	"strings"
 	"time"
 
@@ -143,12 +144,16 @@ func NewHumaAPI(
 	uiHandler http.Handler,
 	authnProvider auth.AuthnProvider,
 	routeOpts *RouteOptions,
+	schemaNamer func(reflect.Type, string) string,
 ) (huma.API, error) {
 	// Create Huma API configuration
 	humaConfig := huma.DefaultConfig("Official MCP Registry", "1.0.0")
 	humaConfig.Info.Description = "A community driven registry service for Model Context Protocol (MCP) servers.\n\n[GitHub repository](https://github.com/modelcontextprotocol/registry) | [Documentation](https://github.com/modelcontextprotocol/registry/tree/main/docs)"
 	// Disable $schema property in responses: https://github.com/danielgtaylor/huma/issues/230
 	humaConfig.CreateHooks = []func(huma.Config) huma.Config{}
+	if schemaNamer != nil {
+		humaConfig.Components.Schemas = huma.NewMapRegistry("#/components/schemas/", schemaNamer)
+	}
 
 	// Create a new API using humago adapter for standard library
 	api := humago.New(mux, humaConfig)

--- a/internal/registry/api/server.go
+++ b/internal/registry/api/server.go
@@ -8,6 +8,7 @@ import (
 	"io/fs"
 	"log/slog"
 	"net/http"
+	"reflect"
 	"strings"
 	"time"
 
@@ -159,6 +160,7 @@ func NewServer(
 	customUIHandler http.Handler,
 	authnProvider auth.AuthnProvider,
 	routeOpts *router.RouteOptions,
+	schemaNamer func(reflect.Type, string) string,
 ) (*Server, error) {
 	// Create HTTP mux and Huma API
 	mux := http.NewServeMux()
@@ -178,7 +180,7 @@ func NewServer(
 		}
 	}
 
-	api, err := router.NewHumaAPI(cfg, mux, metrics, versionInfo, uiHandler, authnProvider, routeOpts)
+	api, err := router.NewHumaAPI(cfg, mux, metrics, versionInfo, uiHandler, authnProvider, routeOpts, schemaNamer)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/registry/registry_app.go
+++ b/internal/registry/registry_app.go
@@ -167,7 +167,7 @@ func App(ctx context.Context, opts ...types.AppOptions) error {
 	routeOpts := buildRouteOptions(options, stores, deploymentAdapters, perKindHooks)
 
 	// Initialize HTTP server
-	baseServer, err := api.NewServer(cfg, metrics, versionInfo, options.UIHandler, authnProvider, routeOpts)
+	baseServer, err := api.NewServer(cfg, metrics, versionInfo, options.UIHandler, authnProvider, routeOpts, options.OpenAPISchemaNamer)
 	if err != nil {
 		return fmt.Errorf("failed to initialize HTTP server: %w", err)
 	}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -15,6 +15,7 @@ package types
 import (
 	"context"
 	"net/http"
+	"reflect"
 
 	"github.com/danielgtaylor/huma/v2"
 	"github.com/modelcontextprotocol/go-sdk/oauthex"
@@ -186,6 +187,12 @@ var NoopAuditor Auditor = noopAuditor{}
 // (internal/registry/registry_app.go) can reference it without a cyclic
 // import.
 type AppOptions struct {
+	// OpenAPISchemaNamer overrides Huma's default schema naming function.
+	// Use this when an application exposes same-named Go types from different
+	// packages; Huma's default namer omits package paths and panics on those
+	// collisions. Nil preserves Huma's default schema names.
+	OpenAPISchemaNamer func(reflect.Type, string) string
+
 	// DatabaseFactory is an optional function to create a database that
 	// adds new functionality. The factory receives the base database and
 	// can run additional migrations. If nil, uses the default PostgreSQL


### PR DESCRIPTION
# Description

Expose an optional Huma schema namer through AppOptions so consumer
applications can disambiguate same-named Go types from different packages.
Preserve the default schema naming behavior when no override is supplied.

# Change Type

```
/kind bug_fix
```

# Changelog

```release-note
NONE
```
