### PR TITLE
`arctl configure` fix batch

### DIFF
--- a/internal/cli/configure/claude_code.go
+++ b/internal/cli/configure/claude_code.go
@@ -1,53 +1,37 @@
 package configure
 
-import (
-	"encoding/json"
-	"fmt"
-	"os"
-)
+import "fmt"
 
 // ClaudeCodeConfigurer handles Claude Code MCP configuration
 type ClaudeCodeConfigurer struct{}
 
-// claudeServerConfig represents a Claude MCP server configuration (supports both stdio and HTTP)
+// claudeServerConfig is the arctl server entry written into .mcp.json. Other
+// servers' entries are preserved verbatim by mergeServerEntry to avoid breaking
+// a user's file.
 type claudeServerConfig struct {
-	Type    string            `json:"type,omitempty"`
-	URL     string            `json:"url,omitempty"`
-	Command string            `json:"command,omitempty"`
-	Args    []string          `json:"args,omitempty"`
-	Env     map[string]string `json:"env,omitempty"`
-}
-
-// claudeConfig represents the Claude MCP configuration file structure
-type claudeConfig struct {
-	MCPServers map[string]claudeServerConfig `json:"mcpServers"`
+	Type    string            `json:"type"`
+	URL     string            `json:"url"`
+	Headers map[string]string `json:"headers,omitempty"`
 }
 
 func (c *ClaudeCodeConfigurer) GetConfigPath() (string, error) {
 	return ".mcp.json", nil
 }
 
-func (c *ClaudeCodeConfigurer) CreateConfig(url string, configPath string) (any, error) {
-	config := claudeConfig{
-		MCPServers: make(map[string]claudeServerConfig),
+func (c *ClaudeCodeConfigurer) CreateConfig(opts CreateOptions, configPath string) (any, error) {
+	entry := claudeServerConfig{
+		Type: "http",
+		URL:  opts.URL,
 	}
-
-	// Read existing config if it exists
-	if data, err := os.ReadFile(configPath); err == nil {
-		if err := json.Unmarshal(data, &config); err != nil {
-			return config, fmt.Errorf("failed to parse existing config: %w", err)
+	if opts.TokenEnv != "" {
+		// Claude Code expands ${VAR} in header values at connect time, keeping the token out of the checked-in file.
+		entry.Headers = map[string]string{
+			"Authorization": fmt.Sprintf("Bearer ${%s}", opts.TokenEnv),
 		}
 	}
-
-	// Add or update the arctl HTTP server
-	config.MCPServers["arctl"] = claudeServerConfig{
-		Type: "http",
-		URL:  url,
-	}
-
-	return config, nil
+	return mergeServerEntry(configPath, "mcpServers", entry)
 }
 
 func (c *ClaudeCodeConfigurer) GetClientName() string {
-	return "Claude Code Editor"
+	return "Claude Code"
 }

--- a/internal/cli/configure/claude_code_test.go
+++ b/internal/cli/configure/claude_code_test.go
@@ -1,0 +1,21 @@
+package configure
+
+import "testing"
+
+func TestClaudeCodeConfigurer_GetConfigPath(t *testing.T) {
+	configurer := &ClaudeCodeConfigurer{}
+	path, err := configurer.GetConfigPath()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if path != ".mcp.json" {
+		t.Errorf("got path %q, want %q", path, ".mcp.json")
+	}
+}
+
+func TestClaudeCodeConfigurer_GetClientName(t *testing.T) {
+	configurer := &ClaudeCodeConfigurer{}
+	if name := configurer.GetClientName(); name != "Claude Code" {
+		t.Errorf("got name %q, want %q", name, "Claude Code")
+	}
+}

--- a/internal/cli/configure/configure.go
+++ b/internal/cli/configure/configure.go
@@ -21,7 +21,7 @@ var clientConfigurers = map[string]ClientConfigurer{
 }
 
 func NewCommand(deps cliruntime.Deps) *cobra.Command {
-	var configureURL, configurePort string
+	var configureURL, configurePort, configureTokenEnv string
 
 	cmd := &cobra.Command{
 		Use:   cliruntime.CommandConfigure + " [client-name]",
@@ -47,6 +47,9 @@ func NewCommand(deps cliruntime.Deps) *cobra.Command {
 
 			url := fmt.Sprintf("http://localhost:%s/mcp", configurePort)
 			if configureURL != "" {
+				if cmd.Flags().Changed("port") {
+					fmt.Fprintln(cmd.OutOrStdout(), "Warning: --port is ignored when --url is set")
+				}
 				url = configureURL
 			}
 
@@ -55,7 +58,8 @@ func NewCommand(deps cliruntime.Deps) *cobra.Command {
 				return fmt.Errorf("failed to get config path: %v", err)
 			}
 
-			config, err := configurer.CreateConfig(url, configPath)
+			opts := CreateOptions{URL: url, TokenEnv: configureTokenEnv}
+			config, err := configurer.CreateConfig(opts, configPath)
 			if err != nil {
 				return fmt.Errorf("failed to create %s config: %v", configurer.GetClientName(), err)
 			}
@@ -65,12 +69,17 @@ func NewCommand(deps cliruntime.Deps) *cobra.Command {
 			}
 
 			fmt.Fprintf(cmd.OutOrStdout(), "Configured %s\n", configurer.GetClientName())
+			if configureTokenEnv != "" && clientName == "vscode" {
+				// VSCode doesn't work off env vars and instead expects inputs, so setting token env is a special case for it
+				fmt.Fprintf(cmd.OutOrStdout(), "Note: VS Code prompts for the token on first connection and stores it in its secret storage; the %s environment variable is not read\n", configureTokenEnv)
+			}
 			return nil
 		},
 	}
 
 	cmd.Flags().StringVar(&configureURL, "url", "", fmt.Sprintf("Custom MCP server URL (default: http://localhost:%s/mcp)", common.DefaultAgentGatewayPort))
 	cmd.Flags().StringVar(&configurePort, "port", common.DefaultAgentGatewayPort, "Port for the MCP server")
+	cmd.Flags().StringVar(&configureTokenEnv, "token-env", "", "Name of the environment variable holding the MCP bearer token for static/direct access (e.g. ARCTL_MCP_TOKEN); written into the config as a reference the client expands at connect time. Clients that support OAuth can authenticate interactively instead, without this flag")
 
 	return cmd
 }

--- a/internal/cli/configure/configure_test.go
+++ b/internal/cli/configure/configure_test.go
@@ -1,0 +1,411 @@
+package configure
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	cliruntime "github.com/agentregistry-dev/agentregistry/pkg/cli/runtime"
+)
+
+// runConfigure executes the configure command in the current working directory
+// and returns its combined output.
+func runConfigure(t *testing.T, args ...string) string {
+	t.Helper()
+	cmd := NewCommand(cliruntime.Deps{})
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs(args)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("configure %v: %v", args, err)
+	}
+	return out.String()
+}
+
+// seedFile writes content at path relative to the current working directory,
+// creating parent directories.
+func seedFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatalf("creating seed directory: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("writing seed file: %v", err)
+	}
+}
+
+// assertFileJSON compares the JSON content of path against want, ignoring
+// formatting and key order.
+func assertFileJSON(t *testing.T, path, want string) {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading %s: %v", path, err)
+	}
+	var got, expected any
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("parsing %s: %v\ncontent:\n%s", path, err, data)
+	}
+	if err := json.Unmarshal([]byte(want), &expected); err != nil {
+		t.Fatalf("parsing expected JSON: %v", err)
+	}
+	if !reflect.DeepEqual(got, expected) {
+		t.Errorf("file %s content mismatch\ngot:\n%s\nwant:\n%s", path, data, want)
+	}
+}
+
+func TestConfigure(t *testing.T) {
+	tests := []struct {
+		name       string
+		args       []string
+		configPath string
+		seed       string
+		runTwice   bool
+		want       string
+		wantOutput []string
+	}{
+		{
+			name:       "claude-code fresh config",
+			args:       []string{"claude-code"},
+			configPath: ".mcp.json",
+			want: `{
+				"mcpServers": {
+					"arctl": {"type": "http", "url": "http://localhost:21212/mcp"}
+				}
+			}`,
+		},
+		{
+			name:       "vscode fresh config",
+			args:       []string{"vscode"},
+			configPath: ".vscode/mcp.json",
+			want: `{
+				"servers": {
+					"arctl": {"type": "http", "url": "http://localhost:21212/mcp"}
+				}
+			}`,
+		},
+		{
+			name:       "cursor fresh config",
+			args:       []string{"cursor"},
+			configPath: ".cursor/mcp.json",
+			want: `{
+				"mcpServers": {
+					"arctl": {"url": "http://localhost:21212/mcp"}
+				}
+			}`,
+		},
+		{
+			name:       "kiro fresh config",
+			args:       []string{"kiro"},
+			configPath: ".kiro/settings/mcp.json",
+			want: `{
+				"mcpServers": {
+					"arctl": {"url": "http://localhost:21212/mcp"}
+				}
+			}`,
+		},
+		{
+			name:       "custom url without port",
+			args:       []string{"claude-code", "--url", "https://are.example.dev/mcp"},
+			configPath: ".mcp.json",
+			want: `{
+				"mcpServers": {
+					"arctl": {"type": "http", "url": "https://are.example.dev/mcp"}
+				}
+			}`,
+		},
+		{
+			name:       "custom port",
+			args:       []string{"cursor", "--port", "9999"},
+			configPath: ".cursor/mcp.json",
+			want: `{
+				"mcpServers": {
+					"arctl": {"url": "http://localhost:9999/mcp"}
+				}
+			}`,
+		},
+		{
+			name:       "cursor merge preserves stdio server and unknown fields",
+			args:       []string{"cursor"},
+			configPath: ".cursor/mcp.json",
+			seed: `{
+				"mcpServers": {
+					"other-server": {
+						"command": "npx",
+						"args": ["-y", "mcp-server"],
+						"env": {"API_KEY": "value"},
+						"disabled": false
+					}
+				}
+			}`,
+			want: `{
+				"mcpServers": {
+					"other-server": {
+						"command": "npx",
+						"args": ["-y", "mcp-server"],
+						"env": {"API_KEY": "value"},
+						"disabled": false
+					},
+					"arctl": {"url": "http://localhost:21212/mcp"}
+				}
+			}`,
+		},
+		{
+			name:       "kiro merge preserves autoApprove and headers",
+			args:       []string{"kiro"},
+			configPath: ".kiro/settings/mcp.json",
+			seed: `{
+				"mcpServers": {
+					"other-server": {
+						"url": "https://other.example.com/mcp",
+						"headers": {"Authorization": "Bearer token"},
+						"autoApprove": ["some_tool"]
+					}
+				}
+			}`,
+			want: `{
+				"mcpServers": {
+					"other-server": {
+						"url": "https://other.example.com/mcp",
+						"headers": {"Authorization": "Bearer token"},
+						"autoApprove": ["some_tool"]
+					},
+					"arctl": {"url": "http://localhost:21212/mcp"}
+				}
+			}`,
+		},
+		{
+			name:       "vscode merge preserves unknown top-level keys and existing servers",
+			args:       []string{"vscode"},
+			configPath: ".vscode/mcp.json",
+			seed: `{
+				"inputs": [
+					{"type": "promptString", "id": "other-token", "description": "Other token", "password": true}
+				],
+				"servers": {
+					"other-server": {
+						"type": "stdio",
+						"command": "npx",
+						"args": ["-y", "mcp-server"]
+					}
+				}
+			}`,
+			want: `{
+				"inputs": [
+					{"type": "promptString", "id": "other-token", "description": "Other token", "password": true}
+				],
+				"servers": {
+					"other-server": {
+						"type": "stdio",
+						"command": "npx",
+						"args": ["-y", "mcp-server"]
+					},
+					"arctl": {"type": "http", "url": "http://localhost:21212/mcp"}
+				}
+			}`,
+		},
+		{
+			name:       "claude-code merge preserves headers and timeout on existing servers",
+			args:       []string{"claude-code"},
+			configPath: ".mcp.json",
+			seed: `{
+				"mcpServers": {
+					"other-server": {
+						"type": "http",
+						"url": "https://other.example.com/mcp",
+						"headers": {"Authorization": "Bearer ${OTHER_TOKEN}"},
+						"timeout": 30000
+					}
+				}
+			}`,
+			want: `{
+				"mcpServers": {
+					"other-server": {
+						"type": "http",
+						"url": "https://other.example.com/mcp",
+						"headers": {"Authorization": "Bearer ${OTHER_TOKEN}"},
+						"timeout": 30000
+					},
+					"arctl": {"type": "http", "url": "http://localhost:21212/mcp"}
+				}
+			}`,
+		},
+		{
+			name:       "legacy ARCTL entry is migrated",
+			args:       []string{"cursor"},
+			configPath: ".cursor/mcp.json",
+			seed: `{
+				"mcpServers": {
+					"ARCTL": {"url": "http://localhost:21212/mcp"}
+				}
+			}`,
+			want: `{
+				"mcpServers": {
+					"arctl": {"url": "http://localhost:21212/mcp"}
+				}
+			}`,
+		},
+		{
+			name:       "claude-code token emission",
+			args:       []string{"claude-code", "--token-env", "ARCTL_MCP_TOKEN"},
+			configPath: ".mcp.json",
+			want: `{
+				"mcpServers": {
+					"arctl": {
+						"type": "http",
+						"url": "http://localhost:21212/mcp",
+						"headers": {"Authorization": "Bearer ${ARCTL_MCP_TOKEN}"}
+					}
+				}
+			}`,
+		},
+		{
+			name:       "cursor token emission",
+			args:       []string{"cursor", "--token-env", "ARCTL_MCP_TOKEN"},
+			configPath: ".cursor/mcp.json",
+			want: `{
+				"mcpServers": {
+					"arctl": {
+						"url": "http://localhost:21212/mcp",
+						"headers": {"Authorization": "Bearer ${env:ARCTL_MCP_TOKEN}"}
+					}
+				}
+			}`,
+		},
+		{
+			name:       "kiro token emission",
+			args:       []string{"kiro", "--token-env", "ARCTL_MCP_TOKEN"},
+			configPath: ".kiro/settings/mcp.json",
+			want: `{
+				"mcpServers": {
+					"arctl": {
+						"url": "http://localhost:21212/mcp",
+						"headers": {"Authorization": "Bearer ${env:ARCTL_MCP_TOKEN}"}
+					}
+				}
+			}`,
+		},
+		{
+			name:       "vscode token emission adds inputs entry",
+			args:       []string{"vscode", "--token-env", "ARCTL_MCP_TOKEN"},
+			configPath: ".vscode/mcp.json",
+			want: `{
+				"servers": {
+					"arctl": {
+						"type": "http",
+						"url": "http://localhost:21212/mcp",
+						"headers": {"Authorization": "Bearer ${input:arctl-mcp-token}"}
+					}
+				},
+				"inputs": [
+					{"type": "promptString", "id": "arctl-mcp-token", "description": "Bearer token for the arctl MCP server", "password": true}
+				]
+			}`,
+			wantOutput: []string{"Note: VS Code prompts for the token on first connection"},
+		},
+		{
+			name:       "vscode token emission appends to existing inputs",
+			args:       []string{"vscode", "--token-env", "ARCTL_MCP_TOKEN"},
+			configPath: ".vscode/mcp.json",
+			seed: `{
+				"inputs": [
+					{"type": "promptString", "id": "other-token", "description": "Other token", "password": true}
+				],
+				"servers": {
+					"other-server": {"type": "http", "url": "https://other.example.com/mcp"}
+				}
+			}`,
+			want: `{
+				"inputs": [
+					{"type": "promptString", "id": "other-token", "description": "Other token", "password": true},
+					{"type": "promptString", "id": "arctl-mcp-token", "description": "Bearer token for the arctl MCP server", "password": true}
+				],
+				"servers": {
+					"other-server": {"type": "http", "url": "https://other.example.com/mcp"},
+					"arctl": {
+						"type": "http",
+						"url": "http://localhost:21212/mcp",
+						"headers": {"Authorization": "Bearer ${input:arctl-mcp-token}"}
+					}
+				}
+			}`,
+		},
+		{
+			name:       "vscode token emission is idempotent",
+			args:       []string{"vscode", "--token-env", "ARCTL_MCP_TOKEN"},
+			configPath: ".vscode/mcp.json",
+			runTwice:   true,
+			want: `{
+				"servers": {
+					"arctl": {
+						"type": "http",
+						"url": "http://localhost:21212/mcp",
+						"headers": {"Authorization": "Bearer ${input:arctl-mcp-token}"}
+					}
+				},
+				"inputs": [
+					{"type": "promptString", "id": "arctl-mcp-token", "description": "Bearer token for the arctl MCP server", "password": true}
+				]
+			}`,
+		},
+		{
+			name:       "port is ignored with url",
+			args:       []string{"claude-code", "--url", "https://example.com/mcp", "--port", "9999"},
+			configPath: ".mcp.json",
+			want: `{
+				"mcpServers": {
+					"arctl": {"type": "http", "url": "https://example.com/mcp"}
+				}
+			}`,
+			wantOutput: []string{"Warning: --port is ignored when --url is set"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Chdir(t.TempDir())
+
+			if tt.seed != "" {
+				seedFile(t, tt.configPath, tt.seed)
+			}
+
+			output := runConfigure(t, tt.args...)
+			if tt.runTwice {
+				output = runConfigure(t, tt.args...)
+			}
+
+			assertFileJSON(t, tt.configPath, tt.want)
+			for _, want := range tt.wantOutput {
+				if !strings.Contains(output, want) {
+					t.Errorf("output missing %q\ngot:\n%s", want, output)
+				}
+			}
+		})
+	}
+}
+
+func TestConfigure_ListsSupportedClients(t *testing.T) {
+	t.Chdir(t.TempDir())
+	output := runConfigure(t)
+	for _, client := range []string{"vscode", "cursor", "claude-code", "kiro"} {
+		if !strings.Contains(output, client) {
+			t.Errorf("client listing missing %q\ngot:\n%s", client, output)
+		}
+	}
+}
+
+func TestConfigure_UnsupportedClient(t *testing.T) {
+	t.Chdir(t.TempDir())
+	cmd := NewCommand(cliruntime.Deps{})
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"not-a-client"})
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("expected error for unsupported client")
+	}
+}

--- a/internal/cli/configure/configurer.go
+++ b/internal/cli/configure/configurer.go
@@ -1,13 +1,25 @@
 package configure
 
+// CreateOptions carries the inputs for building a client's arctl MCP server entry.
+type CreateOptions struct {
+	// URL is the MCP server endpoint written into the client config.
+	URL string
+	// TokenEnv, when set, is the name of the environment variable holding the
+	// bearer token. It is written into the config as a client-side reference
+	// expanded by the client at connect time.
+	TokenEnv string
+}
+
 // ClientConfigurer defines the interface for client-specific MCP configuration
 type ClientConfigurer interface {
 	// GetConfigPath returns the path where the config file should be written
 	GetConfigPath() (string, error)
 
-	// CreateConfig creates or updates the MCP configuration for the client
-	// It should read existing config, merge with the new server, and return the updated config
-	CreateConfig(url string, configPath string) (any, error)
+	// CreateConfig creates or updates the MCP configuration for the client.
+	// It reads any existing config at configPath, replaces only the arctl
+	// server entry, and returns the updated config with all other content
+	// preserved to avoid breaking existing configurations.
+	CreateConfig(opts CreateOptions, configPath string) (any, error)
 
 	// GetClientName returns the display name of the client
 	GetClientName() string

--- a/internal/cli/configure/cursor.go
+++ b/internal/cli/configure/cursor.go
@@ -1,46 +1,33 @@
 package configure
 
-import (
-	"encoding/json"
-	"fmt"
-	"os"
-)
+import "fmt"
 
 // CursorConfigurer handles Cursor MCP configuration
 type CursorConfigurer struct{}
 
-// cursorServerConfig represents a Cursor MCP server configuration
+// cursorServerConfig is the arctl server entry written into .cursor/mcp.json.
+// Other servers' entries are preserved verbatim by mergeServerEntry.
 type cursorServerConfig struct {
-	URL string `json:"url"`
-}
-
-// cursorConfig represents the Cursor MCP configuration file structure
-type cursorConfig struct {
-	MCPServers map[string]cursorServerConfig `json:"mcpServers"`
+	URL     string            `json:"url"`
+	Headers map[string]string `json:"headers,omitempty"`
 }
 
 func (c *CursorConfigurer) GetConfigPath() (string, error) {
 	return ".cursor/mcp.json", nil
 }
 
-func (c *CursorConfigurer) CreateConfig(url string, configPath string) (any, error) {
-	config := cursorConfig{
-		MCPServers: make(map[string]cursorServerConfig),
+func (c *CursorConfigurer) CreateConfig(opts CreateOptions, configPath string) (any, error) {
+	entry := cursorServerConfig{
+		URL: opts.URL,
 	}
-
-	// Read existing config if it exists
-	if data, err := os.ReadFile(configPath); err == nil {
-		if err := json.Unmarshal(data, &config); err != nil {
-			return config, fmt.Errorf("failed to parse existing config: %w", err)
+	if opts.TokenEnv != "" {
+		// Cursor interpolates ${env:NAME} in header values at connect time,
+		// keeping the token out of the checked-in file.
+		entry.Headers = map[string]string{
+			"Authorization": fmt.Sprintf("Bearer ${env:%s}", opts.TokenEnv),
 		}
 	}
-
-	// Add or update the ARCTL server
-	config.MCPServers["ARCTL"] = cursorServerConfig{
-		URL: url,
-	}
-
-	return config, nil
+	return mergeServerEntry(configPath, "mcpServers", entry)
 }
 
 func (c *CursorConfigurer) GetClientName() string {

--- a/internal/cli/configure/cursor_test.go
+++ b/internal/cli/configure/cursor_test.go
@@ -1,0 +1,21 @@
+package configure
+
+import "testing"
+
+func TestCursorConfigurer_GetConfigPath(t *testing.T) {
+	configurer := &CursorConfigurer{}
+	path, err := configurer.GetConfigPath()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if path != ".cursor/mcp.json" {
+		t.Errorf("got path %q, want %q", path, ".cursor/mcp.json")
+	}
+}
+
+func TestCursorConfigurer_GetClientName(t *testing.T) {
+	configurer := &CursorConfigurer{}
+	if name := configurer.GetClientName(); name != "Cursor AI Editor" {
+		t.Errorf("got name %q, want %q", name, "Cursor AI Editor")
+	}
+}

--- a/internal/cli/configure/kiro.go
+++ b/internal/cli/configure/kiro.go
@@ -1,46 +1,35 @@
 package configure
 
-import (
-	"encoding/json"
-	"fmt"
-	"os"
-)
+import "fmt"
 
 // KiroConfigurer handles Kiro MCP configuration
 type KiroConfigurer struct{}
 
-// kiroServerConfig represents a Kiro MCP server configuration
+// kiroServerConfig is the arctl server entry written into .kiro/settings/mcp.json.
+// Other servers' entries are preserved verbatim by mergeServerEntry.
 type kiroServerConfig struct {
-	URL string `json:"url"`
-}
-
-// kiroConfig represents the Kiro MCP configuration file structure
-type kiroConfig struct {
-	MCPServers map[string]kiroServerConfig `json:"mcpServers"`
+	URL     string            `json:"url"`
+	Headers map[string]string `json:"headers,omitempty"`
 }
 
 func (c *KiroConfigurer) GetConfigPath() (string, error) {
 	return ".kiro/settings/mcp.json", nil
 }
 
-func (c *KiroConfigurer) CreateConfig(url string, configPath string) (any, error) {
-	config := kiroConfig{
-		MCPServers: make(map[string]kiroServerConfig),
+func (c *KiroConfigurer) CreateConfig(opts CreateOptions, configPath string) (any, error) {
+	entry := kiroServerConfig{
+		URL: opts.URL,
 	}
-
-	// Read existing config if it exists
-	if data, err := os.ReadFile(configPath); err == nil {
-		if err := json.Unmarshal(data, &config); err != nil {
-			return config, fmt.Errorf("failed to parse existing config: %w", err)
+	if opts.TokenEnv != "" {
+		// Kiro documents plain ${VAR} expansion in header values, but based on this issue
+		// it is sent literally instead of expanded: https://github.com/kirodotdev/Kiro/issues/5060.
+		// The undocumented ${env:VAR} form is reported working in that issue's comments, so it is emitted here.
+		// Revisit if Kiro fixes #5060 in favor of the documented syntax.
+		entry.Headers = map[string]string{
+			"Authorization": fmt.Sprintf("Bearer ${env:%s}", opts.TokenEnv),
 		}
 	}
-
-	// Add or update the ARCTL server
-	config.MCPServers["ARCTL"] = kiroServerConfig{
-		URL: url,
-	}
-
-	return config, nil
+	return mergeServerEntry(configPath, "mcpServers", entry)
 }
 
 func (c *KiroConfigurer) GetClientName() string {

--- a/internal/cli/configure/kiro_test.go
+++ b/internal/cli/configure/kiro_test.go
@@ -1,129 +1,21 @@
 package configure
 
-import (
-	"encoding/json"
-	"os"
-	"path/filepath"
-	"testing"
-)
+import "testing"
 
 func TestKiroConfigurer_GetConfigPath(t *testing.T) {
 	configurer := &KiroConfigurer{}
 	path, err := configurer.GetConfigPath()
-
 	if err != nil {
-		t.Errorf("Expected no error, got %v", err)
+		t.Fatalf("unexpected error: %v", err)
 	}
-
-	expected := ".kiro/settings/mcp.json"
-	if path != expected {
-		t.Errorf("Expected path %s, got %s", expected, path)
+	if path != ".kiro/settings/mcp.json" {
+		t.Errorf("got path %q, want %q", path, ".kiro/settings/mcp.json")
 	}
 }
 
 func TestKiroConfigurer_GetClientName(t *testing.T) {
 	configurer := &KiroConfigurer{}
-	name := configurer.GetClientName()
-
-	expected := "Kiro agentic IDE"
-	if name != expected {
-		t.Errorf("Expected name %s, got %s", expected, name)
-	}
-}
-
-func TestKiroConfigurer_CreateConfig(t *testing.T) {
-	// Create a temporary directory for testing
-	tempDir := t.TempDir()
-	configPath := filepath.Join(tempDir, ".kiro", "settings", "mcp.json")
-
-	configurer := &KiroConfigurer{}
-	url := "http://localhost:8080/mcp"
-
-	// Test creating a new config
-	config, err := configurer.CreateConfig(url, configPath)
-	if err != nil {
-		t.Fatalf("Expected no error, got %v", err)
-	}
-
-	// Verify the config structure
-	kiroConfig, ok := config.(kiroConfig)
-	if !ok {
-		t.Fatal("Expected config to be of type kiroConfig")
-	}
-
-	if len(kiroConfig.MCPServers) != 1 {
-		t.Errorf("Expected 1 server, got %d", len(kiroConfig.MCPServers))
-	}
-
-	arctlServer, exists := kiroConfig.MCPServers["ARCTL"]
-	if !exists {
-		t.Fatal("Expected ARCTL server to exist")
-	}
-
-	if arctlServer.URL != url {
-		t.Errorf("Expected URL %s, got %s", url, arctlServer.URL)
-	}
-}
-
-func TestKiroConfigurer_CreateConfig_MergesExisting(t *testing.T) {
-	// Create a temporary directory for testing
-	tempDir := t.TempDir()
-	configPath := filepath.Join(tempDir, "mcp.json")
-
-	// Create an existing config with another server
-	existingConfig := kiroConfig{
-		MCPServers: map[string]kiroServerConfig{
-			"existing-server": {
-				URL: "http://existing.com",
-			},
-		},
-	}
-
-	data, err := json.MarshalIndent(existingConfig, "", "  ")
-	if err != nil {
-		t.Fatalf("Failed to marshal existing config: %v", err)
-	}
-
-	if err := os.WriteFile(configPath, data, 0644); err != nil {
-		t.Fatalf("Failed to write existing config: %v", err)
-	}
-
-	// Now create config with arctl
-	configurer := &KiroConfigurer{}
-	url := "http://localhost:8080/mcp"
-
-	config, err := configurer.CreateConfig(url, configPath)
-	if err != nil {
-		t.Fatalf("Expected no error, got %v", err)
-	}
-
-	// Verify both servers exist
-	kiroConfig, ok := config.(kiroConfig)
-	if !ok {
-		t.Fatal("Expected config to be of type kiroConfig")
-	}
-
-	if len(kiroConfig.MCPServers) != 2 {
-		t.Errorf("Expected 2 servers, got %d", len(kiroConfig.MCPServers))
-	}
-
-	// Check existing server is preserved
-	existingServer, exists := kiroConfig.MCPServers["existing-server"]
-	if !exists {
-		t.Fatal("Expected existing-server to be preserved")
-	}
-
-	if existingServer.URL != "http://existing.com" {
-		t.Errorf("Existing server URL changed unexpectedly")
-	}
-
-	// Check arctl server was added
-	arctlServer, exists := kiroConfig.MCPServers["ARCTL"]
-	if !exists {
-		t.Fatal("Expected ARCTL server to exist")
-	}
-
-	if arctlServer.URL != url {
-		t.Errorf("Expected arctl URL %s, got %s", url, arctlServer.URL)
+	if name := configurer.GetClientName(); name != "Kiro agentic IDE" {
+		t.Errorf("got name %q, want %q", name, "Kiro agentic IDE")
 	}
 }

--- a/internal/cli/configure/merge.go
+++ b/internal/cli/configure/merge.go
@@ -1,0 +1,52 @@
+package configure
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+// serverName is the key arctl writes for its MCP server entry in every client config.
+const serverName = "arctl"
+
+// legacyServerName was written by earlier versions of the Cursor and Kiro
+// configurers; it is removed in favor of serverName on rewrite. This maintains
+// the same name across clients.
+// This migration can be dropped once legacy-named configs are no longer expected in the wild.
+const legacyServerName = "ARCTL"
+
+// mergeServerEntry reads the JSON config at configPath (if present), replaces only
+// <serversKey>[serverName] with entry, and returns the full document. All other
+// content is preserved as raw JSON so fields arctl does not model survive the rewrite.
+func mergeServerEntry(configPath, serversKey string, entry any) (map[string]json.RawMessage, error) {
+	root := map[string]json.RawMessage{}
+	if data, err := os.ReadFile(configPath); err == nil {
+		if err := json.Unmarshal(data, &root); err != nil {
+			return nil, fmt.Errorf("parsing existing config: %w", err)
+		}
+	}
+
+	servers := map[string]json.RawMessage{}
+	if raw, ok := root[serversKey]; ok {
+		if err := json.Unmarshal(raw, &servers); err != nil {
+			return nil, fmt.Errorf("parsing %q: %w", serversKey, err)
+		}
+	}
+
+	entryJSON, err := json.Marshal(entry)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling server entry: %w", err)
+	}
+	servers[serverName] = entryJSON
+
+	// delete 'ARCTL' to prefer newer 'arctl' name
+	delete(servers, legacyServerName)
+
+	serversJSON, err := json.Marshal(servers)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling %q: %w", serversKey, err)
+	}
+	root[serversKey] = serversJSON
+
+	return root, nil
+}

--- a/internal/cli/configure/vscode.go
+++ b/internal/cli/configure/vscode.go
@@ -3,48 +3,94 @@ package configure
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 )
 
 // VSCodeConfigurer handles VS Code MCP configuration
 type VSCodeConfigurer struct{}
 
-// mcpServerConfig represents a VS Code MCP server configuration
-type mcpServerConfig struct {
-	Type string `json:"type"`
-	URL  string `json:"url"`
-}
+// vscodeTokenInputID identifies the arctl token prompt in the top-level inputs
+// array of .vscode/mcp.json. VS Code caches the prompted secret keyed by this
+// id, so it must stay stable across runs.
+const vscodeTokenInputID = "arctl-mcp-token"
 
-// mcpConfig represents the VS Code MCP configuration file structure
-type mcpConfig struct {
-	Servers map[string]mcpServerConfig `json:"servers"`
+// vscodeServerConfig is the arctl server entry written into .vscode/mcp.json.
+// Other servers' entries are preserved verbatim by mergeServerEntry.
+type vscodeServerConfig struct {
+	Type    string            `json:"type"`
+	URL     string            `json:"url"`
+	Headers map[string]string `json:"headers,omitempty"`
 }
 
 func (v *VSCodeConfigurer) GetConfigPath() (string, error) {
 	return ".vscode/mcp.json", nil
 }
 
-func (v *VSCodeConfigurer) CreateConfig(url string, configPath string) (any, error) {
-	config := mcpConfig{
-		Servers: make(map[string]mcpServerConfig),
+func (v *VSCodeConfigurer) CreateConfig(opts CreateOptions, configPath string) (any, error) {
+	entry := vscodeServerConfig{
+		Type: "http",
+		URL:  opts.URL,
 	}
-
-	// Read existing config if it exists
-	if data, err := os.ReadFile(configPath); err == nil {
-		if err := json.Unmarshal(data, &config); err != nil {
-			return config, fmt.Errorf("failed to parse existing config: %w", err)
+	if opts.TokenEnv != "" {
+		// VS Code prompts for ${input:...} values once and keeps them in its
+		// secret storage; the token never lands in the file.
+		entry.Headers = map[string]string{
+			"Authorization": fmt.Sprintf("Bearer ${input:%s}", vscodeTokenInputID),
 		}
 	}
 
-	// Add or update the arctl server
-	config.Servers["arctl"] = mcpServerConfig{
-		Type: "http",
-		URL:  url,
+	root, err := mergeServerEntry(configPath, "servers", entry)
+	if err != nil {
+		return nil, err
 	}
-
-	return config, nil
+	if opts.TokenEnv != "" {
+		if err := ensureTokenInput(root); err != nil {
+			return nil, err
+		}
+	}
+	return root, nil
 }
 
 func (v *VSCodeConfigurer) GetClientName() string {
 	return "Visual Studio Code"
+}
+
+// ensureTokenInput appends the arctl token prompt to the top-level inputs array
+// unless an entry with vscodeTokenInputID already exists. The inputs array is
+// shared by every server in the file, so existing entries must be preserved and
+// not duplcated.
+func ensureTokenInput(root map[string]json.RawMessage) error {
+	var inputs []json.RawMessage
+	if raw, ok := root["inputs"]; ok {
+		if err := json.Unmarshal(raw, &inputs); err != nil {
+			return fmt.Errorf("parsing \"inputs\": %w", err)
+		}
+	}
+
+	for _, raw := range inputs {
+		var entry struct {
+			ID string `json:"id"`
+		}
+		// avoids duplicates
+		if err := json.Unmarshal(raw, &entry); err == nil && entry.ID == vscodeTokenInputID {
+			return nil
+		}
+	}
+
+	inputJSON, err := json.Marshal(map[string]any{
+		"type":        "promptString",
+		"id":          vscodeTokenInputID,
+		"description": "Bearer token for the arctl MCP server",
+		"password":    true,
+	})
+	if err != nil {
+		return fmt.Errorf("marshaling token input: %w", err)
+	}
+	inputs = append(inputs, inputJSON)
+
+	inputsJSON, err := json.Marshal(inputs)
+	if err != nil {
+		return fmt.Errorf("marshaling \"inputs\": %w", err)
+	}
+	root["inputs"] = inputsJSON
+	return nil
 }

--- a/internal/cli/configure/vscode_test.go
+++ b/internal/cli/configure/vscode_test.go
@@ -1,134 +1,21 @@
 package configure
 
-import (
-	"encoding/json"
-	"os"
-	"path/filepath"
-	"testing"
-)
+import "testing"
 
 func TestVSCodeConfigurer_GetConfigPath(t *testing.T) {
 	configurer := &VSCodeConfigurer{}
 	path, err := configurer.GetConfigPath()
-
 	if err != nil {
-		t.Errorf("Expected no error, got %v", err)
+		t.Fatalf("unexpected error: %v", err)
 	}
-
-	expected := ".vscode/mcp.json"
-	if path != expected {
-		t.Errorf("Expected path %s, got %s", expected, path)
+	if path != ".vscode/mcp.json" {
+		t.Errorf("got path %q, want %q", path, ".vscode/mcp.json")
 	}
 }
 
 func TestVSCodeConfigurer_GetClientName(t *testing.T) {
 	configurer := &VSCodeConfigurer{}
-	name := configurer.GetClientName()
-
-	expected := "Visual Studio Code"
-	if name != expected {
-		t.Errorf("Expected name %s, got %s", expected, name)
-	}
-}
-
-func TestVSCodeConfigurer_CreateConfig(t *testing.T) {
-	// Create a temporary directory for testing
-	tempDir := t.TempDir()
-	configPath := filepath.Join(tempDir, ".vscode", "mcp.json")
-
-	configurer := &VSCodeConfigurer{}
-	url := "http://localhost:8080/mcp"
-
-	// Test creating a new config
-	config, err := configurer.CreateConfig(url, configPath)
-	if err != nil {
-		t.Fatalf("Expected no error, got %v", err)
-	}
-
-	// Verify the config structure
-	mcpConfig, ok := config.(mcpConfig)
-	if !ok {
-		t.Fatal("Expected config to be of type mcpConfig")
-	}
-
-	if len(mcpConfig.Servers) != 1 {
-		t.Errorf("Expected 1 server, got %d", len(mcpConfig.Servers))
-	}
-
-	arctlServer, exists := mcpConfig.Servers["arctl"]
-	if !exists {
-		t.Fatal("Expected arctl server to exist")
-	}
-
-	if arctlServer.Type != "http" {
-		t.Errorf("Expected type 'http', got %s", arctlServer.Type)
-	}
-
-	if arctlServer.URL != url {
-		t.Errorf("Expected URL %s, got %s", url, arctlServer.URL)
-	}
-}
-
-func TestVSCodeConfigurer_CreateConfig_MergesExisting(t *testing.T) {
-	// Create a temporary directory for testing
-	tempDir := t.TempDir()
-	configPath := filepath.Join(tempDir, "mcp.json")
-
-	// Create an existing config with another server
-	existingConfig := mcpConfig{
-		Servers: map[string]mcpServerConfig{
-			"existing-server": {
-				Type: "http",
-				URL:  "http://existing.com",
-			},
-		},
-	}
-
-	data, err := json.MarshalIndent(existingConfig, "", "  ")
-	if err != nil {
-		t.Fatalf("Failed to marshal existing config: %v", err)
-	}
-
-	if err := os.WriteFile(configPath, data, 0644); err != nil {
-		t.Fatalf("Failed to write existing config: %v", err)
-	}
-
-	// Now create config with arctl
-	configurer := &VSCodeConfigurer{}
-	url := "http://localhost:8080/mcp"
-
-	config, err := configurer.CreateConfig(url, configPath)
-	if err != nil {
-		t.Fatalf("Expected no error, got %v", err)
-	}
-
-	// Verify both servers exist
-	mcpConfig, ok := config.(mcpConfig)
-	if !ok {
-		t.Fatal("Expected config to be of type mcpConfig")
-	}
-
-	if len(mcpConfig.Servers) != 2 {
-		t.Errorf("Expected 2 servers, got %d", len(mcpConfig.Servers))
-	}
-
-	// Check existing server is preserved
-	existingServer, exists := mcpConfig.Servers["existing-server"]
-	if !exists {
-		t.Fatal("Expected existing-server to be preserved")
-	}
-
-	if existingServer.URL != "http://existing.com" {
-		t.Errorf("Existing server URL changed unexpectedly")
-	}
-
-	// Check arctl server was added
-	arctlServer, exists := mcpConfig.Servers["arctl"]
-	if !exists {
-		t.Fatal("Expected arctl server to exist")
-	}
-
-	if arctlServer.URL != url {
-		t.Errorf("Expected arctl URL %s, got %s", url, arctlServer.URL)
+	if name := configurer.GetClientName(); name != "Visual Studio Code" {
+		t.Errorf("got name %q, want %q", name, "Visual Studio Code")
 	}
 }


### PR DESCRIPTION
# Description

**Motivation**
A few issues with `arctl configure`s output. To name a few:
1. We are overriding existing MCP server configs with our un/marshalling that was based expected narrow structs, deleting unrelated keys and only modifying our managed config (`arctl`).
    - e.g. In Cursor/Kiro existing stdio servers became `{"url": ""}` in Cursor/Kiro; VS Code lost top-level `inputs`/`sandbox`, Claude Code dropped `headers`/`timeout`/`oauth` from other servers.
3. (Minor) Naming inconsistency. Different configs had different mcp server naming (`arctl` vs `ARCTL`)
4. We have no way to `configure` a bearer token for the mcp bridge. We recently we've added support for vendor ext. to configure mcp bridge auth, so this is a good additions to that.

**What Changed**
1. Stopped marshalling to specific keys because each client configures a lot of unrelated keys that we must preserve. Now we do a raw marshal to preserve existing information.
2. Changed naming in some Clients from `ARCTL` to `arctl` with cleanup to avoid end-user changes needed.
3. Added new flag `--token-env` allowing direct-access config to MCP bridge if it requires auth.
    - This is different from authenticating via the OAuth flow in interactive clients.
5. Additional testing

# Change Type

```
/kind feature
/kind fix
```

# Changelog

```release-note
Fix issue where `arctl configure` was removing unrelated keys from local config files, and support static MCP bridge token for `arctl configure` via `--token-env VAR_NAME`.
```

# Additional Notes

Does not set up any auth or changes to the server. Simply focused on input (cmd) -> output (config file) translation which is verified via tests and local runs of `arctl configure`.

The largest unknown is Kiro and if it requires `${TOKEN}` vs `${env:TOKEN}` where there is an open issue stating the former [documented version](https://kiro.dev/docs/cli/mcp/configuration/#remote-server-with-headers) does not work. If anyone with Kiro tests locally and hits an issue, we likely just need to remove the `env:` prefix to the variable.