### PR TITLE
Allow overriding daemon docker registry via env

### DIFF
--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -28,6 +28,7 @@ const (
 // Root creates a fresh arctl root command from Config.
 func Root(cfg Config) *cobra.Command {
 	cfg = cfg.withDefaults()
+	daemonConfig := daemonManagerConfig(cfg)
 
 	root := &cobra.Command{
 		Use:     cfg.Use,
@@ -74,7 +75,7 @@ func Root(cfg Config) *cobra.Command {
 	}
 	root.AddCommand(configure.NewCommand(deps))
 	root.AddCommand(internalcli.NewVersionCommand(deps))
-	root.AddCommand(clidaemon.NewCommand(dockercompose.NewManager(dockercompose.DefaultConfig())))
+	root.AddCommand(clidaemon.NewCommand(dockercompose.NewManager(daemonConfig)))
 	root.AddCommand(declarative.NewApplyCmd(deps))
 	root.AddCommand(declarative.NewGetCmd(deps))
 	root.AddCommand(declarative.NewDeleteCmd(deps))
@@ -96,6 +97,15 @@ func Root(cfg Config) *cobra.Command {
 	}
 
 	return root
+}
+
+func daemonManagerConfig(cfg Config) dockercompose.Config {
+	config := dockercompose.DefaultConfig()
+	if override := strings.TrimSpace(cfg.Env.Getenv("ARCTL_DAEMON_DOCKER_REGISTRY")); override != "" {
+		config.DockerRegistry = override
+	}
+
+	return config
 }
 
 func removeDisabledCommands(root *cobra.Command, disabled map[string]bool) {

--- a/pkg/cli/root_test.go
+++ b/pkg/cli/root_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/agentregistry-dev/agentregistry/internal/version"
 	dbmigrate "github.com/agentregistry-dev/agentregistry/pkg/cli/db/migrate"
 )
 
@@ -38,6 +39,36 @@ func TestRootDisabledCommandPathsPruneBuiltInsBeforeExtraCommands(t *testing.T) 
 	}
 	if migrateCmd.PersistentFlags().Lookup("source") == nil {
 		t.Fatal("expected db migrate --source flag for multiple migration sources")
+	}
+}
+
+type testEnv map[string]string
+
+func (e testEnv) Getenv(key string) string {
+	return e[key]
+}
+
+func TestDaemonManagerConfigUsesEnvOverride(t *testing.T) {
+	const override = "registry.example.com"
+
+	cfg := DefaultConfig()
+	cfg.Env = testEnv{
+		"ARCTL_DAEMON_DOCKER_REGISTRY": "  " + override + "  ",
+	}
+
+	daemonConfig := daemonManagerConfig(cfg)
+	if daemonConfig.DockerRegistry != override {
+		t.Fatalf("daemonManagerConfig() DockerRegistry = %q, want %q", daemonConfig.DockerRegistry, override)
+	}
+}
+
+func TestDaemonManagerConfigFallsBackToDefaultRegistry(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.Env = testEnv{}
+
+	daemonConfig := daemonManagerConfig(cfg)
+	if daemonConfig.DockerRegistry != version.DockerRegistry {
+		t.Fatalf("daemonManagerConfig() DockerRegistry = %q, want %q", daemonConfig.DockerRegistry, version.DockerRegistry)
 	}
 }
 


### PR DESCRIPTION
## Problem
`arctl daemon start` always initializes the compose manager with the default docker registry (`localhost:5001`) via `dockercompose.DefaultConfig()` so CI and non-local environments cannot point daemon image pulls to another registry without code changes.

## Root cause
In the root command wiring, the daemon manager was created with a fixed default config, and there was no environment-configurable override for `DockerRegistry` in this start path.

## Focused solution
Add a small helper in `pkg/cli/root.go` that reads `ARCTL_DAEMON_DOCKER_REGISTRY` from environment (trimmed) and applies it to the daemon compose config before constructing `clidaemon.NewCommand`.

The default behavior remains unchanged (`localhost:5001`) when the variable is unset.

### Files changed
- `pkg/cli/root.go`
- `pkg/cli/root_test.go`

### Tests added
- `TestDaemonManagerConfigUsesEnvOverride` (verifies whitespace-trimmed env override is applied)
- `TestDaemonManagerConfigFallsBackToDefaultRegistry` (verifies default remains `version.DockerRegistry` when unset)

## Validation
- `go test ./pkg/cli/...`
- `make build-cli`
- `./bin/arctl daemon start`

`./bin/arctl daemon start` and `ARCTL_DAEMON_DOCKER_REGISTRY=registry.example.com ./bin/arctl daemon start` are blocked in this environment because Docker daemon is not running, so both fail with:
`Cannot connect to the Docker daemon at ...` before registry resolution is reached.

## Issue
Fixes #553

## Known limitations
- This change adds environment support but does not add a dedicated CLI flag for override; only `ARCTL_DAEMON_DOCKER_REGISTRY` is supported in this patch.
