### PR TITLE
feat(model): cut over Agent model ownership

### DIFF
--- a/docs/auth/authz-matrix.md
+++ b/docs/auth/authz-matrix.md
@@ -31,7 +31,7 @@ These five kinds share the same endpoint shape. `{kind}` = `agent` | `server` | 
 
 ## Models
 
-Model is a tagged catalog kind. Each tag versions provider identity together with platform connection posture (auth strategy, endpoint, secret refs), allowing Deployments to pin the complete configuration they consume. Models are intended to be admin-writable, so a non-public provider should grant `Publish`/`Edit`/`Delete` on `model:{name}` to platform admins only. Secret values never live on the Model — only `SecretKeyRef` names — so `Read` does not expose key material.
+Model is a tagged catalog kind. Each tag versions provider identity together with platform connection posture (auth strategy, endpoint, secret refs), allowing Deployments to pin the complete configuration they consume. Models are intended to be admin-writable, so a non-public provider should grant `Publish`/`Edit`/`Delete` on `model:{name}` to platform admins only. Secret values never live on the Model — only `SecretKeyRef` names — so `Read` does not expose key material. A harness Agent Deployment that omits `spec.modelRef` selects `Model/<deployment namespace>/default@latest`; platform administrators therefore own both creation and mutation of each namespace's `default` Model.
 
 | Operation | HTTP | Required permissions | Notes |
 | --- | --- | --- | --- |

--- a/docs/declarative-cli.md
+++ b/docs/declarative-cli.md
@@ -14,9 +14,9 @@ arctl apply -f summarizer/agent.yaml
 
 ## Tags And Mutable Objects
 
-Agents, MCP servers, remote MCP servers, skills, and prompts are taggable artifacts. Set `metadata.tag` to publish a deterministic name you can reference from other manifests; if you omit it, the registry uses the literal `latest` tag.
+Agents, Models, MCP servers, remote MCP servers, skills, and prompts are taggable artifacts. Set `metadata.tag` to publish a deterministic name you can reference from other manifests; if you omit it, the registry uses the literal `latest` tag.
 
-Providers and deployments are mutable control-plane objects. They use public namespace/name identity, not tags or versions.
+Runtimes and Deployments are mutable control-plane objects. They use public namespace/name identity, not tags or versions.
 
 ```bash
 arctl init agent summarizer --framework adk --language python --model-provider gemini --model-name gemini-2.5-flash
@@ -46,6 +46,55 @@ arctl run --dry-run   # print the command without executing
 ```bash
 npx -y @modelcontextprotocol/inspector --server-url <url>
 ```
+
+## Models and harness deployment defaults
+
+Models are admin-owned tagged resources containing provider identity together
+with the platform's endpoint and authentication posture. A harness Agent
+Deployment can select a Model explicitly:
+
+```yaml
+spec:
+  targetRef:
+    kind: Agent
+    name: summarizer
+  runtimeRef:
+    kind: Runtime
+    name: agentcore
+  harness:
+    type: claude-code
+  modelRef:
+    name: claude-opus-4-8
+    tag: approved-v1
+```
+
+When `modelRef` is omitted from a harness Agent Deployment, the registry
+materializes `{name: default}` and resolves
+`Model/<deployment namespace>/default@latest`. An explicit `modelRef` always
+wins. Non-harness Agent and MCPServer Deployments do not receive an implicit
+Model.
+
+Platform administrators should create one `Model` named `default` in each
+namespace where deployment authors may rely on omission:
+
+```yaml
+apiVersion: ar.dev/v1alpha1
+kind: Model
+metadata:
+  name: default
+  # tag omitted: literal "latest"
+spec:
+  title: Namespace default model
+  provider: bedrock
+  model: us.anthropic.claude-opus-4-8
+  auth:
+    strategy: runtime
+```
+
+If that default does not exist, reference resolution rejects the Deployment
+with a `spec.modelRef` dangling-reference error. The registry never selects the
+first or only Model automatically, because catalog growth would make that
+behavior nondeterministic.
 
 ### Wiring MCP dependencies into a new agent
 

--- a/examples/agent.yaml
+++ b/examples/agent.yaml
@@ -7,8 +7,6 @@ spec:
     image: ghcr.io/acme/summarizer:v1.0.0
     # repository:                 # optional: link to source code
     #   url: https://github.com/acme/summarizer
-  modelProvider: gemini         # OpenAI | Anthropic | Gemini | AzureOpenAI | Agentgateway
-  modelName: gemini-2.5-flash
   description: "An agent that summarizes documents"
   # References to other registry resources -- resolved at deploy time:
   # mcpServers:

--- a/examples/full-stack.yaml
+++ b/examples/full-stack.yaml
@@ -56,9 +56,7 @@ metadata:
 spec:
   source:
     image: ghcr.io/acme/summarizer:v1.0.0
-  modelProvider: gemini
-  modelName: gemini-2.5-flash
-  description: "An agent that summarizes documents using Gemini"
+  description: "An agent that summarizes documents"
   # References to resources defined above -- resolved from the registry at deploy time.
   mcpServers:
     - kind: MCPServer

--- a/examples/model.yaml
+++ b/examples/model.yaml
@@ -1,10 +1,11 @@
-# Admin-owned model identity plus how the platform reaches and authenticates
-# to it.
+# Admin-owned namespace default for harness Agent deployments. When a harness
+# Deployment in this namespace omits spec.modelRef, the registry selects
+# Model/default@latest. Use an explicit modelRef to override this convention.
 apiVersion: ar.dev/v1alpha1
 kind: Model
 metadata:
-  name: claude-opus-4-8
-  tag: approved-v1
+  name: default
+  # tag omitted: stored and resolved as the literal "latest" tag
 spec:
   title: Claude Opus 4.8 (Bedrock)
   provider: bedrock

--- a/internal/cli/buildconfig/buildconfig.go
+++ b/internal/cli/buildconfig/buildconfig.go
@@ -16,8 +16,9 @@ const Filename = "arctl.yaml"
 // Config is the per-project build-config. Future fields are additive; older
 // arctl ignores unknown keys.
 type Config struct {
-	Framework string `yaml:"framework"`
-	Language  string `yaml:"language"`
+	Framework   string   `yaml:"framework"`
+	Language    string   `yaml:"language"`
+	RequiredEnv []string `yaml:"requiredEnv,omitempty"`
 	// Port is set for MCPServer projects to expose HTTP transport. arctl run
 	// maps it to the host and the MCP runtime binds 0.0.0.0:<port>.
 	Port int `yaml:"port,omitempty"`
@@ -25,6 +26,36 @@ type Config struct {
 	// "http" or "stdio". Empty for agent projects; empty on MCPServer is
 	// treated as "http" for back-compat.
 	Transport string `yaml:"transport,omitempty"`
+
+	// legacyModelProvider is populated only when reading an older arctl.yaml.
+	// It keeps existing generated projects' run-time credential validation
+	// working without serializing the removed provider/model configuration.
+	legacyModelProvider string
+}
+
+// UnmarshalYAML accepts historical modelProvider while keeping it outside the
+// current serialized Config shape. New projects use RequiredEnv directly.
+func (c *Config) UnmarshalYAML(value *yaml.Node) error {
+	type plainConfig Config
+	var decoded struct {
+		plainConfig   `yaml:",inline"`
+		ModelProvider string `yaml:"modelProvider"`
+	}
+	if err := value.Decode(&decoded); err != nil {
+		return err
+	}
+	*c = Config(decoded.plainConfig)
+	c.legacyModelProvider = decoded.ModelProvider
+	return nil
+}
+
+// LegacyModelProvider returns modelProvider from a historical arctl.yaml, if
+// present. It is a read-only compatibility input and is never serialized.
+func (c *Config) LegacyModelProvider() string {
+	if c == nil {
+		return ""
+	}
+	return c.legacyModelProvider
 }
 
 // Path returns the canonical arctl.yaml path under projectDir.

--- a/internal/cli/buildconfig/buildconfig.go
+++ b/internal/cli/buildconfig/buildconfig.go
@@ -16,10 +16,8 @@ const Filename = "arctl.yaml"
 // Config is the per-project build-config. Future fields are additive; older
 // arctl ignores unknown keys.
 type Config struct {
-	Framework     string `yaml:"framework"`
-	Language      string `yaml:"language"`
-	ModelProvider string `yaml:"modelProvider,omitempty"`
-	ModelName     string `yaml:"modelName,omitempty"`
+	Framework string `yaml:"framework"`
+	Language  string `yaml:"language"`
 	// Port is set for MCPServer projects to expose HTTP transport. arctl run
 	// maps it to the host and the MCP runtime binds 0.0.0.0:<port>.
 	Port int `yaml:"port,omitempty"`

--- a/internal/cli/buildconfig/buildconfig.go
+++ b/internal/cli/buildconfig/buildconfig.go
@@ -26,36 +26,6 @@ type Config struct {
 	// "http" or "stdio". Empty for agent projects; empty on MCPServer is
 	// treated as "http" for back-compat.
 	Transport string `yaml:"transport,omitempty"`
-
-	// legacyModelProvider is populated only when reading an older arctl.yaml.
-	// It keeps existing generated projects' run-time credential validation
-	// working without serializing the removed provider/model configuration.
-	legacyModelProvider string
-}
-
-// UnmarshalYAML accepts historical modelProvider while keeping it outside the
-// current serialized Config shape. New projects use RequiredEnv directly.
-func (c *Config) UnmarshalYAML(value *yaml.Node) error {
-	type plainConfig Config
-	var decoded struct {
-		plainConfig   `yaml:",inline"`
-		ModelProvider string `yaml:"modelProvider"`
-	}
-	if err := value.Decode(&decoded); err != nil {
-		return err
-	}
-	*c = Config(decoded.plainConfig)
-	c.legacyModelProvider = decoded.ModelProvider
-	return nil
-}
-
-// LegacyModelProvider returns modelProvider from a historical arctl.yaml, if
-// present. It is a read-only compatibility input and is never serialized.
-func (c *Config) LegacyModelProvider() string {
-	if c == nil {
-		return ""
-	}
-	return c.legacyModelProvider
 }
 
 // Path returns the canonical arctl.yaml path under projectDir.

--- a/internal/cli/buildconfig/buildconfig_test.go
+++ b/internal/cli/buildconfig/buildconfig_test.go
@@ -12,10 +12,8 @@ import (
 func TestWriteAndRead_RoundTrip(t *testing.T) {
 	dir := t.TempDir()
 	cfg := &Config{
-		Framework:     "adk",
-		Language:      "python",
-		ModelProvider: "openai",
-		ModelName:     "gpt-4",
+		Framework: "adk",
+		Language:  "python",
 	}
 	require.NoError(t, Write(dir, cfg))
 
@@ -23,23 +21,21 @@ func TestWriteAndRead_RoundTrip(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, cfg.Framework, got.Framework)
 	assert.Equal(t, cfg.Language, got.Language)
-	assert.Equal(t, cfg.ModelProvider, got.ModelProvider)
-	assert.Equal(t, cfg.ModelName, got.ModelName)
 }
 
-func TestWriteAndRead_OmitsEmptyModelFields(t *testing.T) {
+func TestRead_IgnoresLegacyModelFields(t *testing.T) {
 	dir := t.TempDir()
-	require.NoError(t, Write(dir, &Config{Framework: "fastmcp", Language: "python"}))
-
-	data, err := os.ReadFile(filepath.Join(dir, "arctl.yaml"))
-	require.NoError(t, err)
-	assert.NotContains(t, string(data), "modelProvider")
-	assert.NotContains(t, string(data), "modelName")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, Filename), []byte(`
+framework: adk
+language: python
+modelProvider: openai
+modelName: gpt-4o
+`), 0o644))
 
 	got, err := Read(dir)
 	require.NoError(t, err)
-	assert.Empty(t, got.ModelProvider)
-	assert.Empty(t, got.ModelName)
+	assert.Equal(t, "adk", got.Framework)
+	assert.Equal(t, "python", got.Language)
 }
 
 func TestRead_MissingFileErrs(t *testing.T) {

--- a/internal/cli/buildconfig/buildconfig_test.go
+++ b/internal/cli/buildconfig/buildconfig_test.go
@@ -25,7 +25,7 @@ func TestWriteAndRead_RoundTrip(t *testing.T) {
 	assert.Equal(t, cfg.RequiredEnv, got.RequiredEnv)
 }
 
-func TestRead_AcceptsLegacyModelFieldsWithoutRewritingThem(t *testing.T) {
+func TestRead_IgnoresRemovedModelFieldsWithoutRewritingThem(t *testing.T) {
 	dir := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(dir, Filename), []byte(`
 framework: adk
@@ -38,7 +38,6 @@ modelName: gpt-4o
 	require.NoError(t, err)
 	assert.Equal(t, "adk", got.Framework)
 	assert.Equal(t, "python", got.Language)
-	assert.Equal(t, "openai", got.LegacyModelProvider())
 
 	require.NoError(t, Write(dir, got))
 	data, err := os.ReadFile(filepath.Join(dir, Filename))

--- a/internal/cli/buildconfig/buildconfig_test.go
+++ b/internal/cli/buildconfig/buildconfig_test.go
@@ -12,8 +12,9 @@ import (
 func TestWriteAndRead_RoundTrip(t *testing.T) {
 	dir := t.TempDir()
 	cfg := &Config{
-		Framework: "adk",
-		Language:  "python",
+		Framework:   "adk",
+		Language:    "python",
+		RequiredEnv: []string{"GOOGLE_API_KEY"},
 	}
 	require.NoError(t, Write(dir, cfg))
 
@@ -21,9 +22,10 @@ func TestWriteAndRead_RoundTrip(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, cfg.Framework, got.Framework)
 	assert.Equal(t, cfg.Language, got.Language)
+	assert.Equal(t, cfg.RequiredEnv, got.RequiredEnv)
 }
 
-func TestRead_IgnoresLegacyModelFields(t *testing.T) {
+func TestRead_AcceptsLegacyModelFieldsWithoutRewritingThem(t *testing.T) {
 	dir := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(dir, Filename), []byte(`
 framework: adk
@@ -36,6 +38,13 @@ modelName: gpt-4o
 	require.NoError(t, err)
 	assert.Equal(t, "adk", got.Framework)
 	assert.Equal(t, "python", got.Language)
+	assert.Equal(t, "openai", got.LegacyModelProvider())
+
+	require.NoError(t, Write(dir, got))
+	data, err := os.ReadFile(filepath.Join(dir, Filename))
+	require.NoError(t, err)
+	assert.NotContains(t, string(data), "modelProvider")
+	assert.NotContains(t, string(data), "modelName")
 }
 
 func TestRead_MissingFileErrs(t *testing.T) {

--- a/internal/cli/declarative/apply_test.go
+++ b/internal/cli/declarative/apply_test.go
@@ -29,8 +29,6 @@ spec:
   description: "A bot"
   language: python
   framework: adk
-  modelProvider: google
-  modelName: gemini-2.0-flash
 `
 
 // batchApplyResponse builds a JSON body matching the POST /v0/apply response shape.

--- a/internal/cli/declarative/build_test.go
+++ b/internal/cli/declarative/build_test.go
@@ -121,8 +121,6 @@ spec:
   image: localhost:5001/my-agent:latest
   language: python
   framework: adk
-  modelProvider: gemini
-  modelName: gemini-2.0-flash
   description: test agent
 `)
 	cmd := declarative.NewBuildCmd(declarativeTestDeps(nil))

--- a/internal/cli/declarative/declarative.go
+++ b/internal/cli/declarative/declarative.go
@@ -50,7 +50,7 @@ func init() {
 	scheme.Register(typedKind(
 		"agent", "agents", []string{"Agent"},
 		[]scheme.Column{
-			{Header: "NAME"}, {Header: "TAG"},
+			{Header: "NAME"}, {Header: "TAG"}, {Header: "MODE"}, {Header: "DESCRIPTION"},
 		},
 		v1alpha1.KindAgent,
 		func() *v1alpha1.Agent { return &v1alpha1.Agent{} },

--- a/internal/cli/declarative/declarative.go
+++ b/internal/cli/declarative/declarative.go
@@ -51,7 +51,6 @@ func init() {
 		"agent", "agents", []string{"Agent"},
 		[]scheme.Column{
 			{Header: "NAME"}, {Header: "TAG"},
-			{Header: "PROVIDER"}, {Header: "MODEL"},
 		},
 		v1alpha1.KindAgent,
 		func() *v1alpha1.Agent { return &v1alpha1.Agent{} },

--- a/internal/cli/declarative/get_test.go
+++ b/internal/cli/declarative/get_test.go
@@ -49,7 +49,7 @@ func TestGetCmd_NoAPIClientErrors(t *testing.T) {
 func TestGetCmd_RegistryDrivenColumnLookup(t *testing.T) {
 	k, err := scheme.Lookup("agents")
 	require.NoError(t, err, "agents alias should resolve via declarative's init() registration")
-	assert.NotEmpty(t, k.TableColumns, "expected TableColumns on the agent kind")
+	assert.Equal(t, []scheme.Column{{Header: "NAME"}, {Header: "TAG"}}, k.TableColumns)
 
 	// Looking up a valid kind should get past kind validation and fail
 	// only at runtime setup — confirming the dispatch ran.

--- a/internal/cli/declarative/get_test.go
+++ b/internal/cli/declarative/get_test.go
@@ -49,7 +49,9 @@ func TestGetCmd_NoAPIClientErrors(t *testing.T) {
 func TestGetCmd_RegistryDrivenColumnLookup(t *testing.T) {
 	k, err := scheme.Lookup("agents")
 	require.NoError(t, err, "agents alias should resolve via declarative's init() registration")
-	assert.Equal(t, []scheme.Column{{Header: "NAME"}, {Header: "TAG"}}, k.TableColumns)
+	assert.Equal(t, []scheme.Column{
+		{Header: "NAME"}, {Header: "TAG"}, {Header: "MODE"}, {Header: "DESCRIPTION"},
+	}, k.TableColumns)
 
 	// Looking up a valid kind should get past kind validation and fail
 	// only at runtime setup — confirming the dispatch ran.

--- a/internal/cli/declarative/init.go
+++ b/internal/cli/declarative/init.go
@@ -242,10 +242,12 @@ init and add an MCP_SERVERS_CONFIG entry, e.g.:
 				image = fmt.Sprintf("%s/%s:latest", registry, name)
 			}
 
-			// Resolve provider + model name once, then thread the resolved
-			// values into templates, arctl.yaml, and agent.yaml so all three
-			// agree. Provider comes from --model-provider flag; otherwise the
-			// interactive picker if a TTY is available; otherwise "gemini".
+			// Resolve provider + model name once for source-template generation.
+			// Runtime model selection belongs to Deployment.spec.modelRef, so
+			// these scaffold inputs are deliberately not persisted in
+			// arctl.yaml or agent.yaml. Provider comes from --model-provider
+			// flag; otherwise the interactive picker if a TTY is available;
+			// otherwise "gemini".
 			// User-cancel propagates as an error; TTY-unavailable falls back
 			// silently so tests and headless runs continue to work.
 			provider := initModelProvider
@@ -278,10 +280,8 @@ init and add an MCP_SERVERS_CONFIG entry, e.g.:
 			}
 
 			cfg := &buildconfig.Config{
-				Framework:     framework.Framework,
-				Language:      framework.Language,
-				ModelProvider: provider,
-				ModelName:     modelName,
+				Framework: framework.Framework,
+				Language:  framework.Language,
 			}
 			if err := buildconfig.Write(projectDir, cfg); err != nil {
 				return fmt.Errorf("write arctl.yaml: %w", err)
@@ -332,7 +332,6 @@ init and add an MCP_SERVERS_CONFIG entry, e.g.:
 			// language/framework now live in arctl.yaml only. The declarative
 			// agent.yaml carries only canonical AgentSpec fields.
 			if err := writeDeclarativeAgentYAML(projectDir, name, image,
-				provider, modelName,
 				initDescription, initGit, initGitBranch, initGitCommit, initMCPs); err != nil {
 				return fmt.Errorf("write agent.yaml: %w", err)
 			}
@@ -568,7 +567,7 @@ func parseNameVersion(s string) (string, string) {
 // metadata.tag is intentionally omitted — tagging is a publish-time concern.
 // The server stores untagged applies as the literal "latest"; users who want
 // a deterministic tag set it on the YAML by hand before `arctl apply`.
-func writeDeclarativeAgentYAML(projectDir, name, image, modelProvider, modelName, description, gitURL, gitBranch, gitCommit string, mcps []string) error {
+func writeDeclarativeAgentYAML(projectDir, name, image, description, gitURL, gitBranch, gitCommit string, mcps []string) error {
 	desc := description
 	if desc == "" {
 		desc = fmt.Sprintf("%s agent", name)
@@ -583,9 +582,7 @@ func writeDeclarativeAgentYAML(projectDir, name, image, modelProvider, modelName
 			Name: name,
 		},
 		Spec: v1alpha1.AgentSpec{
-			ModelProvider: modelProvider,
-			ModelName:     modelName,
-			Description:   desc,
+			Description: desc,
 			Source: &v1alpha1.AgentSource{
 				Image: image,
 			},

--- a/internal/cli/declarative/init.go
+++ b/internal/cli/declarative/init.go
@@ -279,19 +279,22 @@ init and add an MCP_SERVERS_CONFIG entry, e.g.:
 				return fmt.Errorf("render templates: %w", err)
 			}
 
+			// Required env = framework's infra keys + project-specific model
+			// provider keys. Persist only the project additions as a generic
+			// source-run concern without retaining provider/model ownership in
+			// arctl.yaml.
+			projectRequired := ModelProviderEnvKeys(provider)
+			required := append([]string{}, framework.Env.Required...)
+			required = append(required, projectRequired...)
+
 			cfg := &buildconfig.Config{
-				Framework: framework.Framework,
-				Language:  framework.Language,
+				Framework:   framework.Framework,
+				Language:    framework.Language,
+				RequiredEnv: projectRequired,
 			}
 			if err := buildconfig.Write(projectDir, cfg); err != nil {
 				return fmt.Errorf("write arctl.yaml: %w", err)
 			}
-
-			// Required env = framework's infra keys + model provider's keys.
-			// arctl owns the provider→keys map (see modelenv.go) so frameworks
-			// don't have to restate it.
-			required := append([]string{}, framework.Env.Required...)
-			required = append(required, ModelProviderEnvKeys(provider)...)
 
 			if err := buildconfig.WriteDotEnv(projectDir, required, framework.Env.Optional); err != nil {
 				return fmt.Errorf("write .env: %w", err)

--- a/internal/cli/declarative/init_test.go
+++ b/internal/cli/declarative/init_test.go
@@ -47,6 +47,7 @@ func TestInitAgent_WritesYAMLAndArctlAndDotEnv(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "adk", cfg.Framework)
 	assert.Equal(t, "python", cfg.Language)
+	assert.Equal(t, []string{"GOOGLE_API_KEY"}, cfg.RequiredEnv)
 
 	spec := readYAMLFile(t, filepath.Join(projectDir, "agent.yaml"))["spec"].(map[string]any)
 	assert.NotContains(t, spec, "modelProvider")

--- a/internal/cli/declarative/init_test.go
+++ b/internal/cli/declarative/init_test.go
@@ -42,12 +42,15 @@ func TestInitAgent_WritesYAMLAndArctlAndDotEnv(t *testing.T) {
 	_, err = os.Stat(filepath.Join(projectDir, "agent.yaml"))
 	require.NoError(t, err)
 
-	// arctl.yaml written with framework + language + default model fields
+	// arctl.yaml carries only source-build concerns.
 	cfg, err := buildconfig.Read(projectDir)
 	require.NoError(t, err)
 	assert.Equal(t, "adk", cfg.Framework)
 	assert.Equal(t, "python", cfg.Language)
-	assert.Equal(t, "gemini", cfg.ModelProvider)
+
+	spec := readYAMLFile(t, filepath.Join(projectDir, "agent.yaml"))["spec"].(map[string]any)
+	assert.NotContains(t, spec, "modelProvider")
+	assert.NotContains(t, spec, "modelName")
 
 	// .env written directly (no cp step needed)
 	_, err = os.Stat(filepath.Join(projectDir, ".env"))
@@ -106,33 +109,71 @@ func TestInitAgent_OutputDirFlag(t *testing.T) {
 	assert.True(t, os.IsNotExist(err), "project should NOT be in cwd")
 }
 
-func TestInitAgent_ModelProviderFlagFlowsToArctlYAML(t *testing.T) {
-	tmp := t.TempDir()
+func TestInitAgent_ModelFlagsRemainScaffoldOnly(t *testing.T) {
 	origDir, err := os.Getwd()
 	require.NoError(t, err)
-	require.NoError(t, os.Chdir(tmp))
 	defer func() { _ = os.Chdir(origDir) }()
 
-	cmd := declarative.NewInitCmd(declarativeTestDeps(nil))
-	cmd.SetArgs([]string{
-		"agent", "openaibot",
-		"--framework", "adk", "--language", "python",
-		"--model-provider", "openai",
-		"--model-name", "gpt4",
-	})
-	require.NoError(t, cmd.Execute())
+	tests := []struct {
+		provider   string
+		model      string
+		sourceText string
+		envKey     string
+	}{
+		{provider: "gemini", model: "gemini-test", sourceText: `return "gemini-test"`, envKey: "GOOGLE_API_KEY="},
+		{provider: "openai", model: "gpt-test", sourceText: `LiteLlm(model="openai/gpt-test")`, envKey: "OPENAI_API_KEY="},
+		{provider: "anthropic", model: "claude-test", sourceText: `LiteLlm(model="anthropic/claude-test")`, envKey: "ANTHROPIC_API_KEY="},
+		{provider: "bedrock", model: "bedrock-test", sourceText: `BedrockClaude(model="bedrock-test")`, envKey: "AWS_ACCESS_KEY_ID="},
+		{provider: "agentgateway", model: "gateway-test", sourceText: `model="gateway-test"`, envKey: ""},
+	}
 
-	projectDir := filepath.Join(tmp, "openaibot")
+	for _, tt := range tests {
+		t.Run(tt.provider, func(t *testing.T) {
+			tmp := t.TempDir()
+			require.NoError(t, os.Chdir(tmp))
 
-	cfg, err := buildconfig.Read(projectDir)
-	require.NoError(t, err)
-	assert.Equal(t, "openai", cfg.ModelProvider)
-	assert.Equal(t, "gpt4", cfg.ModelName)
+			projectName := tt.provider + "bot"
+			cmd := declarative.NewInitCmd(declarativeTestDeps(nil))
+			cmd.SetArgs([]string{
+				"agent", projectName,
+				"--framework", "adk", "--language", "python",
+				"--model-provider", tt.provider,
+				"--model-name", tt.model,
+			})
+			require.NoError(t, cmd.Execute())
 
-	// agent.yaml still mirrors model fields for the registry side
-	spec := readYAMLFile(t, filepath.Join(projectDir, "agent.yaml"))["spec"].(map[string]any)
-	assert.Equal(t, "openai", spec["modelProvider"])
-	assert.Equal(t, "gpt4", spec["modelName"])
+			projectDir := filepath.Join(tmp, projectName)
+
+			// Every existing provider/model choice still drives its generated
+			// source template and local compose wiring.
+			agentSource, err := os.ReadFile(filepath.Join(projectDir, projectName, "agent.py"))
+			require.NoError(t, err)
+			assert.Contains(t, string(agentSource), tt.sourceText)
+
+			dotEnv, err := os.ReadFile(filepath.Join(projectDir, ".env"))
+			require.NoError(t, err)
+			if tt.envKey != "" {
+				assert.Contains(t, string(dotEnv), tt.envKey)
+			}
+
+			compose, err := os.ReadFile(filepath.Join(projectDir, "docker-compose.yaml"))
+			require.NoError(t, err)
+			assert.Contains(t, string(compose), "MODEL_PROVIDER="+tt.provider)
+			assert.Contains(t, string(compose), "MODEL_NAME="+tt.model)
+
+			// The selection is a source-scaffold concern only. Runtime model
+			// authority is Deployment.spec.modelRef, so neither persistent
+			// config surface keeps the deprecated Agent-owned values.
+			arctlYAML, err := os.ReadFile(filepath.Join(projectDir, "arctl.yaml"))
+			require.NoError(t, err)
+			assert.NotContains(t, string(arctlYAML), "modelProvider")
+			assert.NotContains(t, string(arctlYAML), "modelName")
+
+			spec := readYAMLFile(t, filepath.Join(projectDir, "agent.yaml"))["spec"].(map[string]any)
+			assert.NotContains(t, spec, "modelProvider")
+			assert.NotContains(t, spec, "modelName")
+		})
+	}
 }
 
 // ---- init mcp ----

--- a/internal/cli/declarative/resources.go
+++ b/internal/cli/declarative/resources.go
@@ -140,8 +140,6 @@ func agentRow(agent *v1alpha1.Agent) []string {
 	return []string{
 		printer.TruncateString(agent.Metadata.Name, 40),
 		agent.Metadata.Tag,
-		printer.EmptyValueOrDefault(agent.Spec.ModelProvider, "<none>"),
-		printer.TruncateString(printer.EmptyValueOrDefault(agent.Spec.ModelName, "<none>"), 30),
 	}
 }
 

--- a/internal/cli/declarative/resources.go
+++ b/internal/cli/declarative/resources.go
@@ -140,6 +140,23 @@ func agentRow(agent *v1alpha1.Agent) []string {
 	return []string{
 		printer.TruncateString(agent.Metadata.Name, 40),
 		agent.Metadata.Tag,
+		agentDisplayMode(agent.Spec),
+		printer.TruncateString(printer.EmptyValueOrDefault(agent.Spec.Description, "<none>"), 60),
+	}
+}
+
+func agentDisplayMode(spec v1alpha1.AgentSpec) string {
+	hasSource := spec.Source != nil && (spec.Source.Image != "" || spec.Source.Repository != nil)
+	hasHarness := len(spec.CompatibleHarnesses) > 0
+	switch {
+	case hasSource && hasHarness:
+		return "source+harness"
+	case hasSource:
+		return "source"
+	case hasHarness:
+		return "harness"
+	default:
+		return "<none>"
 	}
 }
 

--- a/internal/cli/declarative/resources_test.go
+++ b/internal/cli/declarative/resources_test.go
@@ -1,0 +1,81 @@
+package declarative
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/agentregistry-dev/agentregistry/pkg/api/v1alpha1"
+)
+
+func TestAgentDisplayMode(t *testing.T) {
+	tests := []struct {
+		name string
+		spec v1alpha1.AgentSpec
+		want string
+	}{
+		{
+			name: "no runnable mode",
+			want: "<none>",
+		},
+		{
+			name: "empty source is not a runnable mode",
+			spec: v1alpha1.AgentSpec{Source: &v1alpha1.AgentSource{}},
+			want: "<none>",
+		},
+		{
+			name: "image source",
+			spec: v1alpha1.AgentSpec{
+				Source: &v1alpha1.AgentSource{Image: "ghcr.io/example/agent:v1"},
+			},
+			want: "source",
+		},
+		{
+			name: "repository source",
+			spec: v1alpha1.AgentSpec{
+				Source: &v1alpha1.AgentSource{
+					Repository: &v1alpha1.Repository{URL: "https://github.com/example/agent"},
+				},
+			},
+			want: "source",
+		},
+		{
+			name: "harness compatibility",
+			spec: v1alpha1.AgentSpec{
+				CompatibleHarnesses: []v1alpha1.HarnessCompatibility{{Type: "claude-code"}},
+			},
+			want: "harness",
+		},
+		{
+			name: "source and harness compatibility",
+			spec: v1alpha1.AgentSpec{
+				Source:              &v1alpha1.AgentSource{Image: "ghcr.io/example/agent:v1"},
+				CompatibleHarnesses: []v1alpha1.HarnessCompatibility{{Type: "claude-code"}},
+			},
+			want: "source+harness",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := agentDisplayMode(tt.spec); got != tt.want {
+				t.Fatalf("agentDisplayMode() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAgentRowIncludesModeAndDescription(t *testing.T) {
+	agent := &v1alpha1.Agent{
+		Metadata: v1alpha1.ObjectMeta{Name: "reviewer", Tag: "stable"},
+		Spec: v1alpha1.AgentSpec{
+			Description:         "Reviews pull requests",
+			Source:              &v1alpha1.AgentSource{Image: "ghcr.io/example/reviewer:v1"},
+			CompatibleHarnesses: []v1alpha1.HarnessCompatibility{{Type: "codex"}},
+		},
+	}
+
+	want := []string{"reviewer", "stable", "source+harness", "Reviews pull requests"}
+	if got := agentRow(agent); !reflect.DeepEqual(got, want) {
+		t.Fatalf("agentRow() = %#v, want %#v", got, want)
+	}
+}

--- a/internal/cli/declarative/run.go
+++ b/internal/cli/declarative/run.go
@@ -171,9 +171,6 @@ func runProject(ctx context.Context, out io.Writer, projectDir string, extraEnv 
 	}
 
 	required := append([]string(nil), p.Env.Required...)
-	if frameworkType == "agent" && cfg.ModelProvider != "" {
-		required = append(required, ModelProviderEnvKeys(cfg.ModelProvider)...)
-	}
 	if err := ValidateRequiredEnv(dotEnv, extraEnv, required); err != nil {
 		return err
 	}

--- a/internal/cli/declarative/run.go
+++ b/internal/cli/declarative/run.go
@@ -172,9 +172,6 @@ func runProject(ctx context.Context, out io.Writer, projectDir string, extraEnv 
 
 	required := append([]string(nil), p.Env.Required...)
 	required = append(required, cfg.RequiredEnv...)
-	if frameworkType == "agent" && len(cfg.RequiredEnv) == 0 && cfg.LegacyModelProvider() != "" {
-		required = append(required, ModelProviderEnvKeys(cfg.LegacyModelProvider())...)
-	}
 	if err := ValidateRequiredEnv(dotEnv, extraEnv, required); err != nil {
 		return err
 	}

--- a/internal/cli/declarative/run.go
+++ b/internal/cli/declarative/run.go
@@ -171,6 +171,10 @@ func runProject(ctx context.Context, out io.Writer, projectDir string, extraEnv 
 	}
 
 	required := append([]string(nil), p.Env.Required...)
+	required = append(required, cfg.RequiredEnv...)
+	if frameworkType == "agent" && len(cfg.RequiredEnv) == 0 && cfg.LegacyModelProvider() != "" {
+		required = append(required, ModelProviderEnvKeys(cfg.LegacyModelProvider())...)
+	}
 	if err := ValidateRequiredEnv(dotEnv, extraEnv, required); err != nil {
 		return err
 	}

--- a/internal/cli/declarative/run_test.go
+++ b/internal/cli/declarative/run_test.go
@@ -55,29 +55,6 @@ func TestRun_AgentScaffoldStillRequiresProviderEnv(t *testing.T) {
 	require.Contains(t, err.Error(), "GOOGLE_API_KEY")
 }
 
-func TestRun_LegacyAgentConfigStillRequiresProviderEnv(t *testing.T) {
-	t.Setenv("OPENAI_API_KEY", "")
-	tmp := t.TempDir()
-	require.NoError(t, os.WriteFile(filepath.Join(tmp, "arctl.yaml"), []byte(`
-framework: adk
-language: python
-modelProvider: openai
-modelName: gpt-4o
-`), 0o644))
-	require.NoError(t, os.WriteFile(filepath.Join(tmp, ".env"), []byte("OPENAI_API_KEY=\n"), 0o644))
-
-	cwd, err := os.Getwd()
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = os.Chdir(cwd) })
-	require.NoError(t, os.Chdir(tmp))
-
-	cmd := declarative.NewRunCmd(declarativeTestDeps(nil))
-	cmd.SetArgs([]string{"--dry-run"})
-	err = cmd.Execute()
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "OPENAI_API_KEY")
-}
-
 // TestRun_ChatDefault_DryRunNarratesFullLifecycle verifies that for an Agent
 // kind, `arctl run --dry-run` reaches the chat-default branch and narrates
 // the detached compose-up, readiness wait, chat launch, and teardown without

--- a/internal/cli/declarative/run_test.go
+++ b/internal/cli/declarative/run_test.go
@@ -35,6 +35,49 @@ func TestRun_DispatchesToFrameworkRunCommand(t *testing.T) {
 	require.NoError(t, cmd.Execute())
 }
 
+func TestRun_AgentScaffoldStillRequiresProviderEnv(t *testing.T) {
+	t.Setenv("GOOGLE_API_KEY", "")
+	tmp := t.TempDir()
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.Chdir(cwd) })
+
+	require.NoError(t, os.Chdir(tmp))
+	initCmd := declarative.NewInitCmd(declarativeTestDeps(nil))
+	initCmd.SetArgs([]string{"agent", "myagent", "--framework", "adk", "--language", "python"})
+	require.NoError(t, initCmd.Execute())
+
+	require.NoError(t, os.Chdir(filepath.Join(tmp, "myagent")))
+	cmd := declarative.NewRunCmd(declarativeTestDeps(nil))
+	cmd.SetArgs([]string{"--dry-run"})
+	err = cmd.Execute()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "GOOGLE_API_KEY")
+}
+
+func TestRun_LegacyAgentConfigStillRequiresProviderEnv(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "")
+	tmp := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(tmp, "arctl.yaml"), []byte(`
+framework: adk
+language: python
+modelProvider: openai
+modelName: gpt-4o
+`), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(tmp, ".env"), []byte("OPENAI_API_KEY=\n"), 0o644))
+
+	cwd, err := os.Getwd()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.Chdir(cwd) })
+	require.NoError(t, os.Chdir(tmp))
+
+	cmd := declarative.NewRunCmd(declarativeTestDeps(nil))
+	cmd.SetArgs([]string{"--dry-run"})
+	err = cmd.Execute()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "OPENAI_API_KEY")
+}
+
 // TestRun_ChatDefault_DryRunNarratesFullLifecycle verifies that for an Agent
 // kind, `arctl run --dry-run` reaches the chat-default branch and narrates
 // the detached compose-up, readiness wait, chat launch, and teardown without

--- a/internal/cli/frameworks/builtin/adk-python/framework.yaml
+++ b/internal/cli/frameworks/builtin/adk-python/framework.yaml
@@ -6,8 +6,8 @@ language: python
 description: Google Agent Development Kit (Python)
 templatesDir: ./templates
 env:
-  # Model-provider keys are computed by arctl from spec.modelProvider; the
-  # plugin only declares its infra/framework env (none for adk-python today).
+  # Model-provider keys are computed by arctl from the init scaffold choice;
+  # the plugin only declares its infra/framework env (none for adk-python today).
   optional:
     - LOG_LEVEL
 build:

--- a/internal/registry/registry_app_integration_test.go
+++ b/internal/registry/registry_app_integration_test.go
@@ -107,7 +107,7 @@ func TestBuildStores_PropagatesAuditor(t *testing.T) {
 	_, err := agentStore.Upsert(t.Context(), &v1alpha1.Agent{
 		TypeMeta: v1alpha1.TypeMeta{APIVersion: v1alpha1.GroupVersion, Kind: v1alpha1.KindAgent},
 		Metadata: v1alpha1.ObjectMeta{Namespace: v1alpha1.DefaultNamespace, Name: "audited"},
-		Spec:     v1alpha1.AgentSpec{ModelName: "model-a"},
+		Spec:     v1alpha1.AgentSpec{Title: "Audited Agent"},
 	})
 	require.NoError(t, err)
 

--- a/internal/registry/runtimes/kubernetes/adapter.go
+++ b/internal/registry/runtimes/kubernetes/adapter.go
@@ -157,6 +157,10 @@ func (a *kubernetesDeploymentAdapter) buildDesiredStateFromV1Alpha1(
 		if in.Runtime != nil {
 			telemetryEndpoint = in.Runtime.Spec.TelemetryEndpoint
 		}
+		model, err := utils.ResolveDeploymentModelSpec(ctx, in.Deployment, in.Getter)
+		if err != nil {
+			return nil, err
+		}
 		agent, servers, err := utils.SpecToRuntimeAgent(ctx, target.Metadata, target.Spec, utils.AgentTranslateOpts{
 			DeploymentID:      deploymentID,
 			Namespace:         namespace,
@@ -164,6 +168,7 @@ func (a *kubernetesDeploymentAdapter) buildDesiredStateFromV1Alpha1(
 			DeploymentEnv:     envValues,
 			TelemetryEndpoint: telemetryEndpoint,
 			HeaderValues:      headerValues,
+			Model:             model,
 			Getter:            in.Getter,
 		})
 		if err != nil {

--- a/internal/registry/runtimes/kubernetes/adapter_test.go
+++ b/internal/registry/runtimes/kubernetes/adapter_test.go
@@ -94,6 +94,52 @@ func TestK8sV1Alpha1Apply_MCPServerTarget_CreatesResource(t *testing.T) {
 	}
 }
 
+func TestBuildDesiredState_AgentUsesResolvedModel(t *testing.T) {
+	adapter := NewKubernetesDeploymentAdapter()
+	deployment := &v1alpha1.Deployment{
+		Metadata: v1alpha1.ObjectMeta{Namespace: "team-a", Name: "assistant-kube"},
+		Spec: v1alpha1.DeploymentSpec{
+			ModelRef: &v1alpha1.ModelRef{Name: "approved-model"},
+			Env: map[string]string{
+				"MODEL_PROVIDER": "deployment-provider",
+				"MODEL_NAME":     "deployment-model",
+			},
+		},
+	}
+	target := &v1alpha1.Agent{
+		Metadata: v1alpha1.ObjectMeta{Namespace: "team-a", Name: "assistant", Tag: "stable"},
+		Spec:     v1alpha1.AgentSpec{Source: &v1alpha1.AgentSource{Image: "ghcr.io/example/assistant:v1"}},
+	}
+	var gotRef v1alpha1.ResourceRef
+	desired, err := adapter.buildDesiredStateFromV1Alpha1(t.Context(), adapterpkgtypes.ApplyInput{
+		Deployment: deployment,
+		Target:     target,
+		Getter: func(_ context.Context, ref v1alpha1.ResourceRef) (v1alpha1.Object, error) {
+			gotRef = ref
+			return &v1alpha1.Model{
+				Spec: v1alpha1.ModelSpec{
+					Provider: v1alpha1.ModelProviderBedrock,
+					Model:    "us.anthropic.claude-sonnet-4-6",
+				},
+			}, nil
+		},
+	}, "kagent")
+	if err != nil {
+		t.Fatalf("buildDesiredStateFromV1Alpha1: %v", err)
+	}
+	if gotRef.Namespace != "team-a" || gotRef.Name != "approved-model" || gotRef.Tag != "latest" {
+		t.Fatalf("resolved ref = %+v", gotRef)
+	}
+	if len(desired.Agents) != 1 {
+		t.Fatalf("agents = %+v", desired.Agents)
+	}
+	env := desired.Agents[0].Deployment.Env
+	if env["MODEL_PROVIDER"] != v1alpha1.ModelProviderBedrock ||
+		env["MODEL_NAME"] != "us.anthropic.claude-sonnet-4-6" {
+		t.Fatalf("model env = %+v", env)
+	}
+}
+
 func TestK8sV1Alpha1Remove_DeletesResourcesByDeploymentID(t *testing.T) {
 	// Seed the fake client with an Agent + MCPServer labeled for our deployment.
 	deploymentID := "weather-kube"

--- a/internal/registry/runtimes/local/adapter.go
+++ b/internal/registry/runtimes/local/adapter.go
@@ -159,12 +159,17 @@ func (a *localDeploymentAdapter) buildDesiredStateFromV1Alpha1(
 		if in.Runtime != nil {
 			telemetryEndpoint = in.Runtime.Spec.TelemetryEndpoint
 		}
+		model, err := utils.ResolveDeploymentModelSpec(ctx, in.Deployment, in.Getter)
+		if err != nil {
+			return nil, err
+		}
 		agent, servers, err := utils.SpecToRuntimeAgent(ctx, target.Metadata, target.Spec, utils.AgentTranslateOpts{
 			DeploymentID:      deploymentID,
 			KagentURL:         "http://localhost",
 			DeploymentEnv:     envValues,
 			TelemetryEndpoint: telemetryEndpoint,
 			HeaderValues:      headerValues,
+			Model:             model,
 			Getter:            in.Getter,
 		})
 		if err != nil {

--- a/internal/registry/runtimes/local/adapter_test.go
+++ b/internal/registry/runtimes/local/adapter_test.go
@@ -105,6 +105,52 @@ func TestV1Alpha1Apply_MCPServerTarget_WritesComposeAndMarksProgressing(t *testi
 	}
 }
 
+func TestBuildDesiredState_AgentUsesResolvedModel(t *testing.T) {
+	adapter := NewLocalDeploymentAdapter(t.TempDir(), 21212)
+	deployment := &v1alpha1.Deployment{
+		Metadata: v1alpha1.ObjectMeta{Namespace: "team-a", Name: "assistant-local"},
+		Spec: v1alpha1.DeploymentSpec{
+			ModelRef: &v1alpha1.ModelRef{Name: "approved-model"},
+			Env: map[string]string{
+				"MODEL_PROVIDER": "deployment-provider",
+				"MODEL_NAME":     "deployment-model",
+			},
+		},
+	}
+	target := &v1alpha1.Agent{
+		Metadata: v1alpha1.ObjectMeta{Namespace: "team-a", Name: "assistant", Tag: "stable"},
+		Spec:     v1alpha1.AgentSpec{Source: &v1alpha1.AgentSource{Image: "ghcr.io/example/assistant:v1"}},
+	}
+	var gotRef v1alpha1.ResourceRef
+	desired, err := adapter.buildDesiredStateFromV1Alpha1(t.Context(), types.ApplyInput{
+		Deployment: deployment,
+		Target:     target,
+		Getter: func(_ context.Context, ref v1alpha1.ResourceRef) (v1alpha1.Object, error) {
+			gotRef = ref
+			return &v1alpha1.Model{
+				Spec: v1alpha1.ModelSpec{
+					Provider: v1alpha1.ModelProviderBedrock,
+					Model:    "us.anthropic.claude-sonnet-4-6",
+				},
+			}, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("buildDesiredStateFromV1Alpha1: %v", err)
+	}
+	if gotRef.Namespace != "team-a" || gotRef.Name != "approved-model" || gotRef.Tag != "latest" {
+		t.Fatalf("resolved ref = %+v", gotRef)
+	}
+	if len(desired.Agents) != 1 {
+		t.Fatalf("agents = %+v", desired.Agents)
+	}
+	env := desired.Agents[0].Deployment.Env
+	if env["MODEL_PROVIDER"] != v1alpha1.ModelProviderBedrock ||
+		env["MODEL_NAME"] != "us.anthropic.claude-sonnet-4-6" {
+		t.Fatalf("model env = %+v", env)
+	}
+}
+
 func TestV1Alpha1Remove_CallsComposeDown(t *testing.T) {
 	tmpDir := t.TempDir()
 

--- a/internal/registry/runtimes/utils/helpers.go
+++ b/internal/registry/runtimes/utils/helpers.go
@@ -79,7 +79,8 @@ type AgentTranslateOpts struct {
 	// refs (MCPServer.Spec.Remote.Headers), already split from
 	// Deployment.Spec.Env by the adapter via the HEADER_ prefix convention.
 	HeaderValues map[string]string
-	// Model is the spec resolved from Deployment.Spec.ModelRef. When nil,
+	// Model is the spec resolved from the Deployment's effective ModelRef,
+	// including the namespace default for a harness Agent. When nil,
 	// SpecToRuntimeAgent omits model provider/name env rather than accepting
 	// those values from DeploymentEnv.
 	Model *v1alpha1.ModelSpec
@@ -87,19 +88,24 @@ type AgentTranslateOpts struct {
 	Getter v1alpha1.GetterFunc
 }
 
-// ResolveDeploymentModelSpec resolves Deployment.Spec.ModelRef through getter
-// and returns the selected Model spec. Blank namespace inherits from the
-// Deployment and blank tag resolves the literal "latest" tag. A Deployment
-// without ModelRef returns (nil, nil).
+// ResolveDeploymentModelSpec resolves the Deployment's effective ModelRef
+// through getter and returns the selected Model spec. A harness Agent
+// Deployment that omits ModelRef selects Model/default@latest in its namespace.
+// Blank namespace inherits from the Deployment and blank tag resolves the
+// literal "latest" tag. A non-harness Deployment without ModelRef returns
+// (nil, nil).
 func ResolveDeploymentModelSpec(
 	ctx context.Context,
 	deployment *v1alpha1.Deployment,
 	getter v1alpha1.GetterFunc,
 ) (*v1alpha1.ModelSpec, error) {
-	if deployment == nil || deployment.Spec.ModelRef == nil {
+	if deployment == nil {
 		return nil, nil
 	}
-	modelRef := deployment.Spec.ModelRef
+	modelRef := deployment.Spec.EffectiveModelRef()
+	if modelRef == nil {
+		return nil, nil
+	}
 	normalized := v1alpha1.ResourceRef{
 		Kind:      v1alpha1.KindModel,
 		Namespace: modelRef.Namespace,

--- a/internal/registry/runtimes/utils/helpers.go
+++ b/internal/registry/runtimes/utils/helpers.go
@@ -79,8 +79,52 @@ type AgentTranslateOpts struct {
 	// refs (MCPServer.Spec.Remote.Headers), already split from
 	// Deployment.Spec.Env by the adapter via the HEADER_ prefix convention.
 	HeaderValues map[string]string
+	// Model is the spec resolved from Deployment.Spec.ModelRef. When nil,
+	// SpecToRuntimeAgent omits model provider/name env rather than accepting
+	// those values from DeploymentEnv.
+	Model *v1alpha1.ModelSpec
 	// Getter resolves AgentSpec.MCPServers refs to v1alpha1.MCPServer objects.
 	Getter v1alpha1.GetterFunc
+}
+
+// ResolveDeploymentModelSpec resolves Deployment.Spec.ModelRef through getter
+// and returns the selected Model spec. Blank namespace inherits from the
+// Deployment and blank tag resolves the literal "latest" tag. A Deployment
+// without ModelRef returns (nil, nil).
+func ResolveDeploymentModelSpec(
+	ctx context.Context,
+	deployment *v1alpha1.Deployment,
+	getter v1alpha1.GetterFunc,
+) (*v1alpha1.ModelSpec, error) {
+	if deployment == nil || deployment.Spec.ModelRef == nil {
+		return nil, nil
+	}
+	modelRef := deployment.Spec.ModelRef
+	normalized := v1alpha1.ResourceRef{
+		Kind:      v1alpha1.KindModel,
+		Namespace: modelRef.Namespace,
+		Name:      modelRef.Name,
+		Tag:       modelRef.Tag,
+	}
+	if normalized.Namespace == "" {
+		normalized.Namespace = deployment.Metadata.NamespaceOrDefault()
+	}
+	if normalized.Tag == "" {
+		normalized.Tag = "latest"
+	}
+	refName := fmt.Sprintf("%s %s/%s@%s", normalized.Kind, normalized.Namespace, normalized.Name, normalized.Tag)
+	if getter == nil {
+		return nil, fmt.Errorf("spec.modelRef resolve %s: getter is required", refName)
+	}
+	obj, err := getter(ctx, normalized)
+	if err != nil {
+		return nil, fmt.Errorf("spec.modelRef resolve %s: %w", refName, err)
+	}
+	model, ok := obj.(*v1alpha1.Model)
+	if !ok || model == nil {
+		return nil, fmt.Errorf("spec.modelRef resolve %s: getter returned unexpected type %T", refName, obj)
+	}
+	return &model.Spec, nil
 }
 
 // SpecToRuntimeAgent translates a v1alpha1 Agent envelope + Deployment
@@ -115,8 +159,12 @@ func SpecToRuntimeAgent(
 	}
 	envValues[constants.EnvKagentName] = agentMeta.Name
 	envValues[constants.EnvAgentName] = agentMeta.Name
-	envValues[constants.EnvModelProvider] = agentSpec.ModelProvider
-	envValues[constants.EnvModelName] = agentSpec.ModelName
+	delete(envValues, constants.EnvModelProvider)
+	delete(envValues, constants.EnvModelName)
+	if opts.Model != nil {
+		envValues[constants.EnvModelProvider] = opts.Model.Provider
+		envValues[constants.EnvModelName] = opts.Model.Model
+	}
 
 	var (
 		resolvedServers []*runtimetypes.MCPServer

--- a/internal/registry/runtimes/utils/helpers_test.go
+++ b/internal/registry/runtimes/utils/helpers_test.go
@@ -163,6 +163,37 @@ func TestResolveDeploymentModelSpec_NormalizesAndResolves(t *testing.T) {
 	}
 }
 
+func TestResolveDeploymentModelSpec_UsesDefaultHarnessModel(t *testing.T) {
+	deployment := &v1alpha1.Deployment{
+		Metadata: v1alpha1.ObjectMeta{Namespace: "team-a", Name: "assistant"},
+		Spec: v1alpha1.DeploymentSpec{
+			TargetRef: v1alpha1.ResourceRef{Kind: v1alpha1.KindAgent, Name: "assistant"},
+			Harness:   &v1alpha1.DeploymentHarness{Type: "claude-code"},
+		},
+	}
+	var gotRef v1alpha1.ResourceRef
+	got, err := ResolveDeploymentModelSpec(t.Context(), deployment, func(_ context.Context, ref v1alpha1.ResourceRef) (v1alpha1.Object, error) {
+		gotRef = ref
+		return &v1alpha1.Model{
+			TypeMeta: v1alpha1.TypeMeta{Kind: v1alpha1.KindModel},
+			Spec: v1alpha1.ModelSpec{
+				Provider: v1alpha1.ModelProviderBedrock,
+				Model:    "us.anthropic.claude-sonnet-4-6",
+			},
+		}, nil
+	})
+	if err != nil {
+		t.Fatalf("ResolveDeploymentModelSpec: %v", err)
+	}
+	if gotRef.Kind != v1alpha1.KindModel || gotRef.Namespace != "team-a" ||
+		gotRef.Name != v1alpha1.DefaultModelName || gotRef.Tag != "latest" {
+		t.Fatalf("default model ref = %+v", gotRef)
+	}
+	if got.Provider != v1alpha1.ModelProviderBedrock {
+		t.Fatalf("resolved model = %+v", got)
+	}
+}
+
 func TestResolveDeploymentModelSpec_FailuresNameNormalizedRef(t *testing.T) {
 	deployment := &v1alpha1.Deployment{
 		Metadata: v1alpha1.ObjectMeta{Namespace: "team-a", Name: "assistant"},

--- a/internal/registry/runtimes/utils/helpers_test.go
+++ b/internal/registry/runtimes/utils/helpers_test.go
@@ -3,6 +3,8 @@ package utils
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"strings"
 	"testing"
 
 	runtimetypes "github.com/agentregistry-dev/agentregistry/internal/registry/runtimes/types"
@@ -103,6 +105,138 @@ func TestSpecToRuntimeMCPServer_NamespaceOptOverridesMeta(t *testing.T) {
 	}
 }
 
+func TestResolveDeploymentModelSpec_NormalizesAndResolves(t *testing.T) {
+	tests := []struct {
+		name      string
+		namespace string
+		tag       string
+		wantNS    string
+		wantTag   string
+	}{
+		{
+			name:    "deployment namespace and latest tag",
+			wantNS:  "team-a",
+			wantTag: "latest",
+		},
+		{
+			name:      "explicit namespace and tag",
+			namespace: "models",
+			tag:       "approved-v1",
+			wantNS:    "models",
+			wantTag:   "approved-v1",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			deployment := &v1alpha1.Deployment{
+				Metadata: v1alpha1.ObjectMeta{Namespace: "team-a", Name: "assistant"},
+				Spec: v1alpha1.DeploymentSpec{
+					ModelRef: &v1alpha1.ModelRef{
+						Namespace: tt.namespace,
+						Name:      "approved-model",
+						Tag:       tt.tag,
+					},
+				},
+			}
+			var gotRef v1alpha1.ResourceRef
+			got, err := ResolveDeploymentModelSpec(t.Context(), deployment, func(_ context.Context, ref v1alpha1.ResourceRef) (v1alpha1.Object, error) {
+				gotRef = ref
+				return &v1alpha1.Model{
+					TypeMeta: v1alpha1.TypeMeta{Kind: v1alpha1.KindModel},
+					Spec: v1alpha1.ModelSpec{
+						Provider: v1alpha1.ModelProviderBedrock,
+						Model:    "us.anthropic.claude-sonnet-4-6",
+					},
+				}, nil
+			})
+			if err != nil {
+				t.Fatalf("ResolveDeploymentModelSpec: %v", err)
+			}
+			if gotRef.Kind != v1alpha1.KindModel || gotRef.Namespace != tt.wantNS ||
+				gotRef.Name != "approved-model" || gotRef.Tag != tt.wantTag {
+				t.Fatalf("normalized ref = %+v", gotRef)
+			}
+			if got.Provider != v1alpha1.ModelProviderBedrock || got.Model != "us.anthropic.claude-sonnet-4-6" {
+				t.Fatalf("resolved model = %+v", got)
+			}
+		})
+	}
+}
+
+func TestResolveDeploymentModelSpec_FailuresNameNormalizedRef(t *testing.T) {
+	deployment := &v1alpha1.Deployment{
+		Metadata: v1alpha1.ObjectMeta{Namespace: "team-a", Name: "assistant"},
+		Spec: v1alpha1.DeploymentSpec{
+			ModelRef: &v1alpha1.ModelRef{Name: "approved-model"},
+		},
+	}
+
+	_, err := ResolveDeploymentModelSpec(t.Context(), deployment, nil)
+	if err == nil || !strings.Contains(err.Error(), "spec.modelRef") ||
+		!strings.Contains(err.Error(), "Model team-a/approved-model@latest") {
+		t.Fatalf("missing getter error = %v", err)
+	}
+
+	_, err = ResolveDeploymentModelSpec(t.Context(), deployment, func(context.Context, v1alpha1.ResourceRef) (v1alpha1.Object, error) {
+		return nil, v1alpha1.ErrDanglingRef
+	})
+	if !errors.Is(err, v1alpha1.ErrDanglingRef) || !strings.Contains(err.Error(), "spec.modelRef") {
+		t.Fatalf("dangling ref error = %v", err)
+	}
+
+	_, err = ResolveDeploymentModelSpec(t.Context(), deployment, func(context.Context, v1alpha1.ResourceRef) (v1alpha1.Object, error) {
+		return &v1alpha1.Agent{}, nil
+	})
+	if err == nil || !strings.Contains(err.Error(), "unexpected type") ||
+		!strings.Contains(err.Error(), "Model team-a/approved-model@latest") {
+		t.Fatalf("unexpected type error = %v", err)
+	}
+}
+
+func TestSpecToRuntimeAgent_ModelEnvIsAuthoritative(t *testing.T) {
+	agent, _, err := SpecToRuntimeAgent(
+		t.Context(),
+		v1alpha1.ObjectMeta{Namespace: "default", Name: "alice"},
+		v1alpha1.AgentSpec{},
+		AgentTranslateOpts{
+			DeploymentEnv: map[string]string{
+				"MODEL_PROVIDER": "deployment-provider",
+				"MODEL_NAME":     "deployment-model",
+			},
+			Model: &v1alpha1.ModelSpec{
+				Provider: v1alpha1.ModelProviderBedrock,
+				Model:    "us.anthropic.claude-opus-4-8",
+			},
+		},
+	)
+	if err != nil {
+		t.Fatalf("SpecToRuntimeAgent: %v", err)
+	}
+	if agent.Deployment.Env["MODEL_PROVIDER"] != v1alpha1.ModelProviderBedrock ||
+		agent.Deployment.Env["MODEL_NAME"] != "us.anthropic.claude-opus-4-8" {
+		t.Fatalf("model env = %+v", agent.Deployment.Env)
+	}
+
+	agent, _, err = SpecToRuntimeAgent(
+		t.Context(),
+		v1alpha1.ObjectMeta{Namespace: "default", Name: "alice"},
+		v1alpha1.AgentSpec{},
+		AgentTranslateOpts{DeploymentEnv: map[string]string{
+			"MODEL_PROVIDER": "deployment-provider",
+			"MODEL_NAME":     "deployment-model",
+		}},
+	)
+	if err != nil {
+		t.Fatalf("SpecToRuntimeAgent without Model: %v", err)
+	}
+	if _, ok := agent.Deployment.Env["MODEL_PROVIDER"]; ok {
+		t.Fatalf("MODEL_PROVIDER should be omitted without Model: %+v", agent.Deployment.Env)
+	}
+	if _, ok := agent.Deployment.Env["MODEL_NAME"]; ok {
+		t.Fatalf("MODEL_NAME should be omitted without Model: %+v", agent.Deployment.Env)
+	}
+}
+
 func TestSpecToRuntimeAgent_ResolvesMCPServerRefs(t *testing.T) {
 	mcp := &v1alpha1.MCPServer{
 		TypeMeta: v1alpha1.TypeMeta{APIVersion: v1alpha1.GroupVersion, Kind: v1alpha1.KindMCPServer},
@@ -128,9 +262,7 @@ func TestSpecToRuntimeAgent_ResolvesMCPServerRefs(t *testing.T) {
 
 	agentMeta := v1alpha1.ObjectMeta{Namespace: "default", Name: "alice", Tag: "1.0.0"}
 	agentSpec := v1alpha1.AgentSpec{
-		Source:        &v1alpha1.AgentSource{Image: "ghcr.io/example/alice:v1"},
-		ModelProvider: "openai",
-		ModelName:     "gpt-4o",
+		Source: &v1alpha1.AgentSource{Image: "ghcr.io/example/alice:v1"},
 		MCPServers: []v1alpha1.ResourceRef{
 			{Kind: v1alpha1.KindMCPServer, Name: "tools", Tag: "1.0.0"},
 		},
@@ -140,7 +272,11 @@ func TestSpecToRuntimeAgent_ResolvesMCPServerRefs(t *testing.T) {
 		DeploymentID:  "dep-42",
 		KagentURL:     "http://localhost",
 		DeploymentEnv: map[string]string{"EXTRA": "value"},
-		Getter:        getter,
+		Model: &v1alpha1.ModelSpec{
+			Provider: v1alpha1.ModelProviderBedrock,
+			Model:    "us.anthropic.claude-sonnet-4-6",
+		},
+		Getter: getter,
 	})
 	if err != nil {
 		t.Fatalf("SpecToRuntimeAgent: %v", err)
@@ -159,6 +295,10 @@ func TestSpecToRuntimeAgent_ResolvesMCPServerRefs(t *testing.T) {
 	}
 	if agent.Deployment.Env["EXTRA"] != "value" {
 		t.Fatalf("EXTRA env missing: %+v", agent.Deployment.Env)
+	}
+	if agent.Deployment.Env["MODEL_PROVIDER"] != v1alpha1.ModelProviderBedrock ||
+		agent.Deployment.Env["MODEL_NAME"] != "us.anthropic.claude-sonnet-4-6" {
+		t.Fatalf("model env = %+v", agent.Deployment.Env)
 	}
 	encoded := agent.Deployment.Env["MCP_SERVERS_CONFIG"]
 	if encoded == "" {

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -46,10 +46,6 @@ components:
           type:
           - array
           - "null"
-        modelName:
-          type: string
-        modelProvider:
-          type: string
         plugins:
           items:
             $ref: '#/components/schemas/ResourceRef'

--- a/pkg/api/v1alpha1/agent.go
+++ b/pkg/api/v1alpha1/agent.go
@@ -19,10 +19,8 @@ func init() {
 // wired in, define a top-level MCPServer resource and reference it here.
 type AgentSpec struct {
 	// Core fields.
-	Title         string `json:"title,omitempty" yaml:"title,omitempty"`
-	Description   string `json:"description,omitempty" yaml:"description,omitempty"`
-	ModelProvider string `json:"modelProvider,omitempty" yaml:"modelProvider,omitempty"`
-	ModelName     string `json:"modelName,omitempty" yaml:"modelName,omitempty"`
+	Title       string `json:"title,omitempty" yaml:"title,omitempty"`
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
 
 	// Source declares where the agent comes from — Image (the runtime
 	// container) and/or Repository (the source code).

--- a/pkg/api/v1alpha1/deployment.go
+++ b/pkg/api/v1alpha1/deployment.go
@@ -59,9 +59,11 @@ const (
 type DeploymentSpec struct {
 	TargetRef  ResourceRef `json:"targetRef" yaml:"targetRef"`
 	RuntimeRef ResourceRef `json:"runtimeRef" yaml:"runtimeRef"`
-	// ModelRef optionally selects the Model for this Deployment. Namespace
-	// defaults to the Deployment's namespace. Provider, endpoint, and auth
-	// configuration remain on the referenced Model.
+	// ModelRef selects the tagged Model for this Deployment. It is required
+	// when an Agent Deployment selects a harness and remains optional for
+	// non-harness Agent and MCPServer Deployments. Namespace defaults to the
+	// Deployment namespace and tag defaults to the literal "latest" tag.
+	// Provider, endpoint, and auth configuration remain on the referenced Model.
 	ModelRef     *ModelRef `json:"modelRef,omitempty" yaml:"modelRef,omitempty"`
 	DesiredState string    `json:"desiredState,omitempty" yaml:"desiredState,omitempty"`
 	// DeploymentRefs declaratively binds this Deployment to other

--- a/pkg/api/v1alpha1/deployment.go
+++ b/pkg/api/v1alpha1/deployment.go
@@ -59,11 +59,11 @@ const (
 type DeploymentSpec struct {
 	TargetRef  ResourceRef `json:"targetRef" yaml:"targetRef"`
 	RuntimeRef ResourceRef `json:"runtimeRef" yaml:"runtimeRef"`
-	// ModelRef selects the tagged Model for this Deployment. It is required
-	// when an Agent Deployment selects a harness and remains optional for
-	// non-harness Agent and MCPServer Deployments. Namespace defaults to the
-	// Deployment namespace and tag defaults to the literal "latest" tag.
-	// Provider, endpoint, and auth configuration remain on the referenced Model.
+	// ModelRef selects the tagged Model for this Deployment. When omitted from
+	// a harness Agent Deployment, it defaults to Model/default@latest in the
+	// Deployment namespace. It remains optional with no implicit selection for
+	// non-harness Agent and MCPServer Deployments. Provider, endpoint, and auth
+	// configuration remain on the referenced Model.
 	ModelRef     *ModelRef `json:"modelRef,omitempty" yaml:"modelRef,omitempty"`
 	DesiredState string    `json:"desiredState,omitempty" yaml:"desiredState,omitempty"`
 	// DeploymentRefs declaratively binds this Deployment to other
@@ -78,6 +78,22 @@ type DeploymentSpec struct {
 	// rollout-specific harness policy. Omitted for BYO image/source Agent
 	// deployments and MCPServer deployments.
 	Harness *DeploymentHarness `json:"harness,omitempty" yaml:"harness,omitempty"`
+}
+
+// EffectiveModelRef returns the explicit ModelRef or the conventional
+// namespace-scoped default for a harness Agent Deployment. It returns nil for
+// non-harness Agent and MCPServer Deployments that omit ModelRef.
+func (s *DeploymentSpec) EffectiveModelRef() *ModelRef {
+	if s == nil {
+		return nil
+	}
+	if s.ModelRef != nil {
+		return s.ModelRef
+	}
+	if s.TargetRef.Kind == KindAgent && s.Harness != nil {
+		return &ModelRef{Name: DefaultModelName}
+	}
+	return nil
 }
 
 // DeploymentHarness selects the concrete harness to run for one Deployment.

--- a/pkg/api/v1alpha1/deployment_validate.go
+++ b/pkg/api/v1alpha1/deployment_validate.go
@@ -22,10 +22,11 @@ func (d *Deployment) Validate() error {
 	return errs
 }
 
-// ResolveRefs checks that TargetRef, RuntimeRef, the optional ModelRef, and
-// every entry in DeploymentRefs resolve. The referenced objects must live in
-// the referenced namespace; when ref.Namespace is blank on the wire we inherit
-// the Deployment's own namespace (mirroring how kubectl treats blank
+// ResolveRefs checks that TargetRef, RuntimeRef, any supplied ModelRef, and
+// every entry in DeploymentRefs resolve. Validation requires ModelRef when an
+// Agent Deployment selects a harness. The referenced objects must live in the
+// referenced namespace; when ref.Namespace is blank on the wire we inherit the
+// Deployment's own namespace (mirroring how kubectl treats blank
 // metadata.namespace).
 func (d *Deployment) ResolveRefs(ctx context.Context, resolver ResolverFunc) error {
 	if resolver == nil {
@@ -98,6 +99,9 @@ func validateDeploymentSpec(s *DeploymentSpec) FieldErrors {
 		}
 		if strings.TrimSpace(s.Harness.Type) == "" {
 			errs.Append("spec.harness.type", fmt.Errorf("%w", ErrRequiredField))
+		}
+		if s.TargetRef.Kind == KindAgent && s.ModelRef == nil {
+			errs.Append("spec.modelRef", fmt.Errorf("%w", ErrRequiredField))
 		}
 	}
 

--- a/pkg/api/v1alpha1/deployment_validate.go
+++ b/pkg/api/v1alpha1/deployment_validate.go
@@ -22,12 +22,12 @@ func (d *Deployment) Validate() error {
 	return errs
 }
 
-// ResolveRefs checks that TargetRef, RuntimeRef, any supplied ModelRef, and
-// every entry in DeploymentRefs resolve. Validation requires ModelRef when an
-// Agent Deployment selects a harness. The referenced objects must live in the
-// referenced namespace; when ref.Namespace is blank on the wire we inherit the
-// Deployment's own namespace (mirroring how kubectl treats blank
-// metadata.namespace).
+// ResolveRefs checks that TargetRef, RuntimeRef, the effective ModelRef, and
+// every entry in DeploymentRefs resolve. A harness Agent Deployment that omits
+// ModelRef resolves Model/default@latest in its own namespace. The referenced
+// objects must live in the referenced namespace; when ref.Namespace is blank on
+// the wire we inherit the Deployment's own namespace (mirroring how kubectl
+// treats blank metadata.namespace).
 func (d *Deployment) ResolveRefs(ctx context.Context, resolver ResolverFunc) error {
 	if resolver == nil {
 		return nil
@@ -46,12 +46,12 @@ func (d *Deployment) ResolveRefs(ctx context.Context, resolver ResolverFunc) err
 	}
 	errs = append(errs, resolveRefWith(ctx, resolver, runtime, "spec.runtimeRef")...)
 
-	if d.Spec.ModelRef != nil {
+	if modelRef := d.Spec.EffectiveModelRef(); modelRef != nil {
 		model := ResourceRef{
 			Kind:      KindModel,
-			Namespace: d.Spec.ModelRef.Namespace,
-			Name:      d.Spec.ModelRef.Name,
-			Tag:       d.Spec.ModelRef.Tag,
+			Namespace: modelRef.Namespace,
+			Name:      modelRef.Name,
+			Tag:       modelRef.Tag,
 		}
 		if model.Namespace == "" {
 			model.Namespace = d.Metadata.Namespace
@@ -100,9 +100,13 @@ func validateDeploymentSpec(s *DeploymentSpec) FieldErrors {
 		if strings.TrimSpace(s.Harness.Type) == "" {
 			errs.Append("spec.harness.type", fmt.Errorf("%w", ErrRequiredField))
 		}
-		if s.TargetRef.Kind == KindAgent && s.ModelRef == nil {
-			errs.Append("spec.modelRef", fmt.Errorf("%w", ErrRequiredField))
-		}
+	}
+
+	// Materialize the namespace-scoped default into the admitted Deployment so
+	// get, fingerprints, dependency tracking, and runtime translation all expose
+	// the same effective selection instead of relying on a hidden fallback.
+	if s.ModelRef == nil {
+		s.ModelRef = s.EffectiveModelRef()
 	}
 
 	if s.ModelRef != nil {

--- a/pkg/api/v1alpha1/ref.go
+++ b/pkg/api/v1alpha1/ref.go
@@ -26,10 +26,18 @@ type DeploymentRef struct {
 	Name      string `json:"name" yaml:"name"`
 }
 
+// DefaultModelName is the conventional namespace-scoped Model selected by a
+// harness Agent Deployment that omits spec.modelRef. Its blank tag resolves the
+// literal "latest" tag, so the complete implicit identity is
+// Model/<deployment namespace>/default@latest.
+const DefaultModelName = "default"
+
 // ModelRef selects a tagged Model. Kind is implicit (always Model).
 //
 // Namespace is optional: blank means "same namespace as the referencing
-// Deployment". Tag is optional: blank resolves the literal "latest" tag.
+// Deployment". Tag is optional: blank resolves the literal "latest" tag. When
+// a harness Agent Deployment omits ModelRef entirely, it defaults to
+// {name: "default"} in the Deployment namespace.
 type ModelRef struct {
 	Namespace string `json:"namespace,omitempty" yaml:"namespace,omitempty"`
 	Name      string `json:"name" yaml:"name"`

--- a/pkg/api/v1alpha1/scheme_test.go
+++ b/pkg/api/v1alpha1/scheme_test.go
@@ -92,7 +92,7 @@ func TestScheme_Register_Duplicate(t *testing.T) {
 	}
 }
 
-func TestScheme_Decode_Agent(t *testing.T) {
+func TestScheme_Decode_Agent_IgnoresLegacyModelFields(t *testing.T) {
 	doc := []byte(`
 apiVersion: ar.dev/v1alpha1
 kind: Agent
@@ -136,6 +136,13 @@ spec:
 		agent.Spec.MCPServers[0].Name != "github-tools" ||
 		agent.Spec.MCPServers[0].Tag != "0.2" {
 		t.Fatalf("mcpServers ref mismatch: %+v", agent.Spec.MCPServers)
+	}
+	encoded, err := Encode(agent)
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	if strings.Contains(string(encoded), "modelProvider") || strings.Contains(string(encoded), "modelName") {
+		t.Fatalf("legacy model fields survived decode/encode:\n%s", encoded)
 	}
 }
 

--- a/pkg/api/v1alpha1/validation_test.go
+++ b/pkg/api/v1alpha1/validation_test.go
@@ -238,13 +238,12 @@ func TestDeploymentValidate_OK(t *testing.T) {
 	require.NoError(t, d.Validate())
 }
 
-func TestDeploymentValidate_HarnessSelectionOK(t *testing.T) {
+func TestDeploymentValidate_HarnessSelectionDefaultsModelRef(t *testing.T) {
 	d := &Deployment{
 		Metadata: ObjectMeta{Namespace: "default", Name: "prod"},
 		Spec: DeploymentSpec{
 			TargetRef:  ResourceRef{Kind: KindAgent, Name: "alice", Tag: "stable"},
 			RuntimeRef: ResourceRef{Kind: KindRuntime, Name: "agentcore"},
-			ModelRef:   &ModelRef{Name: "claude-opus-4-8"},
 			Harness: &DeploymentHarness{
 				Type:           "claude-code",
 				PermissionMode: "acceptEdits",
@@ -252,6 +251,7 @@ func TestDeploymentValidate_HarnessSelectionOK(t *testing.T) {
 		},
 	}
 	require.NoError(t, d.Validate())
+	require.Equal(t, &ModelRef{Name: DefaultModelName}, d.Spec.ModelRef)
 }
 
 func TestDeploymentValidate_ModelRef(t *testing.T) {
@@ -266,9 +266,8 @@ func TestDeploymentValidate_ModelRef(t *testing.T) {
 			name: "omitted",
 		},
 		{
-			name:       "omitted for harness deployment",
-			harness:    &DeploymentHarness{Type: "claude-code"},
-			wantFields: []string{"spec.modelRef"},
+			name:    "omitted for harness deployment defaults",
+			harness: &DeploymentHarness{Type: "claude-code"},
 		},
 		{
 			name:       "omitted for MCPServer deployment",
@@ -536,6 +535,30 @@ func TestDeploymentResolveRefs_ModelRef(t *testing.T) {
 	}
 }
 
+func TestDeploymentResolveRefs_UsesDefaultHarnessModel(t *testing.T) {
+	var seen []ResourceRef
+	resolver := func(_ context.Context, ref ResourceRef) error {
+		seen = append(seen, ref)
+		return nil
+	}
+	d := &Deployment{
+		Metadata: ObjectMeta{Namespace: "team-b", Name: "prod"},
+		Spec: DeploymentSpec{
+			TargetRef:  ResourceRef{Kind: KindAgent, Name: "alice", Tag: "stable"},
+			RuntimeRef: ResourceRef{Kind: KindRuntime, Name: "local"},
+			Harness:    &DeploymentHarness{Type: "claude-code"},
+		},
+	}
+
+	require.NoError(t, d.ResolveRefs(context.Background(), resolver))
+	require.Len(t, seen, 3)
+	require.Equal(t, ResourceRef{
+		Kind:      KindModel,
+		Namespace: "team-b",
+		Name:      DefaultModelName,
+	}, seen[2])
+}
+
 func TestDeploymentResolveRefs_ReportsDanglingModelRef(t *testing.T) {
 	resolver := func(_ context.Context, ref ResourceRef) error {
 		if ref.Kind == KindModel {
@@ -549,6 +572,27 @@ func TestDeploymentResolveRefs_ReportsDanglingModelRef(t *testing.T) {
 			TargetRef:  ResourceRef{Kind: KindAgent, Name: "alice", Tag: "stable"},
 			RuntimeRef: ResourceRef{Kind: KindRuntime, Name: "local"},
 			ModelRef:   &ModelRef{Name: "missing"},
+		},
+	}
+
+	err := d.ResolveRefs(context.Background(), resolver)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "spec.modelRef")
+}
+
+func TestDeploymentResolveRefs_ReportsDanglingDefaultHarnessModel(t *testing.T) {
+	resolver := func(_ context.Context, ref ResourceRef) error {
+		if ref.Kind == KindModel && ref.Name == DefaultModelName {
+			return ErrDanglingRef
+		}
+		return nil
+	}
+	d := &Deployment{
+		Metadata: ObjectMeta{Namespace: "default", Name: "prod"},
+		Spec: DeploymentSpec{
+			TargetRef:  ResourceRef{Kind: KindAgent, Name: "alice", Tag: "stable"},
+			RuntimeRef: ResourceRef{Kind: KindRuntime, Name: "local"},
+			Harness:    &DeploymentHarness{Type: "claude-code"},
 		},
 	}
 

--- a/pkg/api/v1alpha1/validation_test.go
+++ b/pkg/api/v1alpha1/validation_test.go
@@ -244,6 +244,7 @@ func TestDeploymentValidate_HarnessSelectionOK(t *testing.T) {
 		Spec: DeploymentSpec{
 			TargetRef:  ResourceRef{Kind: KindAgent, Name: "alice", Tag: "stable"},
 			RuntimeRef: ResourceRef{Kind: KindRuntime, Name: "agentcore"},
+			ModelRef:   &ModelRef{Name: "claude-opus-4-8"},
 			Harness: &DeploymentHarness{
 				Type:           "claude-code",
 				PermissionMode: "acceptEdits",
@@ -256,6 +257,7 @@ func TestDeploymentValidate_HarnessSelectionOK(t *testing.T) {
 func TestDeploymentValidate_ModelRef(t *testing.T) {
 	tests := []struct {
 		name       string
+		targetKind string
 		modelRef   *ModelRef
 		harness    *DeploymentHarness
 		wantFields []string
@@ -264,8 +266,18 @@ func TestDeploymentValidate_ModelRef(t *testing.T) {
 			name: "omitted",
 		},
 		{
-			name:    "omitted for harness deployment",
-			harness: &DeploymentHarness{Type: "claude-code"},
+			name:       "omitted for harness deployment",
+			harness:    &DeploymentHarness{Type: "claude-code"},
+			wantFields: []string{"spec.modelRef"},
+		},
+		{
+			name:       "omitted for MCPServer deployment",
+			targetKind: KindMCPServer,
+		},
+		{
+			name:       "supplied for MCPServer deployment",
+			targetKind: KindMCPServer,
+			modelRef:   &ModelRef{Name: "claude-opus-4-8"},
 		},
 		{
 			name:     "same namespace",
@@ -303,10 +315,14 @@ func TestDeploymentValidate_ModelRef(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			targetKind := tt.targetKind
+			if targetKind == "" {
+				targetKind = KindAgent
+			}
 			d := &Deployment{
 				Metadata: ObjectMeta{Namespace: "default", Name: "prod"},
 				Spec: DeploymentSpec{
-					TargetRef:  ResourceRef{Kind: KindAgent, Name: "alice", Tag: "stable"},
+					TargetRef:  ResourceRef{Kind: targetKind, Name: "alice", Tag: "stable"},
 					RuntimeRef: ResourceRef{Kind: KindRuntime, Name: "agentcore"},
 					ModelRef:   tt.modelRef,
 					Harness:    tt.harness,
@@ -323,6 +339,7 @@ func TestDeploymentValidate_RejectsHarnessSelectionWithoutType(t *testing.T) {
 		Spec: DeploymentSpec{
 			TargetRef:  ResourceRef{Kind: KindAgent, Name: "alice", Tag: "stable"},
 			RuntimeRef: ResourceRef{Kind: KindRuntime, Name: "agentcore"},
+			ModelRef:   &ModelRef{Name: "claude-opus-4-8"},
 			Harness:    &DeploymentHarness{},
 		},
 	}

--- a/pkg/registry/v1alpha1store/store_tagging_test.go
+++ b/pkg/registry/v1alpha1store/store_tagging_test.go
@@ -18,17 +18,17 @@ import (
 )
 
 // agentObj returns an Agent envelope with the given name + a deterministic
-// spec keyed by modelName, so the four apply-branch tests can produce both
+// spec keyed by title, so the four apply-branch tests can produce both
 // hash-equal and hash-distinct payloads without recomputing fixtures.
-func agentObj(name, modelName string, labels map[string]string) *v1alpha1.Agent {
-	return taggedAgentObj(name, "", modelName, labels)
+func agentObj(name, title string, labels map[string]string) *v1alpha1.Agent {
+	return taggedAgentObj(name, "", title, labels)
 }
 
-func taggedAgentObj(name, tag, modelName string, labels map[string]string) *v1alpha1.Agent {
+func taggedAgentObj(name, tag, title string, labels map[string]string) *v1alpha1.Agent {
 	return &v1alpha1.Agent{
 		TypeMeta: v1alpha1.TypeMeta{APIVersion: v1alpha1.GroupVersion, Kind: v1alpha1.KindAgent},
 		Metadata: v1alpha1.ObjectMeta{Namespace: "default", Name: name, Tag: tag, Labels: labels},
-		Spec:     v1alpha1.AgentSpec{ModelName: modelName},
+		Spec:     v1alpha1.AgentSpec{Title: title},
 	}
 }
 

--- a/pkg/types/adapter.go
+++ b/pkg/types/adapter.go
@@ -100,7 +100,7 @@ type ApplyInput struct {
 
 	// Getter fetches the typed Object for a ResourceRef. Adapters use
 	// this when they need the target's Spec (not just an existence
-	// check) — for example, resolving Deployment.Spec.ModelRef or
+	// check) — for example, resolving a Deployment's effective ModelRef or
 	// walking AgentSpec.MCPServers to build agentgateway upstream config.
 	Getter v1alpha1.GetterFunc
 }

--- a/pkg/types/adapter.go
+++ b/pkg/types/adapter.go
@@ -100,8 +100,8 @@ type ApplyInput struct {
 
 	// Getter fetches the typed Object for a ResourceRef. Adapters use
 	// this when they need the target's Spec (not just an existence
-	// check) — for example, the local adapter walking
-	// AgentSpec.MCPServers to build agentgateway upstream config.
+	// check) — for example, resolving Deployment.Spec.ModelRef or
+	// walking AgentSpec.MCPServers to build agentgateway upstream config.
 	Getter v1alpha1.GetterFunc
 }
 

--- a/pkg/types/fingerprint.go
+++ b/pkg/types/fingerprint.go
@@ -235,7 +235,11 @@ func materialHash(parts ...json.RawMessage) string {
 
 func defaultApplyDependencies(ctx context.Context, in ApplyInput) ([]v1alpha1.Object, error) {
 	agent, ok := in.Target.(*v1alpha1.Agent)
-	hasModelRef := in.Deployment != nil && in.Deployment.Spec.ModelRef != nil
+	var modelRef *v1alpha1.ModelRef
+	if in.Deployment != nil {
+		modelRef = in.Deployment.Spec.EffectiveModelRef()
+	}
+	hasModelRef := modelRef != nil
 	hasAgentRefs := ok && agent != nil &&
 		(len(agent.Spec.MCPServers) > 0 || hasHarnessCompositionRefs(in.Deployment, agent))
 	if in.Getter == nil {
@@ -247,7 +251,6 @@ func defaultApplyDependencies(ctx context.Context, in ApplyInput) ([]v1alpha1.Ob
 	deps := make([]v1alpha1.Object, 0)
 	var err error
 	if hasModelRef {
-		modelRef := in.Deployment.Spec.ModelRef
 		deps, err = appendResolvedRefs(ctx, deps, in.Getter, in.Deployment.Metadata.NamespaceOrDefault(), []v1alpha1.ResourceRef{{
 			Kind:      v1alpha1.KindModel,
 			Namespace: modelRef.Namespace,

--- a/pkg/types/fingerprint_test.go
+++ b/pkg/types/fingerprint_test.go
@@ -141,6 +141,37 @@ func TestDefaultApplyFingerprintResultIncludesModelDependency(t *testing.T) {
 	}
 }
 
+func TestDefaultApplyFingerprintResultIncludesDefaultHarnessModel(t *testing.T) {
+	in := testApplyInput()
+	in.Deployment.Metadata.Namespace = "team-a"
+	in.Deployment.Spec.TargetRef = v1alpha1.ResourceRef{Kind: v1alpha1.KindAgent, Name: "assistant"}
+	in.Deployment.Spec.Harness = &v1alpha1.DeploymentHarness{Type: "claude-code"}
+	in.Target = &v1alpha1.Agent{
+		TypeMeta: v1alpha1.TypeMeta{Kind: v1alpha1.KindAgent},
+		Metadata: v1alpha1.ObjectMeta{Namespace: "team-a", Name: "assistant"},
+	}
+	in.Getter = func(_ context.Context, ref v1alpha1.ResourceRef) (v1alpha1.Object, error) {
+		if ref.Kind != v1alpha1.KindModel || ref.Namespace != "team-a" ||
+			ref.Name != v1alpha1.DefaultModelName || ref.Tag != "" {
+			t.Fatalf("default model ref = %+v", ref)
+		}
+		return testModel("team-a", v1alpha1.DefaultModelName, "latest", "us.anthropic.claude-sonnet-4-6"), nil
+	}
+
+	result, err := DefaultApplyFingerprintResult(context.Background(), in, ApplyFingerprintOptions{AdapterType: "test"})
+	if err != nil {
+		t.Fatalf("DefaultApplyFingerprintResult: %v", err)
+	}
+	if len(result.Dependencies) != 1 {
+		t.Fatalf("dependencies = %+v, want one default Model dependency", result.Dependencies)
+	}
+	dep := result.Dependencies[0]
+	if dep.Kind != v1alpha1.KindModel || dep.Namespace != "team-a" ||
+		dep.Name != v1alpha1.DefaultModelName || dep.Tag != "latest" {
+		t.Fatalf("default model dependency identity mismatch: %+v", dep)
+	}
+}
+
 func TestDefaultApplyFingerprintIncludesAgentHarnessCompositionDependencies(t *testing.T) {
 	in := testApplyInput()
 	in.Deployment.Metadata.Namespace = "team-a"

--- a/test/e2e/declarative_test.go
+++ b/test/e2e/declarative_test.go
@@ -152,8 +152,6 @@ spec:
   source:
     image: ghcr.io/e2e-test/decl-agent:latest
   description: "E2E declarative apply test agent"
-  modelProvider: gemini
-  modelName: gemini-2.0-flash
 `, agentName)
 
 	yamlPath := writeDeclarativeYAML(t, tmpDir, "agent.yaml", agentYAML)
@@ -284,8 +282,6 @@ spec:
   source:
     image: ghcr.io/e2e-test/multi-agent:latest
   description: "Multi-doc test agent"
-  modelProvider: gemini
-  modelName: gemini-2.0-flash
 `, serverName, agentName)
 
 	yamlPath := writeDeclarativeYAML(t, tmpDir, "stack.yaml", multiDocYAML)
@@ -317,8 +313,6 @@ spec:
   source:
     image: ghcr.io/e2e-test/dryrun:latest
   description: "Dry-run test agent"
-  modelProvider: gemini
-  modelName: gemini-2.0-flash
 `, agentName)
 
 	yamlPath := writeDeclarativeYAML(t, tmpDir, "dryrun.yaml", agentYAML)
@@ -661,8 +655,6 @@ spec:
   source:
     image: ghcr.io/e2e-test/idemp-agent:latest
   description: "Idempotent apply test agent"
-  modelProvider: gemini
-  modelName: gemini-2.0-flash
 `, agentName)
 
 	yamlPath := writeDeclarativeYAML(t, tmpDir, "agent.yaml", agentYAML)
@@ -735,8 +727,6 @@ spec:
   source:
     image: ghcr.io/e2e-test/update-agent:latest
   description: "v1 description"
-  modelProvider: gemini
-  modelName: gemini-2.0-flash
 `, agentName)
 
 	yamlPath := writeDeclarativeYAML(t, tmpDir, "agent.yaml", v1YAML)
@@ -763,8 +753,6 @@ spec:
   source:
     image: ghcr.io/e2e-test/update-agent:latest
   description: "v2 description"
-  modelProvider: gemini
-  modelName: gemini-2.0-flash
 `, agentName)
 
 	yamlPath = writeDeclarativeYAML(t, tmpDir, "agent.yaml", v2YAML)
@@ -1082,8 +1070,6 @@ spec:
   source:
     image: ghcr.io/e2e-test/batch-agent:latest
   description: "Batch multi-resource apply test agent"
-  modelProvider: gemini
-  modelName: gemini-2.0-flash
 ---
 apiVersion: ar.dev/v1alpha1
 kind: Runtime
@@ -1133,8 +1119,6 @@ spec:
   source:
     image: ghcr.io/e2e-test/idemp-batch-agent:latest
   description: "Idempotent batch apply test"
-  modelProvider: gemini
-  modelName: gemini-2.0-flash
 ---
 apiVersion: ar.dev/v1alpha1
 kind: Runtime
@@ -1289,8 +1273,6 @@ spec:
   source:
     image: ghcr.io/e2e-test/del-batch-agent:latest
   description: "Delete-file batch test agent"
-  modelProvider: gemini
-  modelName: gemini-2.0-flash
 `, agentName)
 
 	yamlPath := writeDeclarativeYAML(t, tmpDir, "agent.yaml", agentYAML)
@@ -1561,8 +1543,6 @@ spec:
   source:
     image: ghcr.io/e2e-test/delmulti-agent:latest
   description: "multi-kind delete test"
-  modelProvider: gemini
-  modelName: gemini-2.0-flash
 ---
 apiVersion: ar.dev/v1alpha1
 kind: MCPServer

--- a/test/e2e/remote_resources_test.go
+++ b/test/e2e/remote_resources_test.go
@@ -86,8 +86,6 @@ spec:
   description: Agent that wires in a remote MCPServer
   language: python
   framework: adk
-  modelProvider: gemini
-  modelName: gemini-2.0-flash
   mcpServers:
     - kind: MCPServer
       name: %s

--- a/test/e2e/tagging_test.go
+++ b/test/e2e/tagging_test.go
@@ -45,8 +45,6 @@ spec:
   description: %q
   language: python
   framework: adk
-  modelProvider: gemini
-  modelName: gemini-2.0-flash
 `, name, tagLine, desc)
 	path := writeDeclarativeYAML(t, tmpDir, fmt.Sprintf("agent-%d.yaml", time.Now().UnixNano()), yaml)
 	result := RunArctl(t, tmpDir, "apply", "-f", path, "--registry-url", regURL)

--- a/ui/app/page.tsx
+++ b/ui/app/page.tsx
@@ -378,7 +378,6 @@ export default function AdminPage() {
       ))
       setFilteredAgents(groupedAgents.filter(({agent}) =>
         agent.name?.toLowerCase().includes(query) ||
-        agent.modelProvider?.toLowerCase().includes(query) ||
         agent.description?.toLowerCase().includes(query)
       ))
       setFilteredPrompts(groupedPrompts.filter(({prompt}) =>

--- a/ui/components/__tests__/agent-card.test.tsx
+++ b/ui/components/__tests__/agent-card.test.tsx
@@ -9,8 +9,6 @@ const mockAgent: AgentResponse = {
     name: "test-agent",
     description: "A test agent for unit testing",
     tag: "1.0.0",
-    modelProvider: "openai",
-    modelName: "gpt-4",
     source: {
       image: "registry.example.com/test-agent:latest",
     },
@@ -37,12 +35,6 @@ describe("AgentCard", () => {
     expect(screen.getByText("1.0.0")).toBeInTheDocument()
   })
 
-  it("renders model provider and name", () => {
-    render(<AgentCard agent={mockAgent} />)
-    expect(screen.getByText("openai")).toBeInTheDocument()
-    expect(screen.getByText("gpt-4")).toBeInTheDocument()
-  })
-
   it("calls onClick when card is clicked", async () => {
     const onClick = vi.fn()
     render(<AgentCard agent={mockAgent} onClick={onClick} />)
@@ -56,8 +48,6 @@ describe("AgentCard", () => {
         name: "minimal-agent",
         description: "",
         tag: "0.1.0",
-        modelProvider: "",
-        modelName: "",
       },
       _meta: {},
     }

--- a/ui/components/agent-card.stories.tsx
+++ b/ui/components/agent-card.stories.tsx
@@ -7,8 +7,6 @@ const mockAgent: AgentResponse = {
     name: "code-review-agent",
     description: "An AI agent that reviews pull requests, identifies bugs, and suggests improvements based on best practices.",
     tag: "2.1.0",
-    modelProvider: "openai",
-    modelName: "gpt-4o",
     source: {
       image: "registry.example.com/code-review-agent:2.1.0",
       repository: {
@@ -31,8 +29,6 @@ const minimalAgent: AgentResponse = {
     name: "simple-bot",
     description: "",
     tag: "0.1.0",
-    modelProvider: "",
-    modelName: "",
   },
   _meta: {},
 }

--- a/ui/components/agent-card.tsx
+++ b/ui/components/agent-card.tsx
@@ -8,7 +8,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip"
-import { Bot, Brain, Cpu, Github, Play } from "lucide-react"
+import { Bot, Github, Play } from "lucide-react"
 
 interface AgentCardProps {
   agent: AgentResponse
@@ -68,20 +68,6 @@ export function AgentCard({ agent, onDeploy, showDeploy = false, onClick, tagCou
 
             {official?.publishedAt && (
               <span>{formatDate(official.publishedAt)}</span>
-            )}
-
-            {agentData.modelProvider && (
-              <span className="flex items-center gap-1">
-                <Brain className="h-3 w-3" aria-hidden="true" />
-                {agentData.modelProvider}
-              </span>
-            )}
-
-            {agentData.modelName && (
-              <span className="flex items-center gap-1 font-mono">
-                <Cpu className="h-3 w-3" aria-hidden="true" />
-                {agentData.modelName}
-              </span>
             )}
 
             {source?.repository?.url && (

--- a/ui/components/agent-detail.tsx
+++ b/ui/components/agent-detail.tsx
@@ -9,8 +9,6 @@ import {
   Calendar,
   Bot,
   Code,
-  Cpu,
-  Brain,
   Clock,
   Github,
   ExternalLink,
@@ -128,26 +126,6 @@ export function AgentDetail({ agent, allTags: allTagsProp }: AgentDetailProps) {
                 <p className="text-[15px] leading-relaxed">{agentData.description}</p>
               </section>
             )}
-
-            <section>
-              <h3 className="text-sm font-semibold uppercase tracking-wider text-muted-foreground mb-3">Details</h3>
-              <div className="grid grid-cols-2 gap-4">
-                <div className="flex items-center gap-2.5">
-                  <Brain className="h-4 w-4 text-muted-foreground" />
-                  <div>
-                    <p className="text-xs text-muted-foreground">Model Provider</p>
-                    <p className="text-[15px] font-medium">{agentData.modelProvider}</p>
-                  </div>
-                </div>
-                <div className="flex items-center gap-2.5">
-                  <Cpu className="h-4 w-4 text-muted-foreground" />
-                  <div>
-                    <p className="text-xs text-muted-foreground">Model</p>
-                    <p className="text-[15px] font-medium font-mono">{agentData.modelName}</p>
-                  </div>
-                </div>
-              </div>
-            </section>
 
             {source?.repository?.url && (
               <section>

--- a/ui/lib/api/types.gen.ts
+++ b/ui/lib/api/types.gen.ts
@@ -22,8 +22,6 @@ export type AgentSpec = {
     description?: string;
     instructions?: ResourceRef;
     mcpServers?: Array<ResourceRef> | null;
-    modelName?: string;
-    modelProvider?: string;
     plugins?: Array<ResourceRef> | null;
     skills?: Array<ResourceRef> | null;
     source?: AgentSource;


### PR DESCRIPTION
# Description

Makes tagged Models the only runtime source for Agent model configuration.

- Removes `AgentSpec.modelProvider` and `AgentSpec.modelName` from the public API, generated OpenAPI/TypeScript clients, examples, CLI output, and Agent UI.
- Resolves explicit `Deployment.spec.modelRef` values through the existing runtime getter and makes the selected Model's provider/name authoritative in both local and Kubernetes adapters.
- Gives harness Agent Deployments a deterministic namespace default: omitting `modelRef` materializes and resolves `Model/<deployment namespace>/default@latest`; explicit refs always win, and a missing default fails reference resolution.
- Includes effective Model dependencies in deployment fingerprints so default and explicit Model changes trigger the same reconciliation path.
- Keeps `arctl init agent` provider/model selection working for source-template generation without persisting those choices in `agent.yaml` or `arctl.yaml`; generated projects persist only generic `requiredEnv` keys.
- Expands `arctl get agents` with mode and description columns, including the valid `source+harness` combination.
- Documents default-Model ownership, resolution semantics, failure behavior, and the rule that the registry never selects the first or only Model automatically.


The broader portable harness-composition scaffold is intentionally separate: #592.

# Change Type

/kind feature
/kind breaking_change
/kind cleanup

# Changelog

```release-note
Agent model configuration now comes from tagged Deployment model references; harness Agent deployments that omit modelRef resolve the namespace's Model/default@latest, and Agent modelProvider/modelName fields are removed.
```

# Additional Notes

Current-head local verification:

- `make test-unit` — 1,266 tests passed
- focused declarative CLI, API, fingerprint, and local/Kubernetes runtime tests
- `git diff --check`

Earlier implementation-pass verification also included:

- `make lint` — 0 issues
- provider-template compatibility coverage for Gemini, OpenAI, Anthropic, Bedrock, and agentgateway
- exact Docker E2E regression coverage for missing provider credentials
- focused Agent card UI tests
- `make lint-ui` — no errors; one pre-existing React hook warning
- `make build-ui`
- clean-commit `make verify`

PostgreSQL-backed integration and Kubernetes E2E coverage remain CI-only in this environment.




