### PR TITLE
fix(helm): remove unused grpc port 21212 and point NOTES.txt to MCP bridge

### DIFF
--- a/charts/agentregistry/README.md
+++ b/charts/agentregistry/README.md
@@ -18,7 +18,7 @@ A PostgreSQL instance is bundled and started automatically — no external datab
 
 This chart bootstraps an [Agent Registry](https://github.com/agentregistry-dev/agentregistry) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
-It exposes both an HTTP REST API and an Agent Gateway gRPC endpoint. A PostgreSQL instance is bundled by default for development and evaluation. For production, set `database.postgres.type: external` and supply a connection string to your own PostgreSQL service.
+It exposes both an HTTP REST API and an MCP server endpoint. A PostgreSQL instance is bundled by default for development and evaluation. For production, set `database.postgres.type: external` and supply a connection string to your own PostgreSQL service.
 
 ## Prerequisites
 
@@ -60,7 +60,7 @@ The chart deploys the following Kubernetes resources:
 | Resource | Description |
 |---|---|
 | Deployment | Agent Registry application |
-| Service | Exposes HTTP (`:12121`) and gRPC (`:21212`) ports |
+| Service | Exposes HTTP (`:12121`) and MCP (`:31313`) ports |
 | ConfigMap | Application configuration injected as environment variables |
 | Secret | JWT signing key (omitted when `config.existingSecret` is set) |
 | Secret (`-postgresql`) | Bundled PostgreSQL password (only when `database.postgres.type=bundled`) |
@@ -228,15 +228,12 @@ This creates a `Role`/`RoleBinding` in each listed namespace (plus the installat
 | service.externalTrafficPolicy | string | `"Cluster"` | External traffic policy |
 | service.loadBalancerIP | string | `""` | LoadBalancer IP |
 | service.loadBalancerSourceRanges | list | `[]` | LoadBalancer allowed source ranges |
-| service.nodePorts.grpc | string | `""` | NodePort for gRPC (when type is NodePort) |
 | service.nodePorts.http | string | `""` | NodePort for HTTP (when type is NodePort) |
 | service.nodePorts.mcp | string | `""` | NodePort for MCP (when type is NodePort) |
-| service.ports.grpc | int | `21212` | Agent Gateway gRPC port |
 | service.ports.http | int | `12121` | HTTP port |
 | service.ports.mcp | int | `31313` | MCP HTTP port |
 | service.sessionAffinity | string | `"None"` | Session affinity (None or ClientIP) |
 | service.sessionAffinityConfig | object | `{}` | Session affinity configuration |
-| service.targetPorts.grpc | int | `21212` | gRPC container target port |
 | service.targetPorts.http | int | `8080` | HTTP container target port |
 | service.targetPorts.mcp | int | `31313` | MCP container target port |
 | service.type | string | `"ClusterIP"` | Kubernetes Service type |

--- a/charts/agentregistry/README.md.gotmpl
+++ b/charts/agentregistry/README.md.gotmpl
@@ -19,7 +19,7 @@ A PostgreSQL instance is bundled and started automatically — no external datab
 
 This chart bootstraps an [Agent Registry](https://github.com/agentregistry-dev/agentregistry) deployment on a [Kubernetes](https://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
 
-It exposes both an HTTP REST API and an Agent Gateway gRPC endpoint. A PostgreSQL instance is bundled by default for development and evaluation. For production, set `database.postgres.type: external` and supply a connection string to your own PostgreSQL service.
+It exposes both an HTTP REST API and an MCP server endpoint. A PostgreSQL instance is bundled by default for development and evaluation. For production, set `database.postgres.type: external` and supply a connection string to your own PostgreSQL service.
 
 ## Prerequisites
 
@@ -61,7 +61,7 @@ The chart deploys the following Kubernetes resources:
 | Resource | Description |
 |---|---|
 | Deployment | Agent Registry application |
-| Service | Exposes HTTP (`:12121`) and gRPC (`:21212`) ports |
+| Service | Exposes HTTP (`:12121`) and MCP (`:31313`) ports |
 | ConfigMap | Application configuration injected as environment variables |
 | Secret | JWT signing key (omitted when `config.existingSecret` is set) |
 | Secret (`-postgresql`) | Bundled PostgreSQL password (only when `database.postgres.type=bundled`) |

--- a/charts/agentregistry/templates/NOTES.txt
+++ b/charts/agentregistry/templates/NOTES.txt
@@ -1,6 +1,6 @@
 {{- $fullName := include "agentregistry.fullname" . -}}
 {{- $httpPort := .Values.service.ports.http -}}
-{{- $grpcPort := .Values.service.ports.grpc -}}
+{{- $mcpPort := .Values.service.ports.mcp -}}
 
 ========================================================================
   Agent Registry has been deployed!
@@ -23,8 +23,8 @@ Useful endpoints (after port-forward):
   - OpenAPI spec (JSON): http://localhost:{{ $httpPort }}/openapi.json
   - Deployments list:    http://localhost:{{ $httpPort }}/v0/deployments?limit=200
 
-gRPC endpoint (Agent Gateway):
-  - kubectl -n {{ .Release.Namespace }} port-forward svc/{{ $fullName }} {{ $grpcPort }}:{{ $grpcPort }}
+Built-in MCP Server (for AI Clients / Chatbots):
+  - kubectl -n {{ .Release.Namespace }} port-forward svc/{{ $fullName }} {{ $mcpPort }}:{{ $mcpPort }}
 
 {{- if eq .Values.database.postgres.type "bundled" }}
 ################################################################################

--- a/charts/agentregistry/templates/deployment.yaml
+++ b/charts/agentregistry/templates/deployment.yaml
@@ -120,9 +120,6 @@ spec:
             - name: http
               containerPort: {{ .Values.service.targetPorts.http }}
               protocol: TCP
-            - name: grpc
-              containerPort: {{ .Values.service.targetPorts.grpc }}
-              protocol: TCP
             - name: mcp
               containerPort: {{ .Values.service.targetPorts.mcp }}
               protocol: TCP

--- a/charts/agentregistry/templates/service.yaml
+++ b/charts/agentregistry/templates/service.yaml
@@ -42,13 +42,6 @@ spec:
       {{- if and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) .Values.service.nodePorts.http }}
       nodePort: {{ .Values.service.nodePorts.http }}
       {{- end }}
-    - name: grpc
-      port: {{ .Values.service.ports.grpc }}
-      targetPort: {{ .Values.service.targetPorts.grpc }}
-      protocol: TCP
-      {{- if and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) .Values.service.nodePorts.grpc }}
-      nodePort: {{ .Values.service.nodePorts.grpc }}
-      {{- end }}
     - name: mcp
       port: {{ .Values.service.ports.mcp }}
       targetPort: {{ .Values.service.targetPorts.mcp }}

--- a/charts/agentregistry/tests/service_test.yaml
+++ b/charts/agentregistry/tests/service_test.yaml
@@ -47,16 +47,6 @@ tests:
             targetPort: 8080
             protocol: TCP
 
-  - it: exposes grpc port 21212
-    asserts:
-      - contains:
-          path: spec.ports
-          content:
-            name: grpc
-            port: 21212
-            targetPort: 21212
-            protocol: TCP
-
   - it: exposes mcp port 31313
     asserts:
       - contains:

--- a/charts/agentregistry/values.yaml
+++ b/charts/agentregistry/values.yaml
@@ -213,22 +213,16 @@ service:
   ports:
     # -- HTTP port
     http: 12121
-    # -- Agent Gateway gRPC port
-    grpc: 21212
     # -- MCP HTTP port
     mcp: 31313
   targetPorts:
     # -- HTTP container target port
     http: 8080
-    # -- gRPC container target port
-    grpc: 21212
     # -- MCP container target port
     mcp: 31313
   nodePorts:
     # -- NodePort for HTTP (when type is NodePort)
     http: ""
-    # -- NodePort for gRPC (when type is NodePort)
-    grpc: ""
     # -- NodePort for MCP (when type is NodePort)
     mcp: ""
   # -- Specific cluster IP (set to None for headless)


### PR DESCRIPTION
# Description

  This PR cleans up the unused gRPC port (`21212`) from the Helm chart and updates `NOTES.txt` to point users to the active built-in MCP server (`31313`).

  - **Motivation:** Following the post-install instructions in `NOTES.txt` caused `dial tcp4 127.0.0.1:21212: connection refused` because the server binary
only runs the HTTP API server (`8080` / `12121`) and the MCP Bridge (`31313`).
  - **What changed:**
    - `charts/agentregistry/templates/NOTES.txt`: Updated port-forward output to point to `.Values.service.ports.mcp` (`31313`).
    - `charts/agentregistry/values.yaml`: Removed unused `grpc: 21212` keys from `ports`, `targetPorts`, and `nodePorts`.
    - `charts/agentregistry/templates/service.yaml` & `deployment.yaml`: Removed dead `grpc` port entries.
    - `charts/agentregistry/tests/service_test.yaml`: Updated Helm unit tests.
  - **Related issues:** Fixes #595

  # Change Type
``
/kind fix
/kind install
``

# Changelog

```release-note
fix(helm): remove unused grpc port 21212 and point NOTES.txt to MCP bridge
```