### PR TITLE
feat(cli): register Plugin kind for arctl get/list/delete

### DIFF
--- a/internal/cli/declarative/declarative.go
+++ b/internal/cli/declarative/declarative.go
@@ -84,6 +84,14 @@ func init() {
 		promptRow,
 	))
 
+	scheme.Register(typedKind(
+		"plugin", "plugins", []string{"Plugin"},
+		[]scheme.Column{{Header: "NAME"}, {Header: "TAG"}, {Header: "DESCRIPTION"}},
+		v1alpha1.KindPlugin,
+		func() *v1alpha1.Plugin { return &v1alpha1.Plugin{} },
+		pluginRow,
+	))
+
 	// Runtime is registered manually because it is a mutable namespace/name
 	// object: the server's runtime store does not expose /tags or
 	// DeleteAllTags endpoints. Routing it through

--- a/internal/cli/declarative/get_test.go
+++ b/internal/cli/declarative/get_test.go
@@ -82,6 +82,21 @@ func TestModel_AllTagsSupport(t *testing.T) {
 	require.Equal(t, "models", k.Plural)
 }
 
+// TestPlugin_AllTagsSupport pins that Plugin — a tag-versioned artifact kind —
+// resolves via every alias and keeps its tagged-kind wiring (ListTags /
+// DeleteAllTags), so it never silently loses registration or --all-tags support.
+func TestPlugin_AllTagsSupport(t *testing.T) {
+	for _, alias := range []string{"plugin", "plugins", "Plugin"} {
+		k, err := scheme.Lookup(alias)
+		require.NoError(t, err, "%q should resolve via declarative's init() registration", alias)
+		require.NotNil(t, k.ListTags, "tagged Plugin should expose ListTags")
+		require.NotNil(t, k.DeleteAllTags, "tagged Plugin should expose DeleteAllTags")
+		require.Equal(t, "plugin", k.Kind)
+		require.Equal(t, "plugins", k.Plural)
+		require.NotEmpty(t, k.TableColumns, "expected TableColumns on the plugin kind")
+	}
+}
+
 // TestDeployment_NoAllTagsSupport is the symmetric assertion for
 // Deployment — also a mutable namespace/name object. Already
 // covered by TestGet_AllTags_DeploymentRejected at the CLI surface

--- a/internal/cli/declarative/resources.go
+++ b/internal/cli/declarative/resources.go
@@ -178,6 +178,17 @@ func promptRow(prompt *v1alpha1.Prompt) []string {
 	}
 }
 
+func pluginRow(plugin *v1alpha1.Plugin) []string {
+	if plugin == nil {
+		return []string{"<invalid>"}
+	}
+	return []string{
+		printer.TruncateString(plugin.Metadata.Name, 40),
+		plugin.Metadata.Tag,
+		printer.TruncateString(printer.EmptyValueOrDefault(plugin.Spec.Description, "<none>"), 60),
+	}
+}
+
 func runtimeRow(runtime *v1alpha1.Runtime) []string {
 	if runtime == nil {
 		return []string{"<invalid>"}


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don't apply.
-->

# Description

<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->
**What changed:**
- `internal/cli/declarative/declarative.go` — register `Plugin` in `init()` via `typedKind` (aliases `plugin` / `plugins` / `Plugin`; columns NAME/TAG/DESCRIPTION), mirroring the existing `skill` / `prompt` entries. `typedKind` (not `mutableTypedKind`) is correct because `Plugin` is a tag-versioned artifact kind (`KindStorageTaggedArtifact`), like skill/prompt/agent/model — it isn't mutable-storage like runtime/deployment.
- `internal/cli/declarative/resources.go` — add `pluginRow` (name, tag, description), identical shape to `skillRow` / `promptRow`.

Reuses the existing server-side Plugin CRUD endpoint — no server change. `arctl get plugin`, `arctl get plugins`, `arctl get Plugin`, and `--all-tags` now all resolve.
# Change Type

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bump
/kind cleanup
/kind design
/kind deprecation
/kind documentation
/kind feature
/kind fix
/kind flake
/kind install
```
-->
/kind feature
# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
`arctl get`, `list`, and `delete` now support the `Plugin` kind (e.g. `arctl get plugin`).
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
