### PR TITLE
Fix error with `json.RawMessage` breaking registry MCP server tool calls

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/golang-migrate/migrate/v4 v4.19.1
 	github.com/google/go-containerregistry v0.21.3
+	github.com/google/jsonschema-go v0.4.3
 	github.com/jackc/pgx/v5 v5.10.0
 	github.com/joho/godotenv v1.5.1
 	github.com/kagent-dev/kagent/go v0.0.0-20260304171409-232ca4ff4a82
@@ -88,7 +89,6 @@ require (
 	github.com/go-viper/mapstructure/v2 v2.5.0 // indirect
 	github.com/goccy/go-json v0.10.5 // indirect
 	github.com/google/gnostic-models v0.7.1 // indirect
-	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/google/pprof v0.0.0-20260202012954-cb029daf43ef // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect

--- a/internal/mcp/registryserver/server.go
+++ b/internal/mcp/registryserver/server.go
@@ -175,7 +175,7 @@ func outputSchemaFor[T any]() *jsonschema.Schema {
 	}
 	s, err := jsonschema.ForType(rt, &jsonschema.ForOptions{
 		TypeSchemas: map[reflect.Type]*jsonschema.Schema{
-			reflect.TypeFor[json.RawMessage](): &jsonschema.Schema{Types: []string{
+			reflect.TypeFor[json.RawMessage](): {Types: []string{
 				"null", "boolean", "object", "array", "number", "string",
 			}},
 		},

--- a/internal/mcp/registryserver/server.go
+++ b/internal/mcp/registryserver/server.go
@@ -7,10 +7,13 @@ package registryserver
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"reflect"
 	"strings"
 
+	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
 	"github.com/agentregistry-dev/agentregistry/internal/version"
@@ -158,6 +161,31 @@ type kindTools[T v1alpha1.Object] struct {
 	ListFilter ListFilter
 }
 
+// Schemas are built here instead of letting the MCP SDK infer them because
+// the default inference maps json.RawMessage to a byte-array schema,
+// while at marshal time a RawMessage emits the raw JSON it holds (for
+// example status.details is a JSON object). Any envelope carrying a
+// populated RawMessage fails the SDK's output validation.
+// The override only applies to json.RawMessage. A named RawMessage wrapper
+// or a plain []byte field would need its own TypeSchemas entry.
+func outputSchemaFor[T any]() *jsonschema.Schema {
+	rt := reflect.TypeFor[T]()
+	if rt.Kind() == reflect.Pointer {
+		rt = rt.Elem()
+	}
+	s, err := jsonschema.ForType(rt, &jsonschema.ForOptions{
+		TypeSchemas: map[reflect.Type]*jsonschema.Schema{
+			reflect.TypeFor[json.RawMessage](): &jsonschema.Schema{Types: []string{
+				"null", "boolean", "object", "array", "number", "string",
+			}},
+		},
+	})
+	if err != nil {
+		panic(fmt.Sprintf("registryserver: output schema for %v: %v", rt, err))
+	}
+	return s
+}
+
 // addKindTools registers list_X + get_X MCP tools for a v1alpha1 kind.
 // Nil store is a no-op so bootstrap can wire every kind unconditionally
 // and skip ones the backend doesn't expose.
@@ -166,8 +194,9 @@ func addKindTools[T v1alpha1.Object](server *mcp.Server, store *v1alpha1store.St
 		return
 	}
 	mcp.AddTool(server, &mcp.Tool{
-		Name:        cfg.ListName,
-		Description: cfg.ListDesc,
+		Name:         cfg.ListName,
+		Description:  cfg.ListDesc,
+		OutputSchema: outputSchemaFor[listOutput[T]](),
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, args listInput) (*mcp.CallToolResult, listOutput[T], error) {
 		raws, next, err := runList(ctx, store, cfg.Kind, cfg.Authorize, cfg.ListFilter, args)
 		if err != nil {
@@ -180,8 +209,9 @@ func addKindTools[T v1alpha1.Object](server *mcp.Server, store *v1alpha1store.St
 		return nil, listOutput[T]{Items: items, NextCursor: next, Count: len(items)}, nil
 	})
 	mcp.AddTool(server, &mcp.Tool{
-		Name:        cfg.GetName,
-		Description: cfg.GetDesc,
+		Name:         cfg.GetName,
+		Description:  cfg.GetDesc,
+		OutputSchema: outputSchemaFor[T](),
 	}, func(ctx context.Context, _ *mcp.CallToolRequest, args getByRefInput) (*mcp.CallToolResult, T, error) {
 		return getEnvelope(ctx, store, cfg.Kind, cfg.Authorize, args, cfg.NewObj)
 	})

--- a/internal/mcp/registryserver/server_integration_test.go
+++ b/internal/mcp/registryserver/server_integration_test.go
@@ -353,6 +353,15 @@ func TestMCPCatalogTools(t *testing.T) {
 					},
 				})
 				require.NoError(t, err, "seed deployment")
+				// Populated status.details (a JSON object held in a json.RawMessage)
+				// The envelope must survive the tools' output-schema validation.
+				var status v1alpha1.Status
+				require.NoError(t, status.SetDetailsKey("runtimeMetadata", map[string]any{"state": "ready"}))
+				statusJSON, err := json.Marshal(status)
+				require.NoError(t, err, "marshal deployment status")
+				require.NoError(t, stores[v1alpha1.KindDeployment].PatchStatus(ctx, namespace, name, "",
+					func(json.RawMessage) (json.RawMessage, error) { return statusJSON, nil },
+				), "seed deployment status")
 			},
 		},
 		{

--- a/internal/mcp/registryserver/server_test.go
+++ b/internal/mcp/registryserver/server_test.go
@@ -1,0 +1,51 @@
+package registryserver
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/stretchr/testify/require"
+
+	"github.com/agentregistry-dev/agentregistry/pkg/api/v1alpha1"
+)
+
+// A populated status.details is the trigger for the RawMessage schema
+// bug: default inference described json.RawMessage as a byte array, so
+// the JSON object it marshals to failed the SDK's output validation and
+// every list/get on such an envelope errored out.
+func TestOutputSchemaFor_AcceptsPopulatedRawMessage(t *testing.T) {
+	d := &v1alpha1.Deployment{
+		Metadata: v1alpha1.ObjectMeta{Namespace: "default", Name: "test-deployment"},
+	}
+	require.NoError(t, d.Status.SetDetailsKey("runtimeMetadata", map[string]any{"state": "ready"}))
+
+	cases := map[string]struct {
+		schema *jsonschema.Schema
+		value  any
+	}{
+		"list": {
+			schema: outputSchemaFor[listOutput[*v1alpha1.Deployment]](),
+			value:  listOutput[*v1alpha1.Deployment]{Items: []*v1alpha1.Deployment{d}, Count: 1},
+		},
+		"get": {
+			schema: outputSchemaFor[*v1alpha1.Deployment](),
+			value:  d,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			// The SDK requires tool schemas to be objects at the top
+			// level, so pointer outputs must be dereferenced.
+			require.Equal(t, "object", tc.schema.Type)
+
+			resolved, err := tc.schema.Resolve(nil)
+			require.NoError(t, err)
+			raw, err := json.Marshal(tc.value)
+			require.NoError(t, err)
+			var decoded any
+			require.NoError(t, json.Unmarshal(raw, &decoded))
+			require.NoError(t, resolved.Validate(decoded))
+		})
+	}
+}


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don't apply.
-->

# Description

**Motivation:** On resources that emit `json.RawMessage` fields, the existing MCP SDK schema parser/validator fails since it expects it to be a byte array. This means no output is ever returned to a caller of MCP tools like deployments.
**What Changed:** Special handling added for the `json.RawMessage` type so that it gets parsed as appropriate types.

# Change Type

```
/kind fix
```

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
Fix issue where the registry mcp server's tool calls error-ed when returning a resource with raw message data.
```

# Additional Notes

Validation Script (place in repo root):
```sh
set -euo pipefail

cd "$(dirname "$0")"

API_URL="http://localhost:12121"
MCP_URL="http://localhost:31313"
ARCTL="./bin/arctl"

# Pin arctl to the local daemon; a shell-level ARCTL_API_BASE_URL export
# would otherwise redirect apply/get to a remote registry.
export ARCTL_API_BASE_URL="${API_URL}"
AGENT_NAME="mcp-schema-check-agent"
DEPLOYMENT_NAME="mcp-schema-check"

echo "==> Starting local docker environment (builds server image from this tree)"
make run-docker

echo "==> Waiting for the MCP bridge and API to come up"
for i in $(seq 1 60); do
  if curl -sf "${MCP_URL}/healthz" >/dev/null 2>&1 && "${ARCTL}" get runtimes >/dev/null 2>&1; then
    break
  fi
  if [ "$i" -eq 60 ]; then
    echo "ERROR: environment did not become ready" >&2
    exit 1
  fi
  sleep 2
done

echo "==> Publishing agent + deployment"
MANIFEST="$(mktemp -t mcp-schema-check.XXXXXX).yaml"
trap 'rm -f "${MANIFEST}"' EXIT
cat > "${MANIFEST}" <<EOF
apiVersion: ar.dev/v1alpha1
kind: Agent
metadata:
  name: ${AGENT_NAME}
spec:
  description: "Throwaway agent for MCP bridge schema validation"
  source:
    image: nginx:alpine
---
apiVersion: ar.dev/v1alpha1
kind: Deployment
metadata:
  name: ${DEPLOYMENT_NAME}
spec:
  targetRef:
    kind: Agent
    name: ${AGENT_NAME}
  runtimeRef:
    kind: Runtime
    name: local
EOF
"${ARCTL}" apply -f "${MANIFEST}"

echo "==> Waiting for status.details to be populated (controller reconcile)"
for i in $(seq 1 45); do
  if "${ARCTL}" get deployment "${DEPLOYMENT_NAME}" -o yaml 2>/dev/null | grep -q '^  details:'; then
    break
  fi
  if [ "$i" -eq 45 ]; then
    echo "WARNING: status.details still empty after 90s; the repro needs it populated." >&2
    echo "Inspect with: ${ARCTL} get deployment ${DEPLOYMENT_NAME} -o yaml" >&2
    break
  fi
  sleep 2
done
"${ARCTL}" get deployment "${DEPLOYMENT_NAME}" -o yaml | sed -n '/^status:/,$p'

echo "==> Minting a bearer token for the MCP bridge (local dev JWT key)"
# The daemon compose sets JWT_PRIVATE_KEY, which makes the MCP bridge
# reject anonymous calls. Sign a token with the same well-known dev seed
# via the repo's own auth package.
MINT_DIR=".tmp-mint-mcp-token"
mkdir -p "${MINT_DIR}"
cat > "${MINT_DIR}/main.go" <<'GOEOF'
package main

import (
	"context"
	"fmt"
	"time"

	"github.com/golang-jwt/jwt/v5"

	"github.com/agentregistry-dev/agentregistry/internal/registry/config"
	"github.com/agentregistry-dev/agentregistry/pkg/registry/auth"
)

func main() {
	cfg := &config.Config{JWTPrivateKey: "0000000000000000000000000000000000000000000000000000000000000000"}
	resp, err := auth.NewJWTManager(cfg).GenerateTokenResponse(context.Background(), auth.JWTClaims{
		RegisteredClaims: jwt.RegisteredClaims{
			Subject:   "validate-mcp-deployments",
			ExpiresAt: jwt.NewNumericDate(time.Now().Add(24 * time.Hour)),
		},
		AuthMethod:  auth.MethodNone,
		Permissions: []auth.Permission{{Action: auth.PermissionActionRead, ResourcePattern: "*"}},
	})
	if err != nil {
		panic(err)
	}
	fmt.Print(resp.RegistryToken)
}
GOEOF
TOKEN="$(go run "./${MINT_DIR}")"
rm -rf "${MINT_DIR}"

cat <<EOF

============================================================
Environment ready. Now run the Claude side manually:

  1. Register the bridge (token is valid 24h; re-run this script to mint
     a fresh one; 'claude mcp remove agentregistry' first if re-adding):
       claude mcp add --transport http agentregistry ${MCP_URL}/ \\
         --header "Authorization: Bearer ${TOKEN}"

  2. In a Claude Code session, ask:
       "Using the agentregistry MCP server, list deployments and
        get the deployment named ${DEPLOYMENT_NAME}."

  Tear down when done: 
    - make down
    - claude mcp remove agentregistry
============================================================
EOF
```

**Note:** The script has a hacky way of getting an access token to use because the dev server is backed by the `JWT_PRIVATE_KEY`, requiring auth, **but** we don't have an issuer / oauth endpoints configured for that (since we are not an authz server). This means we can only auth via an access token minted, and interactive oauth isn't possible with `JWT_PRIVATE_KEY`. You could theoretically avoid this by not setting `JWT_PRIVATE_KEY` on installation which would make it all public.

Without fix (`main`):
```
Both calls failed with the same MCP output-schema validation error. Let me find where that schema mismatch comes from in the codebase.

[...]
```

With fix:
```
Both calls worked against the agentregistry MCP server. There's exactly one deployment in the registry, and it's the one you asked for:

mcp-schema-check (uid 410d524a-2610-4b51-b4d7-3f8c6edd377a)
- Target: Agent mcp-schema-check-agent
- Runtime: local (docker-compose)
- Created: 2026-07-29 20:47 UTC, last updated 21:59 UTC
- Status conditions:
  - RuntimeConfigured: True — local runtime ready
  - Progressing: True — "docker-compose stack reconciled; waiting for workload convergence"
- Last applied fingerprint: sha256:b1b934bc…
```