### PR TITLE
controller: support configurable deployment dependencies

### DIFF
--- a/internal/registry/controller/controller.go
+++ b/internal/registry/controller/controller.go
@@ -44,6 +44,9 @@ type DeploymentController struct {
 	BatchLimit int
 	Wakeups    <-chan struct{}
 	Queue      workqueue.TypedRateLimitingInterface[deploymentQueueKey]
+	// DependencyKinds extends the built-in resource kinds whose durable events
+	// requeue Deployments. Fingerprint gating prevents unchanged adapter work.
+	DependencyKinds map[string]bool
 
 	mu         sync.RWMutex
 	checkpoint int64
@@ -128,6 +131,9 @@ func (c *DeploymentController) HandleEvent(ctx context.Context, event v1alpha1st
 	case v1alpha1.KindRuntime, v1alpha1.KindAgent, v1alpha1.KindMCPServer, v1alpha1.KindPlugin, v1alpha1.KindSkill, v1alpha1.KindPrompt, v1alpha1.KindModel:
 		return c.FullReconcile(ctx)
 	default:
+		if c.DependencyKinds[event.Key.Kind] {
+			return c.FullReconcile(ctx)
+		}
 		return 0, nil
 	}
 }

--- a/internal/registry/controller/controller_integration_test.go
+++ b/internal/registry/controller/controller_integration_test.go
@@ -90,6 +90,24 @@ func TestDeploymentControllerHandleDependencyEventsFullReconcileDeployments(t *t
 	}
 }
 
+func TestDeploymentControllerHandleConfiguredDependencyEventFullReconcilesDeployments(t *testing.T) {
+	ctx := context.Background()
+	stores := newControllerTestStores(t)
+	seedRuntime(t, stores, "local")
+	seedMCPServer(t, stores, "weather")
+	seedDeployment(t, stores, "api", v1alpha1.DesiredStateDeployed)
+	seedDeployment(t, stores, "worker", v1alpha1.DesiredStateDeployed)
+	controller := newDeploymentTestController(stores, &recordingDeploymentAdapter{})
+	controller.DependencyKinds = map[string]bool{"CustomDependency": true}
+
+	count, err := controller.HandleEvent(ctx, v1alpha1store.ControlPlaneEvent{
+		Key: v1alpha1store.ResourceKey{Kind: "CustomDependency", Namespace: "default", Name: "example"},
+	})
+	require.NoError(t, err)
+	require.Equal(t, 2, count)
+	require.Equal(t, 2, controller.workQueue().Len())
+}
+
 func TestDeploymentControllerRetentionGapTriggersFullReconcile(t *testing.T) {
 	ctx := context.Background()
 	stores := newControllerTestStores(t)

--- a/internal/registry/controller/runner.go
+++ b/internal/registry/controller/runner.go
@@ -40,6 +40,7 @@ type ControllerConfig struct {
 	DiscoveryInterval          time.Duration
 	DiscoveryStaleAfterMisses  int
 	DiscoveryDeleteAfterMisses int
+	DependencyKinds            map[string]bool
 }
 
 // StartDeploymentController constructs the Deployment controller, runs the
@@ -61,10 +62,11 @@ func StartDeploymentController(
 
 	controlPlaneEventStore := v1alpha1store.NewControlPlaneEventStore(pool, pkgdb.MustNewSchema(pkgdb.OSSSchema))
 	controller := &DeploymentController{
-		Stores:   stores,
-		Adapters: adapters,
-		Getter:   internaldb.NewGetter(stores),
-		Events:   controlPlaneEventStore,
+		Stores:          stores,
+		Adapters:        adapters,
+		Getter:          internaldb.NewGetter(stores),
+		Events:          controlPlaneEventStore,
+		DependencyKinds: config.DependencyKinds,
 	}
 	if _, err := controller.Refresh(ctx); err != nil {
 		return nil, fmt.Errorf("deployment controller initial refresh: %w", err)

--- a/internal/registry/registry_app.go
+++ b/internal/registry/registry_app.go
@@ -101,7 +101,7 @@ func App(ctx context.Context, opts ...types.AppOptions) error {
 
 	// v1alpha1 DeploymentAdapter map consumed by the Deployment controller and
 	// adjacent adapter resolver surfaces.
-	// Built OSS-side from the local + kubernetes ports; enterprise extends
+	// Built from the local + kubernetes ports; downstream applications extend
 	// via AppOptions.DeploymentAdapters. Keys are the canonical CamelCase
 	// Spec.Type values; Runtime.Validate canonicalizes user-supplied case
 	// at admission so adapter lookup can use exact-match.
@@ -112,7 +112,9 @@ func App(ctx context.Context, opts ...types.AppOptions) error {
 	maps.Copy(deploymentAdapters, options.DeploymentAdapters)
 	pool := db.Pool()
 	stores := buildStores(pool, options.V1Alpha1StoreTables, options.V1Alpha1MutableStoreKinds, options.Auditor)
-	if _, err := controller.StartDeploymentController(ctx, pool, stores, deploymentAdapters, deploymentControllerConfig(cfg)); err != nil {
+	controllerConfig := deploymentControllerConfig(cfg)
+	controllerConfig.DependencyKinds = maps.Clone(options.DeploymentDependencyKinds)
+	if _, err := controller.StartDeploymentController(ctx, pool, stores, deploymentAdapters, controllerConfig); err != nil {
 		return fmt.Errorf("start deployment controller: %w", err)
 	}
 	// The Plugin controller resolves each plugin's pinned source pointer to a

--- a/pkg/cli/db/migrate/migrate.go
+++ b/pkg/cli/db/migrate/migrate.go
@@ -128,7 +128,7 @@ func sourceNames(srcs []Source) string {
 // unguarded.
 func withSourceMigrator(ctx context.Context, src Source, dsn string, fn func(mg *migrate.Migrate) error) error {
 	return orchestrator.WithSourceLock(ctx, dsn, src.Name, func(_ *sql.DB) error {
-		mg, err := database.NewMigrator(ctx, dsn, src.Files, src.Dir, src.Schema)
+		mg, err := database.NewMigratorWithSearchPath(ctx, dsn, src.Files, src.Dir, src.Schema, src.AdditionalSchemas...)
 		if err != nil {
 			return fmt.Errorf("construct %s migrator: %w", src.Name, err)
 		}

--- a/pkg/registry/database/migrate.go
+++ b/pkg/registry/database/migrate.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io/fs"
 	"net/url"
+	"strings"
 
 	"github.com/golang-migrate/migrate/v4"
 	migratepgx "github.com/golang-migrate/migrate/v4/database/pgx/v5"
@@ -45,6 +46,14 @@ const migrationsTable = "schema_migrations"
 // code; sql.Open is lazy (never pings) and go-migrate's API is
 // synchronous and doesn't accept a context.
 func NewMigrator(ctx context.Context, dsn string, migrationsFS fs.FS, dir string, schema Schema) (*migrate.Migrate, error) {
+	return NewMigratorWithSearchPath(ctx, dsn, migrationsFS, dir, schema)
+}
+
+// NewMigratorWithSearchPath constructs a migrator whose unqualified names
+// resolve first in schema and then in additionalSchemas. Additional schemas
+// let extension migrations call shared functions owned by an earlier source
+// while keeping migration SQL schema-agnostic.
+func NewMigratorWithSearchPath(ctx context.Context, dsn string, migrationsFS fs.FS, dir string, schema Schema, additionalSchemas ...Schema) (*migrate.Migrate, error) {
 	// migratepgx.WithInstance does NOT set search_path on the connection
 	// it acquires — its `SchemaName` config only controls where
 	// `schema_migrations` lives. Unqualified identifiers in migration
@@ -55,7 +64,12 @@ func NewMigrator(ctx context.Context, dsn string, migrationsFS fs.FS, dir string
 	// driver passes it as a connection-startup parameter and every
 	// connection migratepgx pulls from the pool sees the right
 	// search_path from the moment it's established.
-	dsnWithSchema, err := withSearchPath(dsn, schema.Name())
+	searchPath := make([]string, 0, 1+len(additionalSchemas))
+	searchPath = append(searchPath, schema.Name())
+	for _, additional := range additionalSchemas {
+		searchPath = append(searchPath, additional.Name())
+	}
+	dsnWithSchema, err := withSearchPath(dsn, strings.Join(searchPath, ","))
 	if err != nil {
 		return nil, fmt.Errorf("inject search_path into DSN: %w", err)
 	}
@@ -99,17 +113,17 @@ func NewMigrator(ctx context.Context, dsn string, migrationsFS fs.FS, dir string
 }
 
 // withSearchPath returns dsn with the `search_path` connection-startup
-// parameter set to schema. If dsn already specifies a search_path it
+// parameter set to searchPath. If dsn already specifies a search_path it
 // is replaced. Used by NewMigrator so unqualified identifiers in
 // migration SQL resolve against the target schema regardless of the
 // connecting user.
-func withSearchPath(dsn, schema string) (string, error) {
+func withSearchPath(dsn, searchPath string) (string, error) {
 	u, err := url.Parse(dsn)
 	if err != nil {
 		return "", fmt.Errorf("parse DSN: %w", err)
 	}
 	q := u.Query()
-	q.Set("search_path", schema)
+	q.Set("search_path", searchPath)
 	u.RawQuery = q.Encode()
 	return u.String(), nil
 }

--- a/pkg/registry/database/orchestrator/orchestrator.go
+++ b/pkg/registry/database/orchestrator/orchestrator.go
@@ -103,6 +103,11 @@ type Source struct {
 	// table is created in that schema.
 	Schema database.Schema
 
+	// AdditionalSchemas are appended to the migration connection's search_path.
+	// Use this when an extension migration calls a shared function owned by an
+	// earlier source. The source's own Schema always remains first.
+	AdditionalSchemas []database.Schema
+
 	// Files is the embedded filesystem holding NNN_name.up.sql /
 	// NNN_name.down.sql pairs.
 	Files fs.FS
@@ -294,7 +299,7 @@ func restoreSource(ctx context.Context, dsn string, a appliedSource) error {
 		}
 	}()
 
-	mg, err := database.NewMigrator(ctx, dsn, a.src.Files, a.src.Dir, a.src.Schema)
+	mg, err := database.NewMigratorWithSearchPath(ctx, dsn, a.src.Files, a.src.Dir, a.src.Schema, a.src.AdditionalSchemas...)
 	if err != nil {
 		return fmt.Errorf("construct migrator for source %s: %w", a.src.Name, err)
 	}
@@ -421,7 +426,7 @@ func runSource(ctx context.Context, dsn string, src Source) (legacyRan bool, err
 		return false, fmt.Errorf("snapshot schema_migrations row count: %w", err)
 	}
 
-	mg, err := database.NewMigrator(ctx, dsn, src.Files, src.Dir, src.Schema)
+	mg, err := database.NewMigratorWithSearchPath(ctx, dsn, src.Files, src.Dir, src.Schema, src.AdditionalSchemas...)
 	if err != nil {
 		return false, fmt.Errorf("construct migrator: %w", err)
 	}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -226,6 +226,12 @@ type AppOptions struct {
 	// additional adapters here.
 	DeploymentAdapters map[string]DeploymentAdapter
 
+	// DeploymentDependencyKinds registers additional resource kinds whose
+	// durable control-plane events may change a Deployment's desired inputs.
+	// The Deployment controller requeues current Deployments for these events;
+	// its apply fingerprint still suppresses unchanged adapter work.
+	DeploymentDependencyKinds map[string]bool
+
 	// Authorizers gates every read + write operation on the
 	// generic v1alpha1 resource handler, keyed by canonical Kind name
 	// (v1alpha1.KindAgent, v1alpha1.KindMCPServer, etc.). Downstream
@@ -245,7 +251,7 @@ type AppOptions struct {
 	ListFilters map[string]ListFilter
 
 	// PostUpserts run after the generic resource handler PUTs a
-	// row, per kind. Enterprise builds wire this for kinds that need
+	// row, per kind. Downstream applications wire this for kinds that need
 	// runtime side-effects on apply — Runtime apply mirroring spec
 	// into a per-type sidecar table, for example. Missing keys =
 	// no post-upsert hook for that kind.

--- a/test/integration/database/migrate_searchpath_test.go
+++ b/test/integration/database/migrate_searchpath_test.go
@@ -95,3 +95,47 @@ func TestNewMigrator_ReturnsErrNoChangeOnReRun(t *testing.T) {
 	require.True(t, errors.Is(second.Up(), migrate.ErrNoChange))
 	_, _ = second.Close()
 }
+
+func TestNewMigratorWithSearchPath_ResolvesAdditionalSchemaFunction(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	dsn := freshDB(t)
+	db, err := sql.Open("pgx", dsn)
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+	require.NoError(t, db.PingContext(ctx))
+	require.NoError(t, execStatements(ctx, db,
+		"CREATE SCHEMA shared_source",
+		"CREATE FUNCTION shared_source.shared_value() RETURNS integer LANGUAGE sql IMMUTABLE AS 'SELECT 42'",
+	))
+
+	mfs := fstest.MapFS{
+		"migrations/001_init.up.sql":   {Data: []byte("CREATE TABLE resolved_value AS SELECT shared_value() AS value;")},
+		"migrations/001_init.down.sql": {Data: []byte("DROP TABLE resolved_value;")},
+	}
+	mg, err := database.NewMigratorWithSearchPath(
+		ctx,
+		dsn,
+		mfs,
+		"migrations",
+		database.MustNewSchema("dependent_source"),
+		database.MustNewSchema("shared_source"),
+	)
+	require.NoError(t, err)
+	defer func() { _, _ = mg.Close() }()
+	require.NoError(t, mg.Up())
+
+	var value int
+	require.NoError(t, db.QueryRowContext(ctx, "SELECT value FROM dependent_source.resolved_value").Scan(&value))
+	require.Equal(t, 42, value)
+}
+
+func execStatements(ctx context.Context, db *sql.DB, statements ...string) error {
+	for _, statement := range statements {
+		if _, err := db.ExecContext(ctx, statement); err != nil {
+			return err
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
# Description

Allow applications to register durable resource events that requeue Deployments while retaining fingerprint-based apply suppression. Support schema-safe shared migration functions through additional search path entries used consistently by orchestration, restoration, and CLI flows.

# Change Type

```
/kind feature
```

# Changelog

```release-note
NONE
```
