### PR TITLE
fix(model): preserve legacy Agent model fields for one release

### DIFF
--- a/internal/cli/declarative/apply.go
+++ b/internal/cli/declarative/apply.go
@@ -14,6 +14,7 @@ import (
 	"github.com/agentregistry-dev/agentregistry/internal/cli/scheme"
 	"github.com/agentregistry-dev/agentregistry/internal/client"
 	arv0 "github.com/agentregistry-dev/agentregistry/pkg/api/v0"
+	"github.com/agentregistry-dev/agentregistry/pkg/api/v1alpha1"
 	cliruntime "github.com/agentregistry-dev/agentregistry/pkg/cli/runtime"
 )
 
@@ -71,9 +72,11 @@ func runApply(cmd *cobra.Command, deps cliruntime.Deps, dryRun bool) error {
 		}
 
 		// Validate locally via registry decode — catches unknown kinds before sending.
-		if _, err := scheme.DecodeBytes(data); err != nil {
+		objects, err := scheme.DecodeBytes(data)
+		if err != nil {
 			return fmt.Errorf("parsing %s: %w", path, err)
 		}
+		warnLegacyAgentModelConfiguration(cmd.ErrOrStderr(), objects)
 		allData = append(allData, data)
 	}
 
@@ -109,6 +112,24 @@ func runApply(cmd *cobra.Command, deps cliruntime.Deps, dryRun bool) error {
 		return fmt.Errorf("one or more resources failed to apply")
 	}
 	return nil
+}
+
+func warnLegacyAgentModelConfiguration(out io.Writer, objects []v1alpha1.Object) {
+	for _, obj := range objects {
+		agent, ok := obj.(*v1alpha1.Agent)
+		if !ok || !agent.Spec.HasLegacyModelConfiguration() {
+			continue
+		}
+		namespace := agent.Metadata.Namespace
+		if namespace == "" {
+			namespace = v1alpha1.DefaultNamespace
+		}
+		fmt.Fprintf(out,
+			"warning: Agent %s/%s uses deprecated spec.modelProvider/modelName; "+
+				"the values are preserved for compatibility only and do not select a runtime model; "+
+				"migrate each Deployment to spec.modelRef\n",
+			namespace, agent.Metadata.Name)
+	}
 }
 
 // InjectArctlLabels reads the v1alpha1 envelope at yamlPath and, if a sibling

--- a/internal/cli/declarative/apply_test.go
+++ b/internal/cli/declarative/apply_test.go
@@ -91,6 +91,49 @@ func TestApplyPostsToBatchEndpoint(t *testing.T) {
 	assert.Equal(t, "/v0/apply", captured.URL.Path)
 }
 
+func TestApplyWarnsForLegacyAgentModelConfiguration(t *testing.T) {
+	results := []arv0.ApplyResult{
+		{Kind: "agent", Name: "acme-bot", Tag: "latest", Status: arv0.ApplyStatusConfigured},
+	}
+	srv, _ := newApplyTestServer(t, results)
+	legacyAgent := `apiVersion: ar.dev/v1alpha1
+kind: Agent
+metadata:
+  namespace: team-a
+  name: acme-bot
+spec:
+  title: Legacy agent
+  modelProvider: gemini
+  modelName: gemini-2.5-flash
+`
+
+	var stdout, stderr bytes.Buffer
+	cmd := declarative.NewApplyCmd(applyDeps(t, srv))
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{"-f", writeTempYAML(t, legacyAgent)})
+	require.NoError(t, cmd.Execute())
+
+	assert.Contains(t, stderr.String(), "warning: Agent team-a/acme-bot uses deprecated spec.modelProvider/modelName")
+	assert.Contains(t, stderr.String(), "migrate each Deployment to spec.modelRef")
+}
+
+func TestApplyDoesNotWarnForAgentWithoutLegacyModelConfiguration(t *testing.T) {
+	results := []arv0.ApplyResult{
+		{Kind: "agent", Name: "acme-bot", Tag: "latest", Status: arv0.ApplyStatusConfigured},
+	}
+	srv, _ := newApplyTestServer(t, results)
+
+	var stdout, stderr bytes.Buffer
+	cmd := declarative.NewApplyCmd(applyDeps(t, srv))
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{"-f", writeTempYAML(t, agentYAML)})
+	require.NoError(t, cmd.Execute())
+
+	assert.NotContains(t, stderr.String(), "deprecated spec.modelProvider/modelName")
+}
+
 // TestApplyPrintsPerResourceStatus verifies stdout contains per-resource lines.
 func TestApplyPrintsPerResourceStatus(t *testing.T) {
 	results := []arv0.ApplyResult{

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -46,6 +46,12 @@ components:
           type:
           - array
           - "null"
+        modelName:
+          deprecated: true
+          type: string
+        modelProvider:
+          deprecated: true
+          type: string
         plugins:
           items:
             $ref: '#/components/schemas/ResourceRef'

--- a/pkg/api/v1alpha1/agent.go
+++ b/pkg/api/v1alpha1/agent.go
@@ -22,6 +22,16 @@ type AgentSpec struct {
 	Title       string `json:"title,omitempty" yaml:"title,omitempty"`
 	Description string `json:"description,omitempty" yaml:"description,omitempty"`
 
+	// ModelProvider and ModelName are retained for one release so existing
+	// Agent resources continue to decode and round-trip without data loss.
+	//
+	// Deprecated: these fields do not select or configure a runtime model.
+	// New and migrated Deployments must use spec.modelRef; distributions may
+	// temporarily preserve Deployment MODEL_PROVIDER / MODEL_NAME environment
+	// values when modelRef is omitted.
+	ModelProvider string `json:"modelProvider,omitempty" yaml:"modelProvider,omitempty" deprecated:"true"`
+	ModelName     string `json:"modelName,omitempty" yaml:"modelName,omitempty" deprecated:"true"`
+
 	// Source declares where the agent comes from — Image (the runtime
 	// container) and/or Repository (the source code).
 	Source *AgentSource `json:"source,omitempty" yaml:"source,omitempty"`
@@ -43,6 +53,14 @@ type AgentSpec struct {
 	Skills       []ResourceRef `json:"skills,omitempty" yaml:"skills,omitempty"`
 	Instructions *ResourceRef  `json:"instructions,omitempty" yaml:"instructions,omitempty"`
 	MCPServers   []ResourceRef `json:"mcpServers,omitempty" yaml:"mcpServers,omitempty"`
+}
+
+// HasLegacyModelConfiguration reports whether an Agent still carries the
+// one-release compatibility fields. The fields are intentionally
+// non-authoritative; callers should use this only for warnings and migration
+// inventory.
+func (s AgentSpec) HasLegacyModelConfiguration() bool {
+	return s.ModelProvider != "" || s.ModelName != ""
 }
 
 // AgentSource is the distribution origin of a bring-your-own container/source

--- a/pkg/api/v1alpha1/scheme_test.go
+++ b/pkg/api/v1alpha1/scheme_test.go
@@ -92,7 +92,7 @@ func TestScheme_Register_Duplicate(t *testing.T) {
 	}
 }
 
-func TestScheme_Decode_Agent_IgnoresLegacyModelFields(t *testing.T) {
+func TestScheme_Decode_Agent_PreservesLegacyModelFieldsForCompatibility(t *testing.T) {
 	doc := []byte(`
 apiVersion: ar.dev/v1alpha1
 kind: Agent
@@ -131,6 +131,13 @@ spec:
 	if agent.Spec.Source.Image != "ghcr.io/example/summarizer:1.0.0" {
 		t.Fatalf("spec.source.image mismatch: %q", agent.Spec.Source.Image)
 	}
+	if agent.Spec.ModelProvider != "openai" || agent.Spec.ModelName != "gpt-4o" {
+		t.Fatalf("legacy model configuration mismatch: provider=%q model=%q",
+			agent.Spec.ModelProvider, agent.Spec.ModelName)
+	}
+	if !agent.Spec.HasLegacyModelConfiguration() {
+		t.Fatal("expected legacy model configuration to be detected")
+	}
 	if len(agent.Spec.MCPServers) != 1 ||
 		agent.Spec.MCPServers[0].Kind != KindMCPServer ||
 		agent.Spec.MCPServers[0].Name != "github-tools" ||
@@ -141,8 +148,29 @@ spec:
 	if err != nil {
 		t.Fatalf("Encode: %v", err)
 	}
-	if strings.Contains(string(encoded), "modelProvider") || strings.Contains(string(encoded), "modelName") {
-		t.Fatalf("legacy model fields survived decode/encode:\n%s", encoded)
+	if !strings.Contains(string(encoded), "modelProvider: openai") ||
+		!strings.Contains(string(encoded), "modelName: gpt-4o") {
+		t.Fatalf("legacy model fields did not survive decode/encode:\n%s", encoded)
+	}
+}
+
+func TestAgentSpec_HasLegacyModelConfiguration(t *testing.T) {
+	tests := []struct {
+		name string
+		spec AgentSpec
+		want bool
+	}{
+		{name: "none", spec: AgentSpec{}, want: false},
+		{name: "provider only", spec: AgentSpec{ModelProvider: "gemini"}, want: true},
+		{name: "model only", spec: AgentSpec{ModelName: "gemini-2.5-flash"}, want: true},
+		{name: "both", spec: AgentSpec{ModelProvider: "bedrock", ModelName: "claude"}, want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.spec.HasLegacyModelConfiguration(); got != tt.want {
+				t.Fatalf("HasLegacyModelConfiguration() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }
 

--- a/pkg/registry/resource/core.go
+++ b/pkg/registry/resource/core.go
@@ -3,6 +3,7 @@ package resource
 import (
 	"context"
 	"errors"
+	"log/slog"
 
 	arv0 "github.com/agentregistry-dev/agentregistry/pkg/api/v0"
 	"github.com/agentregistry-dev/agentregistry/pkg/api/v1alpha1"
@@ -109,6 +110,15 @@ func applyCore(
 	}
 	if err := v1alpha1.ValidateObjectRegistries(ctx, obj, opts.RegistryValidator); err != nil {
 		return types.AdmissionResult{}, &applyError{Stage: stageRegistries, Err: err}
+	}
+
+	if agent, ok := obj.(*v1alpha1.Agent); ok && agent.Spec.HasLegacyModelConfiguration() {
+		slog.WarnContext(ctx,
+			"Agent uses deprecated model configuration; preserving values for compatibility only",
+			"namespace", meta.Namespace,
+			"name", meta.Name,
+			"migration", "set Deployment.spec.modelRef",
+		)
 	}
 
 	if opts.Prepare != nil {

--- a/ui/lib/api/types.gen.ts
+++ b/ui/lib/api/types.gen.ts
@@ -22,6 +22,14 @@ export type AgentSpec = {
     description?: string;
     instructions?: ResourceRef;
     mcpServers?: Array<ResourceRef> | null;
+    /**
+     * @deprecated
+     */
+    modelName?: string;
+    /**
+     * @deprecated
+     */
+    modelProvider?: string;
     plugins?: Array<ResourceRef> | null;
     skills?: Array<ResourceRef> | null;
     source?: AgentSource;


### PR DESCRIPTION
# Description

Preserves `Agent.spec.modelProvider` and `Agent.spec.modelName` for one release
so existing resources continue to decode and round-trip without data loss
during the Model ownership transition.

The restored fields are deprecated and non-authoritative: new and migrated
workloads select models through `Deployment.spec.modelRef`. CLI and server
apply paths emit an actionable warning when a legacy Agent is encountered, and
the OpenAPI and generated UI contracts mark both fields deprecated.

# Change Type

/kind fix
/kind deprecation

# Changelog

```release-note
Legacy Agent modelProvider and modelName fields remain readable for one compatibility release and emit migration warnings; use Deployment.spec.modelRef for model selection.
```

# Additional Notes

Validation:

- `go test -race -count=1 ./pkg/api/v1alpha1 ./internal/cli/declarative ./pkg/registry/resource`
- `go test -race -count=1 ./...`
- `make lint`
- `make verify`
