### PR TITLE
test: Run E2E only on Kubernetes

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,4 +1,4 @@
-name: E2E Tests
+name: E2E
 
 on:
   pull_request:
@@ -12,11 +12,7 @@ jobs:
   e2e:
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    strategy:
-      fail-fast: false
-      matrix:
-        backend: [k8s, docker]
-    name: e2e (${{ matrix.backend }})
+    name: e2e
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -36,8 +32,8 @@ jobs:
           DOCKER_BUILD_ARGS: "--push --platform linux/amd64"
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-        run: make test-e2e-${{ matrix.backend }}
+        run: make test-e2e
 
       - name: Dump cluster state on failure
-        if: failure() && matrix.backend == 'k8s'
+        if: failure()
         run: make dump-kind-state

--- a/Makefile
+++ b/Makefile
@@ -237,28 +237,11 @@ test-cli-e2e: ## Run CLI subprocess e2e tests (no docker/k8s required; DB cases 
 	@echo "Running CLI e2e tests..."
 	$(GOTESTSUM) --format testdox -- -tags=e2e -timeout 5m ./pkg/cli/...
 
-# Run e2e tests against docker backend (skips Kind cluster setup and k8s tests)
-.PHONY: test-e2e-docker
-test-e2e-docker: local-registry docker docker-tag-as-dev daemon-start
-	@set -e; \
-	  trap '$(MAKE) --no-print-directory daemon-stop-purge >/dev/null 2>&1 || true' EXIT; \
-	  ARCTL_API_BASE_URL=http://localhost:12121/v0 E2E_BACKEND=docker GOOGLE_API_KEY=$(GOOGLE_API_KEY) OPENAI_API_KEY=$(OPENAI_API_KEY) \
-	    $(GOTESTSUM) --format testdox -- -v -tags=e2e -timeout 45m ./test/e2e/...
-
-# Run e2e tests against k8s backend (full Kind cluster setup)
-.PHONY: test-e2e-k8s
-test-e2e-k8s: setup-kind-cluster build-cli
-	KIND_CLUSTER_NAME=$(KIND_CLUSTER_NAME) E2E_BACKEND=k8s GOOGLE_API_KEY=$(GOOGLE_API_KEY) OPENAI_API_KEY=$(OPENAI_API_KEY) \
-	  $(GOTESTSUM) --format testdox -- -v -tags=e2e -timeout 45m ./test/e2e/...
-
-# Run e2e tests (default: k8s)
+# Run e2e tests against a local Kind cluster.
 .PHONY: test-e2e
-test-e2e: ## Run end-to-end tests (default: k8s)
-	@if [ "$(E2E_BACKEND)" = "docker" ]; then \
-	  $(MAKE) test-e2e-docker; \
-	else \
-	  $(MAKE) test-e2e-k8s; \
-	fi
+test-e2e: setup-kind-cluster build-cli ## Run end-to-end tests against Kubernetes
+	KIND_CLUSTER_NAME=$(KIND_CLUSTER_NAME) GOOGLE_API_KEY=$(GOOGLE_API_KEY) OPENAI_API_KEY=$(OPENAI_API_KEY) \
+	  $(GOTESTSUM) --format testdox -- -v -tags=e2e -timeout 45m ./test/e2e/...
 
 .PHONY: gen-openapi
 gen-openapi: ## Generate the OpenAPI specification

--- a/test/e2e/declarative_test.go
+++ b/test/e2e/declarative_test.go
@@ -895,37 +895,24 @@ spec:
 }
 
 // TestApplyDeployment_HTTPIdempotent exercises POST /v0/apply deployment idempotency
-// against the local provider: it builds and publishes an agent, then issues
+// against Kubernetes: it builds and publishes an agent, then issues
 // POST /v0/apply three times with a deployment YAML. The first call deploys;
 // the second and third calls must succeed without error (idempotent re-apply).
-// Skipped on the kubernetes backend.
 func TestApplyDeployment_HTTPIdempotent(t *testing.T) {
-	if IsK8sBackend() {
-		t.Skip("skipping local apply-deployment idempotency test: E2E_BACKEND=k8s")
-	}
-	// Local-provider deploy binds port 8080 via a shared docker-compose
-	// project. Multiple tests exercising that path race on port allocation
-	// and on lazy-cleanup from prior tests, making the suite flaky on CI.
-	// Opt-in via E2E_RUN_LOCAL_DEPLOY=1 to run locally.
-	if os.Getenv("E2E_RUN_LOCAL_DEPLOY") != "1" {
-		t.Skip("skipping local-deploy test; set E2E_RUN_LOCAL_DEPLOY=1 to run")
-	}
-
 	regURL := RegistryURL(t)
 	tmpDir := t.TempDir()
 	agentName := UniqueAgentName("e2eapplydpl")
-	// localhost:5001 is the private registry the daemon runs on the docker
-	// backend. `arctl build --push` pushes to it so the local-provider
-	// deploy can pull it back. Public images don't satisfy the adapter's
+	// localhost:5001 is the private registry connected to the Kind cluster.
+	// `arctl build --push` pushes to it so the Kubernetes adapter can deploy
+	// the image. Public images don't satisfy the adapter's
 	// expected container shape, so we build a real one.
 	agentImage := fmt.Sprintf("localhost:5001/%s:e2e", agentName)
 
 	t.Cleanup(func() { RemoveDeploymentsByServerName(t, regURL, agentName) })
-	t.Cleanup(func() { removeLocalDeployment(t) })
 
-	// Init → build+push → apply. Build is required: the local-provider
+	// Init -> build+push -> apply. Build is required: the Kubernetes adapter
 	// deploy actually pulls the tagged image and starts it, so the image
-	// must exist in the daemon's localhost:5001 registry first.
+	// must exist in the localhost:5001 registry first.
 	result := RunArctl(t, tmpDir,
 		"init", "agent", agentName,
 		"--framework", "adk", "--language", "python",
@@ -952,7 +939,7 @@ spec:
     name: %s
   runtimeRef:
     kind: Runtime
-    name: local
+    name: kubernetes-default
 `, agentName, agentName)
 
 	httpClient := &http.Client{Timeout: 60 * time.Second}
@@ -1148,8 +1135,7 @@ spec:
 
 // TestBatchApply_DriftRequiresForce verifies that applying a deployment whose
 // config has drifted from the running deployment fails without --force and
-// succeeds with --force. This test only runs on the docker backend, as it
-// requires a live local deployment that can be in-flight.
+// succeeds with --force.
 //
 // The test uses the Deployment kind's ErrDeploymentDrift path by:
 //  1. Publishing an agent and deploying it.
@@ -1157,31 +1143,20 @@ spec:
 //  3. Re-applying without --force — expects failure with a "force" hint.
 //  4. Re-applying with --force — expects success.
 func TestBatchApply_DriftRequiresForce(t *testing.T) {
-	if IsK8sBackend() {
-		t.Skip("skipping drift test: not applicable on k8s backend (requires local docker provider)")
-	}
-	// See TestApplyDeployment_HTTPIdempotent: local-deploy races on port 8080
-	// against other deploy tests when cleanup lags; opt-in via env var.
-	if os.Getenv("E2E_RUN_LOCAL_DEPLOY") != "1" {
-		t.Skip("skipping local-deploy test; set E2E_RUN_LOCAL_DEPLOY=1 to run")
-	}
-
 	regURL := RegistryURL(t)
 	tmpDir := t.TempDir()
 	agentName := UniqueAgentName("driftbatch")
 	agentImage := fmt.Sprintf("localhost:5001/%s:e2e", agentName)
 	agentTag := defaultArtifactTag
-	runtimeID := "local"
+	runtimeID := "kubernetes-default"
 
 	t.Cleanup(func() {
 		RemoveDeploymentsByServerName(t, regURL, agentName)
-		removeLocalDeployment(t)
 		RunArctl(t, tmpDir, "delete", "agent", agentName, "--tag", agentTag, "--registry-url", regURL)
 	})
 
-	// Step 1: init → build+push → apply the agent. Build pushes to the
-	// daemon's private localhost:5001 registry so the subsequent local
-	// deploy can pull it.
+	// Step 1: init -> build+push -> apply the agent. Build pushes to the
+	// localhost:5001 registry connected to Kind so Kubernetes can pull it.
 	result := RunArctl(t, tmpDir, "init", "agent", agentName,
 		"--framework", "adk", "--language", "python",
 		"--model-name", "gemini-2.5-flash",
@@ -1724,36 +1699,26 @@ func TestDeclarativeDelete_NotFound(t *testing.T) {
 	RequireOutputContains(t, result, "not found")
 }
 
-// TestDeploymentGet_YAMLIncludesStatus creates an agent + local deployment,
+// TestDeploymentGet_YAMLIncludesStatus creates an agent and deployment,
 // then checks that `arctl get deployment NAME -o yaml` renders a .status
 // block (phase/id/origin) in addition to the declarative spec. Round-trips
 // the output through `arctl apply` to confirm status is silently dropped on
 // input.
 func TestDeploymentGet_YAMLIncludesStatus(t *testing.T) {
-	if IsK8sBackend() {
-		t.Skip("skipping local deployment status test: E2E_BACKEND=k8s")
-	}
-	// See TestApplyDeployment_HTTPIdempotent: local-deploy races on port 8080
-	// against other deploy tests when cleanup lags; opt-in via env var.
-	if os.Getenv("E2E_RUN_LOCAL_DEPLOY") != "1" {
-		t.Skip("skipping local-deploy test; set E2E_RUN_LOCAL_DEPLOY=1 to run")
-	}
-
 	regURL := RegistryURL(t)
 	tmpDir := t.TempDir()
 	agentName := UniqueAgentName("e2estatus")
 	tag := defaultArtifactTag
-	// Local-provider deploys pull from localhost:5001 (the daemon's private
-	// registry). Scaffold → build+push so the image resolves at deploy time.
+	// Kubernetes deploys pull from the registry connected to the Kind cluster.
+	// Scaffold -> build+push so the image resolves at deploy time.
 	agentImage := fmt.Sprintf("localhost:5001/%s:e2e", agentName)
 
 	t.Cleanup(func() { RemoveDeploymentsByServerName(t, regURL, agentName) })
-	t.Cleanup(func() { removeLocalDeployment(t) })
 	t.Cleanup(func() {
 		RunArctl(t, tmpDir, "delete", "agent", agentName, "--tag", tag, "--registry-url", regURL)
 	})
 
-	// init → build+push → apply — same shape as TestApplyDeployment_HTTPIdempotent.
+	// init -> build+push -> apply, as in TestApplyDeployment_HTTPIdempotent.
 	RequireSuccess(t, RunArctl(t, tmpDir,
 		"init", "agent", agentName,
 		"--framework", "adk", "--language", "python",
@@ -1776,7 +1741,7 @@ spec:
     tag: %s
   runtimeRef:
     kind: Runtime
-    name: local
+    name: kubernetes-default
 `, agentName, agentName, tag)
 	deployPath := writeDeclarativeYAML(t, tmpDir, "deployment.yaml", deployYAML)
 	RequireSuccess(t, RunArctl(t, tmpDir, "apply", "-f", deployPath, "--registry-url", regURL))
@@ -1786,14 +1751,14 @@ spec:
 	RequireSuccess(t, result)
 	RequireOutputContains(t, result, "apiVersion: ar.dev/v1alpha1")
 	RequireOutputContains(t, result, "kind: Deployment")
-	// Spec fields — declarative, round-trippable.
+	// Spec fields are declarative and round-trippable.
 	RequireOutputContains(t, result, "runtimeRef:")
-	RequireOutputContains(t, result, "name: local")
+	RequireOutputContains(t, result, "name: kubernetes-default")
 	RequireOutputContains(t, result, "kind: Runtime")
-	// Status block — server-managed.
+	// Status block is server-managed.
 	RequireOutputContains(t, result, "status:")
 	// phase may be "deploying" or "deployed" depending on how fast the
-	// reconciler runs for the local runtime; both assert the status block.
+	// Kubernetes reconciler runs; both assert the status block.
 	if !strings.Contains(result.Stdout, "phase:") {
 		t.Fatalf("expected .status.phase in get output, got:\n%s", result.Stdout)
 	}
@@ -1813,10 +1778,6 @@ spec:
 // agent does not exist. Apply must exit non-zero with a clear error message
 // identifying the missing template — not silently create a ghost row.
 func TestDeploymentApply_BadTemplateRef(t *testing.T) {
-	if IsK8sBackend() {
-		t.Skip("skipping bad-templateRef test: E2E_BACKEND=k8s")
-	}
-
 	regURL := RegistryURL(t)
 	tmpDir := t.TempDir()
 	// Name intentionally NOT created as an agent.
@@ -1833,7 +1794,7 @@ spec:
     tag: latest
   runtimeRef:
     kind: Runtime
-    name: local
+    name: kubernetes-default
 `, missingName, missingName)
 	deployPath := writeDeclarativeYAML(t, tmpDir, "deployment.yaml", deployYAML)
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -38,30 +38,17 @@ func TestMain(m *testing.M) {
 	// otherwise re-resolve against whatever cwd a test happens to be in.
 	os.Setenv("ARCTL_BINARY", resolveArctlBinaryPath())
 
-	var cleanupFns []func()
-
-	registryURL = os.Getenv("ARCTL_API_BASE_URL")
-	if IsK8sBackend() {
-		var cleanup func()
-		registryURL, cleanup = resolveRegistryURL()
-		cleanupFns = append(cleanupFns, cleanup)
-	}
-	if registryURL == "" {
-		log.Fatal("ARCTL_API_BASE_URL not set — run tests via `make test-e2e-docker` or `make test-e2e-k8s`")
-	}
+	var cleanup func()
+	registryURL, cleanup = resolveRegistryURL()
 	os.Setenv("ARCTL_API_BASE_URL", registryURL)
 
 	log.Printf("Configuration:")
 	log.Printf("  ARCTL_API_BASE_URL: %s", registryURL)
 	log.Printf("  GOOGLE_API_KEY:     %s", maskEnv("GOOGLE_API_KEY"))
-	if IsK8sBackend() {
-		log.Printf("  Cluster:            %s (context: %s)", e2eClusterName, e2eKubeContext)
-	}
+	log.Printf("  Cluster:            %s (context: %s)", e2eClusterName, e2eKubeContext)
 
 	code := m.Run()
-	for i := len(cleanupFns) - 1; i >= 0; i-- {
-		cleanupFns[i]()
-	}
+	cleanup()
 	os.Exit(code)
 }
 
@@ -166,14 +153,12 @@ func checkPrerequisites() {
 	if _, err := exec.LookPath("docker"); err != nil {
 		log.Fatalf("docker not found in PATH -- required for e2e tests")
 	}
-	if IsK8sBackend() {
-		if _, err := exec.LookPath("kubectl"); err != nil {
-			log.Fatalf("kubectl not found in PATH -- required for k8s e2e tests")
-		}
-		toolsModfile := filepath.Join(testDir(), "..", "..", "tools", "go.mod")
-		if out, err := exec.Command("go", "tool", "-modfile="+toolsModfile, "kind", "version").CombinedOutput(); err != nil {
-			log.Fatalf("kind not available via tools/go.mod -- required for k8s e2e tests: %v\n%s", err, out)
-		}
+	if _, err := exec.LookPath("kubectl"); err != nil {
+		log.Fatalf("kubectl not found in PATH -- required for e2e tests")
+	}
+	toolsModfile := filepath.Join(testDir(), "..", "..", "tools", "go.mod")
+	if out, err := exec.Command("go", "tool", "-modfile="+toolsModfile, "kind", "version").CombinedOutput(); err != nil {
+		log.Fatalf("kind not available via tools/go.mod -- required for e2e tests: %v\n%s", err, out)
 	}
 }
 
@@ -219,29 +204,6 @@ func TestArctlVersion(t *testing.T) {
 	RequireSuccess(t, result)
 	RequireOutputContains(t, result, "arctl version")
 	RequireOutputContains(t, result, "Server version:")
-}
-
-// TestDaemonContainersRunning verifies that the agentregistry daemon
-// containers (server + postgres) are running. Only applicable to the
-// docker backend where containers are managed by docker compose.
-func TestDaemonContainersRunning(t *testing.T) {
-	if IsK8sBackend() {
-		t.Skip("Skipping: docker-compose containers are not used in k8s backend")
-	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
-	for _, container := range []string{"agentregistry-server", "agent-registry-postgres"} {
-		cmd := exec.CommandContext(ctx, "docker", "inspect", "--format", "{{.State.Running}}", container)
-		out, err := cmd.Output()
-		if err != nil {
-			t.Fatalf("Failed to inspect container %s: %v", container, err)
-		}
-		if got := strings.TrimSpace(string(out)); got != "true" {
-			t.Fatalf("Expected container %s to be running, got state: %s", container, got)
-		}
-	}
 }
 
 // TestRegistryHealth verifies the registry health endpoint responds with 200.

--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -4,7 +4,6 @@ package e2e
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -17,19 +16,8 @@ import (
 	"time"
 )
 
-// localDeployComposeProject is the docker-compose project label the local
-// deploy adapter uses for its runtime containers. Tests that apply a
-// deployment with `runtimeRef.name: local` use this to clean up after themselves.
-const localDeployComposeProject = "agentregistry_runtime"
-
 // registryURL is set during TestMain setup and used by all tests that need the registry.
 var registryURL string
-
-// IsK8sBackend returns true when the e2e backend is kubernetes (the default).
-// Returns false when E2E_BACKEND=docker, which skips Kind setup and k8s-only tests.
-func IsK8sBackend() bool {
-	return os.Getenv("E2E_BACKEND") == "k8s"
-}
 
 // getEnv returns the value of the environment variable named by key,
 // or defaultVal if the variable is unset or empty.
@@ -279,29 +267,4 @@ func UniqueNameWithPrefix(prefix string) string {
 // must start with a letter, contain only letters and digits, minimum 2 characters.
 func UniqueAgentName(prefix string) string {
 	return fmt.Sprintf("%s%d", prefix, time.Now().UnixNano()%100000)
-}
-
-// removeLocalDeployment tears down any docker-compose containers left behind
-// by a local-runtime deployment. Idempotent — no-op when nothing matches.
-// Used in t.Cleanup from tests that apply deployments with `runtimeRef.name: local`.
-// Survives even if the test's apply step failed before a deployment ran.
-func removeLocalDeployment(t *testing.T) {
-	t.Helper()
-	t.Logf("Cleaning up local deployment...")
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-	projectFilter := "label=com.docker.compose.project=" + localDeployComposeProject
-
-	listCmd := exec.CommandContext(ctx, "docker", "ps", "-a", "-q", "--filter", projectFilter)
-	out, err := listCmd.Output()
-	if err != nil || strings.TrimSpace(string(out)) == "" {
-		return
-	}
-
-	ids := strings.Fields(strings.TrimSpace(string(out)))
-	rmArgs := append([]string{"rm", "-f"}, ids...)
-	rmCmd := exec.CommandContext(ctx, "docker", rmArgs...)
-	if out, err := rmCmd.CombinedOutput(); err != nil {
-		t.Logf("Warning: failed to remove local deployment containers: %v\n%s", err, string(out))
-	}
 }


### PR DESCRIPTION
# Description

AgentRegistry end-to-end coverage uses Kubernetes as its supported deployment
environment. Remove the Docker backend from the workflow matrix and Makefile so
local and CI invocations of `make test-e2e` always provision and target Kind.

Move deployment behavior checks to the `kubernetes-default` runtime and remove
backend selection flags, Compose container assertions, and local-runtime cleanup
that only served the Docker E2E path.

# Change Type

/kind cleanup

# Changelog

```release-note
NONE
```

# Additional Notes

Docker remains a tool dependency for Kind and CLI image-build coverage, but is
no longer an alternate registry backend in the E2E suite.

Verified with an E2E package compile and `make lint`. The full E2E suite is left
to CI because it provisions the complete Kind environment.
