### PR TITLE
agent: add protocol to source specification

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -24,6 +24,11 @@ components:
       properties:
         image:
           type: string
+        protocol:
+          enum:
+          - A2A
+          - HTTP
+          type: string
         repository:
           $ref: '#/components/schemas/Repository'
       type: object

--- a/pkg/api/v1alpha1/agent.go
+++ b/pkg/api/v1alpha1/agent.go
@@ -73,7 +73,20 @@ type AgentSource struct {
 
 	// Repository links to the source code the image was built from.
 	Repository *Repository `json:"repository,omitempty" yaml:"repository,omitempty"`
+
+	// Protocol is the application protocol spoken by every runnable form of the
+	// agent, whether built from Repository or supplied as Image. When omitted,
+	// A2A is inferred as the default.
+	Protocol *AgentProtocol `json:"protocol,omitempty" yaml:"protocol,omitempty" enum:"A2A,HTTP"`
 }
+
+// AgentProtocol is the application protocol exposed by an Agent source.
+type AgentProtocol string
+
+const (
+	AgentProtocolA2A  AgentProtocol = "A2A"
+	AgentProtocolHTTP AgentProtocol = "HTTP"
+)
 
 // HarnessCompatibility declares one harness family this Agent can run under.
 // Rollout policy selection lives on Deployment so the same Agent can be rolled

--- a/pkg/api/v1alpha1/agent_validate.go
+++ b/pkg/api/v1alpha1/agent_validate.go
@@ -3,6 +3,8 @@ package v1alpha1
 import (
 	"context"
 	"fmt"
+
+	"k8s.io/utils/ptr"
 )
 
 // Validate runs structural validation on the Agent envelope: ObjectMeta
@@ -65,6 +67,14 @@ func validateAgentSpec(s *AgentSpec) FieldErrors {
 	if s.Source != nil {
 		for _, e := range validateRepository(s.Source.Repository) {
 			errs.Append("spec.source."+e.Path, e.Cause)
+		}
+		if s.Source.Protocol != nil {
+			protocol := ptr.Deref(s.Source.Protocol, AgentProtocol(""))
+			switch protocol {
+			case AgentProtocolA2A, AgentProtocolHTTP:
+			default:
+				errs.Append("spec.source.protocol", fmt.Errorf("%w: must be %q or %q, got %q", ErrInvalidFormat, AgentProtocolA2A, AgentProtocolHTTP, protocol))
+			}
 		}
 	}
 	errs = append(errs, validateHarnessCompatibility(s.CompatibleHarnesses)...)

--- a/pkg/api/v1alpha1/validation_test.go
+++ b/pkg/api/v1alpha1/validation_test.go
@@ -112,6 +112,37 @@ func TestAgentValidate_AcceptsBlankOptionalFields(t *testing.T) {
 	require.NoError(t, a.Validate())
 }
 
+func TestAgentValidate_Protocol(t *testing.T) {
+	tests := []struct {
+		name     string
+		protocol *AgentProtocol
+		wantErr  bool
+	}{
+		{name: "omitted defaults at consumption"},
+		{name: "A2A", protocol: new(AgentProtocolA2A)},
+		{name: "HTTP", protocol: new(AgentProtocolHTTP)},
+		{name: "reject empty", protocol: new(AgentProtocol("")), wantErr: true},
+		{name: "reject lowercase", protocol: new(AgentProtocol("http")), wantErr: true},
+		{name: "reject unknown", protocol: new(AgentProtocol("GRPC")), wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			agent := &Agent{
+				Metadata: ObjectMeta{Namespace: "default", Name: "protocol-agent"},
+				Spec:     AgentSpec{Source: &AgentSource{Protocol: tt.protocol}},
+			}
+			err := agent.Validate()
+			if tt.wantErr {
+				require.Error(t, err)
+				require.Contains(t, failedFields(t, err), "spec.source.protocol")
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
 func TestAgentValidate_AccumulatesErrors(t *testing.T) {
 	a := &Agent{
 		Metadata: ObjectMeta{Namespace: "default", Name: "a"},

--- a/ui/lib/api/types.gen.ts
+++ b/ui/lib/api/types.gen.ts
@@ -14,6 +14,7 @@ export type Agent = {
 
 export type AgentSource = {
     image?: string;
+    protocol?: 'A2A' | 'HTTP';
     repository?: Repository;
 };
 


### PR DESCRIPTION
# Description

Allow agents to declare whether their runnable source speaks A2A or HTTP. Keep the field optional and infer A2A when it is omitted.

# Change Type

```
/kind feature
```

# Changelog

```release-note
Agents can optionally declare A2A or HTTP as their source protocol.
```