### PR TITLE
Fix/share cli resolution

### DIFF
--- a/pkg/cli/README.md
+++ b/pkg/cli/README.md
@@ -28,6 +28,8 @@ registry as built-in commands. Commands using an extended downstream client
 should call `deps.Runtime.ResolveRegistryTarget` and pass the returned base URL
 and token to that client; commands using the OSS API client can call
 `deps.Runtime.RegistryClient` directly.
+`ResolveRegistryTarget` replaces the former partial `RegistryTarget` getter so
+callers cannot bypass token resolution.
 
 The OSS migration source is always registered first by `Root`. Extra migration
 sources are appended in config order. When more than one source is present,

--- a/pkg/cli/README.md
+++ b/pkg/cli/README.md
@@ -11,15 +11,23 @@ root := cli.Root(cli.Config{
 	Disabled: map[string]bool{
 		"db migrate goto": true,
 	},
-	ExtraCommands: []*cobra.Command{
-		runtime.NewCommand(),
-		user.UserCommand(ctx),
+	ExtraCommands: func(deps cliruntime.Deps) []*cobra.Command {
+		return []*cobra.Command{
+			runtime.NewCommand(deps),
+			user.UserCommand(ctx, deps),
+		}
 	},
 	ExtraMigrationSources: []migrate.Source{
 		entlegacymigrate.EnterpriseSource(),
 	},
 })
 ```
+
+Extra commands receive the same runtime, authentication provider, and kind
+registry as built-in commands. Commands using an extended downstream client
+should call `deps.Runtime.ResolveRegistryTarget` and pass the returned base URL
+and token to that client; commands using the OSS API client can call
+`deps.Runtime.RegistryClient` directly.
 
 The OSS migration source is always registered first by `Root`. Extra migration
 sources are appended in config order. When more than one source is present,

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -85,11 +85,13 @@ func Root(cfg Config) *cobra.Command {
 
 	removeDisabledCommands(root, cfg.Disabled)
 
-	for _, cmd := range cfg.ExtraCommands {
-		if cmd == nil {
-			continue
+	if cfg.ExtraCommands != nil {
+		for _, cmd := range cfg.ExtraCommands(deps) {
+			if cmd == nil {
+				continue
+			}
+			root.AddCommand(cmd)
 		}
-		root.AddCommand(cmd)
 	}
 
 	return root
@@ -136,7 +138,7 @@ type Config struct {
 	Env  cliruntime.Env
 	Auth cliruntime.AuthProvider
 
-	ExtraCommands []*cobra.Command
+	ExtraCommands func(cliruntime.Deps) []*cobra.Command
 	Disabled      map[string]bool // command paths to remove, such as "db migrate goto"
 
 	ExtraMigrationSources []migrate.Source

--- a/pkg/cli/root_test.go
+++ b/pkg/cli/root_test.go
@@ -6,7 +6,59 @@ import (
 	"github.com/spf13/cobra"
 
 	dbmigrate "github.com/agentregistry-dev/agentregistry/pkg/cli/db/migrate"
+	cliruntime "github.com/agentregistry-dev/agentregistry/pkg/cli/runtime"
 )
+
+func TestRootExtraCommandsReceiveDeps(t *testing.T) {
+	var (
+		factoryCalls int
+		gotDeps      cliruntime.Deps
+		gotTarget    cliruntime.RegistryTarget
+	)
+	cfg := DefaultConfig()
+	cfg.ExtraCommands = func(deps cliruntime.Deps) []*cobra.Command {
+		factoryCalls++
+		gotDeps = deps
+		return []*cobra.Command{{
+			Use: "enterprise",
+			RunE: func(cmd *cobra.Command, _ []string) error {
+				var err error
+				gotTarget, err = deps.Runtime.ResolveRegistryTarget(cmd.Context())
+				return err
+			},
+		}}
+	}
+
+	root := Root(cfg)
+	root.SetArgs([]string{
+		"--registry-url", "registry.example.com",
+		"--registry-token", "flag-token",
+		"enterprise",
+	})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	if factoryCalls != 1 {
+		t.Fatalf("ExtraCommands() calls = %d, want 1", factoryCalls)
+	}
+	if gotDeps.Runtime == nil {
+		t.Fatal("ExtraCommands() received nil Runtime")
+	}
+	if gotDeps.Auth != cfg.Auth {
+		t.Fatal("ExtraCommands() received a different Auth provider")
+	}
+	if gotDeps.Kinds == nil {
+		t.Fatal("ExtraCommands() received nil Kinds registry")
+	}
+	wantTarget := cliruntime.RegistryTarget{
+		BaseURL: "http://registry.example.com",
+		Token:   "flag-token",
+	}
+	if gotTarget != wantTarget {
+		t.Fatalf("resolved target = %#v, want %#v", gotTarget, wantTarget)
+	}
+}
 
 func TestRootDisabledCommandPaths(t *testing.T) {
 	cfg := DefaultConfig()

--- a/pkg/cli/runtime/runtime.go
+++ b/pkg/cli/runtime/runtime.go
@@ -70,7 +70,7 @@ func (r *runtime) ResolveRegistryTarget(ctx context.Context) (RegistryTarget, er
 			err = nil
 		}
 		if err != nil {
-			return RegistryTarget{}, err
+			return RegistryTarget{}, fmt.Errorf("resolving registry token: %w", err)
 		}
 		target.Token = token
 	}

--- a/pkg/cli/runtime/runtime.go
+++ b/pkg/cli/runtime/runtime.go
@@ -20,7 +20,7 @@ type RegistryTarget struct {
 
 // Runtime is the command-facing runtime contract.
 type Runtime interface {
-	RegistryTarget() RegistryTarget
+	ResolveRegistryTarget(ctx context.Context) (RegistryTarget, error)
 	RegistryClient(ctx context.Context) (*client.Client, error)
 }
 
@@ -39,7 +39,10 @@ func New(cfg Config) Runtime {
 	return &runtime{cfg: cfg}
 }
 
-func (r *runtime) RegistryTarget() RegistryTarget {
+// ResolveRegistryTarget resolves the registry address and bearer token for a
+// command invocation. Explicit flags take precedence over environment values;
+// AuthProvider is consulted only when neither supplies a token.
+func (r *runtime) ResolveRegistryTarget(ctx context.Context) (RegistryTarget, error) {
 	var baseURL string
 	if r.cfg.RegistryURL != nil {
 		baseURL = *r.cfg.RegistryURL
@@ -56,10 +59,29 @@ func (r *runtime) RegistryTarget() RegistryTarget {
 		token = r.cfg.Env.Getenv("ARCTL_API_TOKEN")
 	}
 
-	return RegistryTarget{
+	target := RegistryTarget{
 		BaseURL: normalizeBaseURL(baseURL),
 		Token:   token,
 	}
+	if target.Token == "" {
+		token, err := r.cfg.Auth.Token(ctx)
+		if errors.Is(err, types.ErrCLINoStoredToken) {
+			token = ""
+			err = nil
+		}
+		if err != nil {
+			return RegistryTarget{}, err
+		}
+		target.Token = token
+	}
+
+	if r.cfg.OnTokenResolved != nil {
+		if err := r.cfg.OnTokenResolved(target.Token); err != nil {
+			return RegistryTarget{}, fmt.Errorf("calling token resolved callback: %w", err)
+		}
+	}
+
+	return target, nil
 }
 
 // RegistryClient returns the shared registry client for this CLI invocation.
@@ -72,25 +94,10 @@ func (r *runtime) RegistryTarget() RegistryTarget {
 // available.
 func (r *runtime) RegistryClient(ctx context.Context) (*client.Client, error) {
 	r.clientOnce.Do(func() {
-		target := r.RegistryTarget()
-		if target.Token == "" {
-			token, err := r.cfg.Auth.Token(ctx)
-			if errors.Is(err, types.ErrCLINoStoredToken) {
-				token = ""
-				err = nil
-			}
-			if err != nil {
-				r.clientErr = err
-				return
-			}
-			target.Token = token
-		}
-
-		if r.cfg.OnTokenResolved != nil {
-			if err := r.cfg.OnTokenResolved(target.Token); err != nil {
-				r.clientErr = fmt.Errorf("calling token resolved callback: %w", err)
-				return
-			}
+		target, err := r.ResolveRegistryTarget(ctx)
+		if err != nil {
+			r.clientErr = err
+			return
 		}
 
 		r.client = client.NewClient(target.BaseURL, target.Token)

--- a/pkg/cli/runtime/runtime_test.go
+++ b/pkg/cli/runtime/runtime_test.go
@@ -14,6 +14,117 @@ func (f authProviderFunc) Token(ctx context.Context) (string, error) {
 	return f(ctx)
 }
 
+type envMap map[string]string
+
+func (e envMap) Getenv(key string) string {
+	return e[key]
+}
+
+func TestResolveRegistryTarget(t *testing.T) {
+	authErr := errors.New("auth failed")
+	tests := []struct {
+		name          string
+		flagURL       string
+		flagToken     string
+		env           envMap
+		authToken     string
+		authErr       error
+		want          RegistryTarget
+		wantErr       error
+		wantAuthCalls int
+	}{
+		{
+			name:      "flags take precedence over environment and stored token",
+			flagURL:   "https://flag.example.com/v0",
+			flagToken: "flag-token",
+			env: envMap{
+				"ARCTL_API_BASE_URL": "https://env.example.com/v0",
+				"ARCTL_API_TOKEN":    "env-token",
+			},
+			authToken: "stored-token",
+			want: RegistryTarget{
+				BaseURL: "https://flag.example.com/v0",
+				Token:   "flag-token",
+			},
+		},
+		{
+			name: "environment takes precedence over stored token",
+			env: envMap{
+				"ARCTL_API_BASE_URL": "env.example.com",
+				"ARCTL_API_TOKEN":    "env-token",
+			},
+			authToken: "stored-token",
+			want: RegistryTarget{
+				BaseURL: "http://env.example.com",
+				Token:   "env-token",
+			},
+		},
+		{
+			name:          "stored token is used when flag and environment are empty",
+			authToken:     "stored-token",
+			wantAuthCalls: 1,
+			want: RegistryTarget{
+				BaseURL: "http://localhost:12121/v0",
+				Token:   "stored-token",
+			},
+		},
+		{
+			name:          "missing stored token allows unauthenticated target",
+			authErr:       types.ErrCLINoStoredToken,
+			wantAuthCalls: 1,
+			want: RegistryTarget{
+				BaseURL: "http://localhost:12121/v0",
+			},
+		},
+		{
+			name:          "auth provider error is returned",
+			authErr:       authErr,
+			wantErr:       authErr,
+			wantAuthCalls: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			authCalls := 0
+			resolvedTokens := make([]string, 0, 1)
+			rt := New(Config{
+				Env:           tt.env,
+				RegistryURL:   &tt.flagURL,
+				RegistryToken: &tt.flagToken,
+				Auth: authProviderFunc(func(context.Context) (string, error) {
+					authCalls++
+					return tt.authToken, tt.authErr
+				}),
+				OnTokenResolved: func(token string) error {
+					resolvedTokens = append(resolvedTokens, token)
+					return nil
+				},
+			})
+
+			got, err := rt.ResolveRegistryTarget(context.Background())
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("ResolveRegistryTarget() error = %v, want %v", err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Fatalf("ResolveRegistryTarget() = %#v, want %#v", got, tt.want)
+			}
+			if authCalls != tt.wantAuthCalls {
+				t.Fatalf("AuthProvider.Token() calls = %d, want %d", authCalls, tt.wantAuthCalls)
+			}
+			if tt.wantErr != nil {
+				if len(resolvedTokens) != 0 {
+					t.Fatalf("OnTokenResolved() tokens = %q, want no calls", resolvedTokens)
+				}
+				return
+			}
+			if len(resolvedTokens) != 1 || resolvedTokens[0] != tt.want.Token {
+				t.Fatalf("OnTokenResolved() tokens = %q, want [%q]", resolvedTokens, tt.want.Token)
+			}
+		})
+	}
+}
+
 func TestRegistryClientAllowsMissingStoredToken(t *testing.T) {
 	var resolvedToken string
 	rt := New(Config{

--- a/pkg/cli/runtime/runtime_test.go
+++ b/pkg/cli/runtime/runtime_test.go
@@ -125,6 +125,25 @@ func TestResolveRegistryTarget(t *testing.T) {
 	}
 }
 
+func TestResolveRegistryTargetReturnsCallbackError(t *testing.T) {
+	callbackErr := errors.New("callback failed")
+	flagToken := "flag-token"
+	rt := New(Config{
+		RegistryToken: &flagToken,
+		OnTokenResolved: func(string) error {
+			return callbackErr
+		},
+	})
+
+	got, err := rt.ResolveRegistryTarget(context.Background())
+	if !errors.Is(err, callbackErr) {
+		t.Fatalf("ResolveRegistryTarget() error = %v, want %v", err, callbackErr)
+	}
+	if got != (RegistryTarget{}) {
+		t.Fatalf("ResolveRegistryTarget() = %#v, want empty target", got)
+	}
+}
+
 func TestRegistryClientAllowsMissingStoredToken(t *testing.T) {
 	var resolvedToken string
 	rt := New(Config{


### PR DESCRIPTION
# Description

  - Change `Config.ExtraCommands` to a dependency-aware factory so downstream commands receive the same
  runtime, authentication provider, and kind registry as built-in commands.

  - Add `Runtime.ResolveRegistryTarget` as the single registry URL and token resolution path, preserving
  flag, environment, and stored-token precedence.

  - Make `Runtime.RegistryClient` delegate to the shared resolver and return contextual token-resolution
  errors.

  - Add coverage for dependency delivery, resolution precedence, missing and failed stored-token
  resolution, and callback failures.


# Change Type

```
/kind cleanup
```

  # Changelog

  ```release-note
NONE
  ```

  # Additional Notes

  This is a breaking developer API change for projects embedding the OSS CLI. It does not change the end-
  user command interface.

  Validation:

  ```sh
  make test-unit
  ```