### PR TITLE
Makefile: Complete local run setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,6 @@ Thank you for your interest in contributing to arctl! This document provides gui
 ./setup.sh
 
 # Or manually:
-go mod download
 cd ui && npm install && cd ..
 make build
 ```
@@ -283,7 +282,6 @@ tag on `main`.
 
 ```bash
 go mod tidy
-go mod download
 ```
 
 ### UI Build Failures

--- a/Makefile
+++ b/Makefile
@@ -182,7 +182,7 @@ run-docker: local-registry docker docker-tag-as-dev ## Start local development e
 
 # Start local development environment with Kind cluster
 .PHONY: run-k8s
-run-k8s: local-registry create-kind-cluster build-cli ## Start local development environment with Kind cluster
+run-k8s: setup-kind-cluster build-cli ## Start local development environment with Kind cluster
 	@echo ""
 	@echo "agentregistry is running (k8s backend):"
 	@echo "  UI:  http://localhost:12121"

--- a/Makefile
+++ b/Makefile
@@ -130,9 +130,8 @@ clean-ui: ## Clean UI build artifacts
 
 # Build the Go CLI
 .PHONY: build-cli
-build-cli: mod-download ## Build the Go CLI
+build-cli: ## Build the Go CLI
 	@echo "Building Go CLI..."
-	@echo "Downloading Go dependencies..."
 	@echo "Building binary..."
 	go build -ldflags "$(LDFLAGS)" \
 		-o bin/arctl cmd/cli/main.go
@@ -140,9 +139,8 @@ build-cli: mod-download ## Build the Go CLI
 
 # Build the Go server (with embedded UI)
 .PHONY: build-server
-build-server: mod-download ## Build the Go server binary
+build-server: ## Build the Go server binary
 	@echo "Building Go CLI..."
-	@echo "Downloading Go dependencies..."
 	@echo "Building binary..."
 	go build -ldflags "$(LDFLAGS)" \
 		-o bin/arctl-server cmd/server/main.go
@@ -527,10 +525,6 @@ verify: fmt mod-tidy gen-client charts-docs ## Run all verification checks
 mod-tidy: ## Run go mod tidy on the main module and tools module
 	go mod tidy
 	cd $(TOOLS_DIR) && go mod tidy
-
-.PHONY: mod-download
-mod-download: ## Run go mod download
-	go mod download
 
 # ──────────────────────────────────────────────────────────────────────────────
 # Helm / Chart targets


### PR DESCRIPTION
# Description

The default local Kubernetes workflow reported AgentRegistry as running after
only creating the Kind cluster and building the CLI. Route `make run` through
the complete cluster setup so it also installs the kagent and AgentRegistry
Helm charts.

Remove the redundant `go mod download` Make target and build prerequisites.
Go builds resolve missing modules automatically; the Dockerfile download step
remains as an image build cache layer.

# Change Type

/kind cleanup

# Changelog

```release-note
NONE
```

# Additional Notes

Validated with `make -n run`, `make build-cli`, `make build-server`, and
`make verify`.

Separating integration and end-to-end CI workflows, including a dedicated
PostgreSQL Compose fixture for integration tests, is intentionally deferred to
a follow-up.
