### PR TITLE
ci: Add nightly image releases

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -36,7 +36,7 @@ jobs:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         previous_sha=$(gh api \
-          "repos/${GITHUB_REPOSITORY}/actions/workflows/nightly.yaml/runs?branch=main&status=completed&conclusion=success&per_page=1" \
+          "repos/${GITHUB_REPOSITORY}/actions/workflows/nightly.yaml/runs?branch=main&status=success&per_page=1" \
           --jq '.workflow_runs[0].head_sha // empty')
         echo "sha=${previous_sha}" >> "${GITHUB_OUTPUT}"
 
@@ -57,7 +57,7 @@ jobs:
     - name: Compute nightly version
       id: version
       run: |
-        short_sha=$(git rev-parse --short=12 HEAD)
+        short_sha=$(git rev-parse --short HEAD)
         echo "version=v0.0.0-alpha.${short_sha}" >> "${GITHUB_OUTPUT}"
 
   publish:

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -1,0 +1,71 @@
+name: Nightly Release
+
+on:
+  schedule:
+  - cron: "0 2 * * *"
+  workflow_dispatch: {}
+
+permissions:
+  actions: read
+  contents: read
+  packages: write
+
+concurrency:
+  group: nightly-release
+  cancel-in-progress: false
+
+jobs:
+  prepare:
+    name: Prepare nightly release
+    if: >-
+      github.ref == 'refs/heads/main' &&
+      (github.repository == 'agentregistry-dev/agentregistry' || github.event_name == 'workflow_dispatch')
+    runs-on: ubuntu-latest
+    outputs:
+      has_commits: ${{ steps.changes.outputs.has_commits }}
+      version: ${{ steps.version.outputs.version }}
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
+        persist-credentials: false
+
+    - name: Find previous successful nightly
+      id: previous
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        previous_sha=$(gh api \
+          "repos/${GITHUB_REPOSITORY}/actions/workflows/nightly.yaml/runs?branch=main&status=completed&conclusion=success&per_page=1" \
+          --jq '.workflow_runs[0].head_sha // empty')
+        echo "sha=${previous_sha}" >> "${GITHUB_OUTPUT}"
+
+    - name: Check for changes since the previous nightly
+      id: changes
+      env:
+        PREVIOUS_SHA: ${{ steps.previous.outputs.sha }}
+      run: |
+        current_sha=$(git rev-parse HEAD)
+        if [[ -z "${PREVIOUS_SHA}" || "${current_sha}" != "${PREVIOUS_SHA}" ]]; then
+          echo "has_commits=true" >> "${GITHUB_OUTPUT}"
+          exit 0
+        fi
+
+        echo "has_commits=false" >> "${GITHUB_OUTPUT}"
+        echo "HEAD matches the previous successful nightly; skipping publication"
+
+    - name: Compute nightly version
+      id: version
+      run: |
+        short_sha=$(git rev-parse --short=12 HEAD)
+        echo "version=v0.0.0-alpha.${short_sha}" >> "${GITHUB_OUTPUT}"
+
+  publish:
+    name: Publish nightly image
+    needs: prepare
+    if: ${{ needs.prepare.outputs.has_commits == 'true' || github.event_name == 'workflow_dispatch' }}
+    uses: ./.github/workflows/release.yaml
+    with:
+      version: ${{ needs.prepare.outputs.version }}
+      image_alias: latest-dev
+    secrets: inherit

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -7,7 +7,10 @@ on:
 
 permissions:
   actions: read
-  contents: read
+  # Reusable workflow permissions cannot exceed the caller's permissions.
+  # release.yaml needs contents: write for its stable release job, even though
+  # that job is skipped for nightly branch runs.
+  contents: write
   packages: write
 
 concurrency:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,8 +41,8 @@ jobs:
 
         if [[ -n "${INPUT_VERSION}" ]]; then
           VERSION="${INPUT_VERSION}"
-          if [[ ! "${VERSION}" =~ ^v0\.0\.0-alpha\.[0-9a-f]{12}$ ]]; then
-            echo "::error::nightly version must match v0.0.0-alpha.<12-character-sha>; got ${VERSION}"
+          if [[ ! "${VERSION}" =~ ^v0\.0\.0-alpha\.[0-9a-f]{7,40}$ ]]; then
+            echo "::error::nightly version must match v0.0.0-alpha.<commit-sha>; got ${VERSION}"
             exit 1
           fi
         else

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,28 +4,63 @@ on:
   push:
     tags:
     - "v*.*.*"
+  workflow_call:
+    inputs:
+      version:
+        description: Nightly version, including the leading v
+        required: true
+        type: string
+      image_alias:
+        description: Optional moving container image tag
+        required: false
+        default: ""
+        type: string
 
 env:
-  VERSION: ${{ github.ref_name }}
+  # Include the caller's owner so reusable releases from forks publish to the
+  # fork owner's GHCR namespace.
+  IMAGE_REGISTRY: ghcr.io/${{ github.repository_owner }}
   DOCKER_REGISTRY: ghcr.io
-  DOCKER_BUILD_REGISTRY: ghcr.io
+  DOCKER_REPO: agentregistry
 
 jobs:
   validate:
     name: Validate release version
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
     steps:
     - name: Validate version
+      id: version
       shell: bash
+      env:
+        INPUT_VERSION: ${{ inputs.version }}
+        REF_VERSION: ${{ github.ref_name }}
       run: |
-        if [[ ! "${VERSION}" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
-          echo "::error::version must match vX.Y.Z; got ${VERSION}"
-          exit 1
+        set -euo pipefail
+
+        if [[ -n "${INPUT_VERSION}" ]]; then
+          VERSION="${INPUT_VERSION}"
+          if [[ ! "${VERSION}" =~ ^v0\.0\.0-alpha\.[0-9a-f]{12}$ ]]; then
+            echo "::error::nightly version must match v0.0.0-alpha.<12-character-sha>; got ${VERSION}"
+            exit 1
+          fi
+        else
+          VERSION="${REF_VERSION}"
+          if [[ ! "${VERSION}" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+            echo "::error::release version must match vX.Y.Z; got ${VERSION}"
+            exit 1
+          fi
         fi
+
+        echo "version=${VERSION}" >> "${GITHUB_OUTPUT}"
 
   docker:
     needs: validate
     runs-on: ubuntu-latest
+    env:
+      DOCKER_BUILD_REGISTRY: ghcr.io/${{ github.repository_owner }}
+      VERSION: ${{ needs.validate.outputs.version }}
     permissions:
       contents: read
       packages: write
@@ -67,11 +102,23 @@ jobs:
         DOCKER_BUILDER: "docker buildx"
       run: make docker-server
 
+    - name: Promote image alias
+      if: ${{ inputs.image_alias != '' }}
+      env:
+        IMAGE_ALIAS: ${{ inputs.image_alias }}
+      run: |
+        docker buildx imagetools create \
+          --tag "${IMAGE_REGISTRY}/${DOCKER_REPO}/server:${IMAGE_ALIAS}" \
+          "${IMAGE_REGISTRY}/${DOCKER_REPO}/server:${VERSION}"
+
   release:
     needs:
     - docker
+    - validate
+    if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     env:
+      VERSION: ${{ needs.validate.outputs.version }}
       HELM_PLUGIN_UNITTEST_VERSION: v1.0.3
       HELM_REGISTRY: ${{ secrets.HELM_REGISTRY || 'ghcr.io' }}
       HELM_REPO: ${{ secrets.HELM_REPO || 'agentregistry-dev/agentregistry' }}

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -29,6 +29,32 @@ For a `vX.Y.Z` release, `.github/workflows/release.yaml` publishes:
 - A GitHub Release with generated release notes, the CLI files, the packaged
   Helm chart, and the chart checksum file.
 
+## Nightly images
+
+The `Nightly Release` workflow checks `main` once per day at 02:00 UTC. When
+`main` has changed since the previous successful nightly run, it publishes the
+multi-architecture server image with two tags:
+
+- `ghcr.io/agentregistry-dev/agentregistry/server:v0.0.0-alpha.<commit-sha>` is
+  immutable and identifies the exact source commit.
+- `ghcr.io/agentregistry-dev/agentregistry/server:latest-dev` moves to the most
+  recent successful nightly image.
+
+Nightly runs do not publish CLI binaries, Helm charts, Git tags, or GitHub
+Releases. They can also be started manually from GitHub Actions, including when
+`main` has not changed since the previous nightly. Manual runs must target the
+`main` branch.
+
+Prefer the immutable tag for repeatable deployments. To evaluate the moving
+tag with the Helm chart, override the image tag and pull policy explicitly:
+
+```bash
+helm upgrade --install agentregistry \
+  oci://ghcr.io/agentregistry-dev/agentregistry/charts/agentregistry \
+  --set image.tag=latest-dev \
+  --set image.pullPolicy=Always
+```
+
 ## Cut a release
 
 1. Choose the next version according to Semantic Versioning.


### PR DESCRIPTION


<!--
Thanks for opening a PR! Please delete any sections that don't apply.
-->

# Description

<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

Publish a multi-architecture development image once per day when main has changed, retaining an immutable commit-qualified tag and latest-dev alias.

Reuse the stable release image build so nightly and tagged images stay aligned. Fork callers publish into their own GHCR namespace, which makes workflow changes testable without touching official packages.

This is heavily inspired by agentgateway's nightly release process.

# Change Type

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bump
/kind cleanup
/kind design
/kind deprecation
/kind documentation
/kind feature
/kind fix
/kind flake
/kind install
```
-->

/kind cleanup

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
-->

```release-note
NONE
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
