### PR TITLE
pkg/types: carry the resource document on AuthorizeInput

### DIFF
--- a/internal/registry/registry_app.go
+++ b/internal/registry/registry_app.go
@@ -324,7 +324,7 @@ func crudPerKindHooks(options types.AppOptions) crud.PerKindHooks {
 			hooks.Authorizers[kind] = func(ctx context.Context, in resource.AuthorizeInput) error {
 				return f(ctx, types.AuthorizeInput{
 					Verb: in.Verb, Kind: in.Kind, Namespace: in.Namespace,
-					Name: in.Name, Tag: in.Tag,
+					Name: in.Name, Tag: in.Tag, Object: in.Object,
 				})
 			}
 		}
@@ -336,7 +336,7 @@ func crudPerKindHooks(options types.AppOptions) crud.PerKindHooks {
 			hooks.ListFilters[kind] = func(ctx context.Context, in resource.AuthorizeInput) (string, []any, error) {
 				return f(ctx, types.AuthorizeInput{
 					Verb: in.Verb, Kind: in.Kind, Namespace: in.Namespace,
-					Name: in.Name, Tag: in.Tag,
+					Name: in.Name, Tag: in.Tag, Object: in.Object,
 				})
 			}
 		}

--- a/internal/registry/registry_app_test.go
+++ b/internal/registry/registry_app_test.go
@@ -15,8 +15,11 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/agentregistry-dev/agentregistry/internal/registry/config"
+	"github.com/agentregistry-dev/agentregistry/pkg/api/v1alpha1"
 	"github.com/agentregistry-dev/agentregistry/pkg/registry/auth"
 	pkgdb "github.com/agentregistry-dev/agentregistry/pkg/registry/database"
+	"github.com/agentregistry-dev/agentregistry/pkg/registry/resource"
+	"github.com/agentregistry-dev/agentregistry/pkg/types"
 )
 
 func TestDeploymentControllerConfigMapsRetentionSettings(t *testing.T) {
@@ -202,4 +205,54 @@ func TestBuildMCPMux(t *testing.T) {
 		buildMCPMux(handler, meta).ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/", nil))
 		assert.Equal(t, catchAll, rec.Code)
 	})
+}
+
+// TestCrudPerKindHooksCopiesAuthorizeInput pins the adapter's field-for-field
+// contract: every AuthorizeInput field reaches the public hooks, Object included.
+func TestCrudPerKindHooksCopiesAuthorizeInput(t *testing.T) {
+	obj := &v1alpha1.Deployment{
+		Metadata: v1alpha1.ObjectMeta{Namespace: "prod", Name: "checkout"},
+		Spec: v1alpha1.DeploymentSpec{
+			TargetRef: v1alpha1.ResourceRef{Kind: v1alpha1.KindMCPServer, Name: "solo-docs"},
+		},
+	}
+	in := resource.AuthorizeInput{
+		Verb:      "apply",
+		Kind:      v1alpha1.KindDeployment,
+		Namespace: "prod",
+		Name:      "checkout",
+		Tag:       "v1",
+		Object:    obj,
+	}
+	want := types.AuthorizeInput{
+		Verb:      "apply",
+		Kind:      v1alpha1.KindDeployment,
+		Namespace: "prod",
+		Name:      "checkout",
+		Tag:       "v1",
+		Object:    obj,
+	}
+
+	var gotAuthorizer, gotListFilter types.AuthorizeInput
+	hooks := crudPerKindHooks(types.AppOptions{
+		Authorizers: map[string]types.Authorizer{
+			v1alpha1.KindDeployment: func(_ context.Context, got types.AuthorizeInput) error {
+				gotAuthorizer = got
+				return nil
+			},
+		},
+		ListFilters: map[string]types.ListFilter{
+			v1alpha1.KindDeployment: func(_ context.Context, got types.AuthorizeInput) (string, []any, error) {
+				gotListFilter = got
+				return "", nil, nil
+			},
+		},
+	})
+
+	require.NoError(t, hooks.Authorizers[v1alpha1.KindDeployment](t.Context(), in))
+	_, _, err := hooks.ListFilters[v1alpha1.KindDeployment](t.Context(), in)
+	require.NoError(t, err)
+
+	assert.Equal(t, want, gotAuthorizer)
+	assert.Equal(t, want, gotListFilter)
 }

--- a/pkg/registry/resource/handler.go
+++ b/pkg/registry/resource/handler.go
@@ -202,10 +202,12 @@ type AuthorizeInput struct {
 	// Tag is populated for exact tagged content resource operations.
 	// Batch delete leaves Tag empty when deleting every tag for a name.
 	Tag string
-	// Object is non-nil only when Verb == "apply"; it carries the decoded
-	// request body post-validation-stamping (path identity already merged
-	// into metadata), so the hook can inspect labels / annotations / spec
-	// in authz decisions.
+	// Object carries the resource document for the hook to inspect: nil for
+	// "get" and "list", the decoded request body post-validation-stamping on
+	// "apply", and deleteOpts.PreDeleteObject on "delete".
+	// That delete value is nil unless DeleteAdmission or PostDelete is wired
+	// and is the caller's own document on the batch path, so a delete
+	// authorizer must re-read the stored document rather than trust it.
 	Object v1alpha1.Object
 }
 

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -36,6 +36,11 @@ type AuthorizeInput struct {
 	Name string
 	// Tag is the resource tag for content kinds; "" for list/get-latest.
 	Tag string
+	// Object carries the resource document for hooks to inspect: nil for
+	// "get" and "list", the validated request body on "apply".
+	// On "delete" it may be nil or, on the batch path, caller-supplied — so
+	// re-read the stored document instead of authorizing against it.
+	Object v1alpha1.Object
 }
 
 // Authorizer gates a single resource handler invocation. Return


### PR DESCRIPTION
# Description

**Motivation:** `pkg/types.AuthorizeInput` documents itself as mirroring
`resource.AuthorizeInput` "field-for-field", but it omits `Object`, and
`crudPerKindHooks` copies only five of the six fields — with a comment that
also calls it a field-for-field copy. The net effect is that `Authorizer` and
`ListFilter` hooks registered through `AppOptions` can never see the document
they are being asked to gate, so any authz decision that depends on the spec
(rather than just kind/namespace/name/tag) is impossible through the public
hook surface.

**What changed:**

- Add `Object v1alpha1.Object` to `pkg/types.AuthorizeInput`. The package
  already imports `v1alpha1`, so this adds no new dependency.
- Copy `Object` at both `crudPerKindHooks` adapter sites (Authorizers and
  ListFilters).
- Correct the doc on `resource.AuthorizeInput.Object`. It claimed the field is
  "non-nil only when `Verb == "apply"`", which is not accurate:
  - `core.go` `applyCore` sets it to the validated request body.
  - `core.go` `deleteCore` also sets it, from `deleteOpts.PreDeleteObject`.
  - The per-kind DELETE path populates `PreDeleteObject` by decoding the row
    read from the store, and only when `DeleteAdmission` or `PostDelete` is
    wired.
  - The batch apply path forwards the **caller's own document** as
    `PreDeleteObject`.

  So on batch delete the value is caller-controlled. The updated comment states
  which verbs populate the field and warns that a delete authorizer must re-read
  the stored document rather than trust `Object`. The same warning is mirrored
  on the new public field, since that is the only one external consumers see.

# Change Type

/kind cleanup
# Changelog

```release-note
NONE
```

# Additional Notes

`TestCrudPerKindHooksCopiesAuthorizeInput` asserts the whole `AuthorizeInput`
in one comparison rather than field-by-field, so a future field added to the
mirror but missed in the adapter fails the test. Verified it is load-bearing:
reverting just the `registry_app.go` change makes it fail with
`Object: <nil>` against the expected document.

`pkg/registry/resource` tests are behind `//go:build integration` and were not
executed here; they were vetted with `go vet -tags integration`. The rest of
`./pkg/types/...` and `./internal/registry/...` passes.
