### PR TITLE
config: drop VERSION env override; use version.Version

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,8 +7,10 @@ AGENT_REGISTRY_SERVER_ADDRESS=:8080
 AGENT_REGISTRY_DATABASE_URL=postgres://localhost:5432/agentregistry?sslmode=disable
 
 # Application Version
-# Set automatically during build, can be overridden for development
-AGENT_REGISTRY_VERSION=dev
+# Set automatically during build via -ldflags "-X .../internal/version.Version=..."
+# See internal/version/version.go. There is intentionally no env var override —
+# the build-time value is the only source of truth so a deployed binary's
+# reported version always matches what it was built with.
 
 # Registry Validation
 # Enable validation of registry package references

--- a/internal/registry/api/handlers/v0/health/handlers.go
+++ b/internal/registry/api/handlers/v0/health/handlers.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/agentregistry-dev/agentregistry/internal/registry/config"
 	"github.com/agentregistry-dev/agentregistry/internal/registry/telemetry"
+	"github.com/agentregistry-dev/agentregistry/internal/version"
 	"github.com/agentregistry-dev/agentregistry/pkg/types"
 )
 
@@ -28,7 +29,7 @@ func RegisterHealthEndpoint(api huma.API, pathPrefix string, cfg *config.Config,
 		Description: "Check the health status of the API",
 		Tags:        []string{"health"},
 	}, func(ctx context.Context, _ *struct{}) (*types.Response[HealthBody], error) {
-		recordHealthMetrics(ctx, metrics, pathPrefix+"/health", cfg.Version)
+		recordHealthMetrics(ctx, metrics, pathPrefix+"/health", version.Version)
 
 		return &types.Response[HealthBody]{
 			Body: HealthBody{

--- a/internal/registry/config/config.go
+++ b/internal/registry/config/config.go
@@ -15,8 +15,12 @@ type Config struct {
 	ServerAddress string `env:"SERVER_ADDRESS" envDefault:":8080"`
 	MCPPort       uint16 `env:"MCP_PORT" envDefault:"0"`
 	DatabaseURL   string `env:"DATABASE_URL" envDefault:"postgres://agentregistry:agentregistry@localhost:5432/agentregistry?sslmode=disable"`
-	Version       string `env:"VERSION" envDefault:"dev"`
-	LogLevel      string `env:"LOG_LEVEL" envDefault:"info"`
+	// Version is set at build time via -ldflags "-X github.com/agentregistry-dev/agentregistry/internal/version.Version=..."
+	// and read from the version package; see internal/version/version.go. There is
+	// intentionally no VERSION env var override — the build-time value is the only
+	// source of truth so a deployed binary's reported version always matches what
+	// it was built with.
+	LogLevel string `env:"LOG_LEVEL" envDefault:"info"`
 
 	// MCP Registry compatibility (read-only)
 	//

--- a/internal/registry/registry_app.go
+++ b/internal/registry/registry_app.go
@@ -139,7 +139,7 @@ func App(ctx context.Context, opts ...types.AppOptions) error {
 		BuildTime: version.BuildDate,
 	}
 
-	shutdownTelemetry, metrics, err := telemetry.InitMetrics(cfg.Version)
+	shutdownTelemetry, metrics, err := telemetry.InitMetrics(version.Version)
 	if err != nil {
 		return fmt.Errorf("failed to initialize metrics: %w", err)
 	}


### PR DESCRIPTION
## What

Removes the redundant `cfg.Version` field from `internal/registry/config` so the registry server reports the version it was built with instead of one overridable through `AGENT_REGISTRY_VERSION` at runtime.

## Why

Issue #567 — `cfg.Version` only ever set the default (`"dev"`), which is what `internal/version.Version` already returns when no `-ldflags` injection happened. Two production paths read it:

1. `internal/registry/registry_app.go` — telemetry init label
2. `internal/registry/api/handlers/v0/health/handlers.go` — health metrics `version` attribute

Both now read `version.Version` directly, so a deployed binary's reported version always matches what it was built with. There is intentionally no env override any more.

## Changes

- `internal/registry/config/config.go` — drop `Version string` field; leave a comment explaining the build-time injection point
- `internal/registry/registry_app.go` — `telemetry.InitMetrics(version.Version)`
- `internal/registry/api/handlers/v0/health/handlers.go` — same, plus the `internal/version` import
- `.env.example` — replace the `AGENT_REGISTRY_VERSION=dev` line with a comment pointing at the ldflags injection

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/registry/config/...` passes
- [x] `go test ./internal/registry/...` passes (telemetry, health, controllers)
- [x] No remaining `cfg.Version` references in the registry config path (CLI root config has its own unrelated `Version` field — left alone)

## Notes

- The other `Version` references in the codebase (`internal/cli/version.go`, `internal/mcp/registryserver/server.go`, `internal/registry/registry_app.go:133/137`) already read from `version.Version`. This change brings the two stragglers into line.
- The maintainer comment on #567 also mentioned `cfg.Verbose`; there is no such field in this config struct (probably from an earlier refactor), so the scope is exactly `cfg.Version` only.

Disclosed: this PR was authored with LLM assistance under the MsfPablo persona.
