### PR TITLE
drop stale ENABLE_REGISTRY_VALIDATION env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,10 +10,6 @@ AGENT_REGISTRY_DATABASE_URL=postgres://localhost:5432/agentregistry?sslmode=disa
 # Set automatically during build, can be overridden for development
 AGENT_REGISTRY_VERSION=dev
 
-# Registry Validation
-# Enable validation of registry package references
-AGENT_REGISTRY_ENABLE_REGISTRY_VALIDATION=false
-
 # MCP Registry v0.1 Compatibility (read-only)
 # Re-exposes MCPServer resources in the official server.json shape at
 # /v0.1/servers so registry-aware clients (e.g. VS Code's MCP gallery) can

--- a/charts/agentregistry/README.md
+++ b/charts/agentregistry/README.md
@@ -129,7 +129,6 @@ This creates a `Role`/`RoleBinding` in each listed namespace (plus the installat
 | commonAnnotations | object | `{}` | Annotations to add to all deployed resources |
 | commonLabels | object | `{}` | Labels to add to all deployed resources |
 | config.agentRegistryMcpPort | string | `"31313"` | Agent Registry MCP server port |
-| config.enableRegistryValidation | string | `"false"` | Enable input validation on the registry API |
 | config.serverAddress | string | `":8080"` | Listen address for the HTTP server |
 | containerSecurityContext.allowPrivilegeEscalation | bool | `false` | Allow privilege escalation |
 | containerSecurityContext.capabilities.drop | list | `["ALL"]` | Linux capabilities to drop |

--- a/charts/agentregistry/templates/configmap.yaml
+++ b/charts/agentregistry/templates/configmap.yaml
@@ -13,4 +13,3 @@ metadata:
 data:
   AGENT_REGISTRY_SERVER_ADDRESS: {{ .Values.config.serverAddress | quote }}
   AGENT_REGISTRY_MCP_PORT: {{ .Values.config.agentRegistryMcpPort | quote }}
-  AGENT_REGISTRY_ENABLE_REGISTRY_VALIDATION: {{ .Values.config.enableRegistryValidation | quote }}

--- a/charts/agentregistry/tests/configmap_test.yaml
+++ b/charts/agentregistry/tests/configmap_test.yaml
@@ -43,12 +43,6 @@ tests:
           path: data.AGENT_REGISTRY_MCP_PORT
           value: "31313"
 
-  - it: sets AGENT_REGISTRY_ENABLE_REGISTRY_VALIDATION
-    asserts:
-      - equal:
-          path: data.AGENT_REGISTRY_ENABLE_REGISTRY_VALIDATION
-          value: "false"
-
   - it: overrides serverAddress
     set:
       config.serverAddress: ":9090"

--- a/charts/agentregistry/values.yaml
+++ b/charts/agentregistry/values.yaml
@@ -45,8 +45,6 @@ config:
   serverAddress: ":8080"
   # -- Agent Registry MCP server port
   agentRegistryMcpPort: "31313"
-  # -- Enable input validation on the registry API
-  enableRegistryValidation: "false"
 
 # @section Deployment parameters
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -42,8 +42,6 @@ services:
     environment:
       AGENT_REGISTRY_DATABASE_URL: "postgres://agentregistry:agentregistry@postgres:5432/agentregistry?sslmode=disable"
       AGENT_REGISTRY_SERVER_ADDRESS: ":8080"
-      # Temporarily only for local development.
-      AGENT_REGISTRY_ENABLE_REGISTRY_VALIDATION: "false"
       AGENT_REGISTRY_MCP_PORT: "31313"
       KUBECONFIG: "/root/.kube/config"
     ports:


### PR DESCRIPTION
## What

Removes `AGENT_REGISTRY_ENABLE_REGISTRY_VALIDATION` and `config.enableRegistryValidation` everywhere they're rendered as if they were an active runtime knob.

## Why

Issue #566 — the OSS Helm chart and the local docker-compose both still render this env var, but the current server config no longer reads it. The actual validation path goes through `types.AppOptions.RegistryValidator` and the v1alpha1 resource handlers. The chart value looks like a working toggle when it is dead surface.

The reporter's suggested cleanup, applied here:

- Remove `config.enableRegistryValidation` from the chart `values.yaml`, the regenerated `README.md`, the `configmap.yaml` template, and the chart unit test that asserts on it.
- Drop the matching `AGENT_REGISTRY_ENABLE_REGISTRY_VALIDATION` line from the local `docker/docker-compose.yml`.
- Drop the matching `# Registry Validation` block from `.env.example`.

## Changes

```
 .env.example                                   | 4 ----
 charts/agentregistry/README.md                 | 1 -
 charts/agentregistry/templates/configmap.yaml  | 1 -
 charts/agentregistry/tests/configmap_test.yaml | 6 ------
 charts/agentregistry/values.yaml               | 2 --
 docker/docker-compose.yml                      | 2 --
 6 files changed, 16 deletions(-)
```

## Test plan

- [x] `go build ./...` clean
- [x] `make charts-docs` regenerates the README with the table row removed (no `config.enableRegistryValidation` entry in the Parameters table)
- [x] `grep -rn 'ENABLE_REGISTRY_VALIDATION\|enableRegistryValidation'` over `*.go *.yaml *.yml *.md *.example *.tpl` returns no hits
- [ ] `helm-unittest` is not installed in this environment; the chart unit test that asserted on the removed env var was deleted alongside it (it would otherwise fail on this PR). Operators with `helm-unittest` should run `helm unittest charts/agentregistry` locally.

## Notes

- Registry validation is now controlled solely by `types.AppOptions.RegistryValidator` (per the reporter's guidance). Any deployment that still sets `AGENT_REGISTRY_ENABLE_REGISTRY_VALIDATION` will see it ignored — no behavior change for callers already on the new validator path.
- The other env vars on the configmap (`AGENT_REGISTRY_SERVER_ADDRESS`, `AGENT_REGISTRY_MCP_PORT`) are untouched.
- Disclosed: this PR was authored with LLM assistance under the MsfPablo persona.