### PR TITLE
pkg: Rename stores as tagged or untagged

### DIFF
--- a/docs/declarative-cli.md
+++ b/docs/declarative-cli.md
@@ -12,11 +12,11 @@ arctl apply -f summarizer/agent.yaml
 
 `arctl init agent NAME` and `arctl init mcp NAME` pick a framework + language interactively unless `--framework` and `--language` are provided. Run `arctl init agent NAME` (or `arctl init mcp NAME`) on its own to see the available choices. All resource `metadata.name` values (Agent, Skill, Prompt, Deployment, MCPServer) must be DNS-1123 subdomain: lowercase alphanumeric, hyphens, and dots; max 253 chars; each dot-separated segment must start and end with alphanumeric (max 63 chars per segment). Examples: `my-server`, `io.example.mcp`. Agent names additionally cannot contain hyphens or dots and cannot collide with Python keywords (`class`, `import`, `return`, …) because they become Python identifiers in generated code.
 
-## Tags And Mutable Objects
+## Tagged And Untagged Resources
 
-Agents, Models, MCP servers, remote MCP servers, skills, and prompts are taggable artifacts. Set `metadata.tag` to publish a deterministic name you can reference from other manifests; if you omit it, the registry uses the literal `latest` tag.
+Agents, Models, MCP servers, remote MCP servers, skills, and prompts are tagged resources. Set `metadata.tag` to create an independently addressable slot; if you omit it, the registry uses the literal `latest` tag. Tags are not immutable versions: applying changed content to an existing tag replaces that tag's row.
 
-Runtimes and Deployments are mutable control-plane objects. They use public namespace/name identity, not tags or versions.
+Runtimes and Deployments are untagged resources. Their identity is namespace/name.
 
 ```bash
 arctl init agent summarizer --framework adk --language python --model-provider gemini --model-name gemini-2.5-flash

--- a/internal/cli/declarative/all_tags_test.go
+++ b/internal/cli/declarative/all_tags_test.go
@@ -175,7 +175,7 @@ func TestGet_AllTags_Agent_JSONOutput(t *testing.T) {
 }
 
 // (3) `arctl get deployment NAME --all-tags` errors cleanly because
-// deployments are mutable namespace/name objects, not taggable artifacts.
+// deployments are untagged namespace/name objects, not taggable artifacts.
 func TestGet_AllTags_DeploymentRejected(t *testing.T) {
 	setDeclarativeTestClient(t, client.NewClient("http://127.0.0.1:1", ""))
 
@@ -188,7 +188,7 @@ func TestGet_AllTags_DeploymentRejected(t *testing.T) {
 }
 
 // (3b) `arctl get runtime NAME --all-tags` errors cleanly — Runtime
-// is a mutable namespace/name object whose store has no /tags endpoint.
+// is a untagged namespace/name object whose store has no /tags endpoint.
 // Pin the CLI surface so a future typedKind change can't
 // silently re-expose --all-tags for Runtime.
 func TestGet_AllTags_ProviderRejected(t *testing.T) {

--- a/internal/cli/declarative/declarative.go
+++ b/internal/cli/declarative/declarative.go
@@ -91,7 +91,7 @@ func init() {
 		pluginRow,
 	))
 
-	// Runtime is registered manually because it is a mutable namespace/name
+	// Runtime is registered manually because it is a untagged namespace/name
 	// object: the server's runtime store does not expose /tags or
 	// DeleteAllTags endpoints. Routing it through
 	// typedKind would advertise --all-tags on its CLI surface and call
@@ -99,7 +99,7 @@ func init() {
 	// what typedKind would otherwise produce; ListTags / DeleteAllTags are
 	// intentionally omitted so the dispatch layer rejects --all-tags cleanly.
 	scheme.Register(
-		mutableTypedKind(
+		untaggedTypedKind(
 			"runtime", "runtimes", []string{"Runtime"},
 			[]scheme.Column{{Header: "NAME"}, {Header: "TYPE"}},
 			v1alpha1.KindRuntime,
@@ -119,13 +119,13 @@ func init() {
 		modelRow,
 	))
 
-	// Deployment is registered manually because it is a mutable namespace/name
+	// Deployment is registered manually because it is a untagged namespace/name
 	// object: the server's deployment store does not expose /tags or
 	// DeleteAllTags endpoints. Explicit get/delete accept either NAME or
 	// NAMESPACE/NAME; ListTags / DeleteAllTags are intentionally omitted so
 	// the dispatch layer rejects --all-tags cleanly.
 	scheme.Register(
-		mutableTypedKind(
+		untaggedTypedKind(
 			"deployment", "deployments", []string{"Deployment"},
 			[]scheme.Column{
 				{Header: "NAME"}, {Header: "TARGET"}, {Header: "VERSION"},
@@ -136,7 +136,7 @@ func init() {
 			func(deployment *v1alpha1.Deployment) []string {
 				return deploymentRow(cliCommon.DeploymentRecordFromObject(deployment))
 			},
-			withMutableListFunc(listDeploymentResources),
+			withUntaggedListFunc(listDeploymentResources),
 		),
 	)
 }
@@ -191,29 +191,29 @@ func typedKind[T v1alpha1.Object](
 	}
 }
 
-// mutableTypedKind is typedKind for namespace/name resources such as Runtime
+// untaggedTypedKind is typedKind for namespace/name resources such as Runtime
 // and Deployment. These kinds use the generic v1alpha1 CRUD surface but do not
 // expose /tags, so the tag-specific callbacks are intentionally nil.
-type mutableTypedKindOption func(*scheme.Kind)
+type untaggedTypedKindOption func(*scheme.Kind)
 
-// withMutableListFunc is an option to override the default ListFunc for a
-// mutableTypedKind.
-func withMutableListFunc(fn scheme.ListFunc) mutableTypedKindOption {
+// withUntaggedListFunc overrides the default ListFunc for an
+// untaggedTypedKind.
+func withUntaggedListFunc(fn scheme.ListFunc) untaggedTypedKindOption {
 	return func(k *scheme.Kind) {
 		k.ListFunc = fn
 	}
 }
 
-// mutableTypedKind builds a scheme.Kind for mutable namespace/name resources which
-// do not support tagging.
-func mutableTypedKind[T v1alpha1.Object](
+// untaggedTypedKind builds a scheme.Kind for namespace/name resources that do
+// not support tagging.
+func untaggedTypedKind[T v1alpha1.Object](
 	cliName, plural string,
 	aliases []string,
 	columns []scheme.Column,
 	canonicalKind string,
 	newObj func() T,
 	row func(T) []string,
-	opts ...mutableTypedKindOption,
+	opts ...untaggedTypedKindOption,
 ) *scheme.Kind {
 	k := &scheme.Kind{
 		Kind:         cliName,

--- a/internal/cli/declarative/get_test.go
+++ b/internal/cli/declarative/get_test.go
@@ -71,8 +71,8 @@ func TestGetCmd_RegistryDrivenColumnLookup(t *testing.T) {
 func TestProvider_NoAllTagsSupport(t *testing.T) {
 	k, err := scheme.Lookup("runtime")
 	require.NoError(t, err)
-	require.Nil(t, k.ListTags, "Runtime should not expose ListTags (mutable object kind)")
-	require.Nil(t, k.DeleteAllTags, "Runtime should not expose DeleteAllTags (mutable object kind)")
+	require.Nil(t, k.ListTags, "Runtime should not expose ListTags (untagged resource kind)")
+	require.Nil(t, k.DeleteAllTags, "Runtime should not expose DeleteAllTags (untagged resource kind)")
 }
 
 func TestModel_AllTagsSupport(t *testing.T) {
@@ -84,7 +84,7 @@ func TestModel_AllTagsSupport(t *testing.T) {
 	require.Equal(t, "models", k.Plural)
 }
 
-// TestPlugin_AllTagsSupport pins that Plugin — a tag-versioned artifact kind —
+// TestPlugin_AllTagsSupport pins that Plugin — a tagged resource kind —
 // resolves via every alias and keeps its tagged-kind wiring (ListTags /
 // DeleteAllTags), so it never silently loses registration or --all-tags support.
 func TestPlugin_AllTagsSupport(t *testing.T) {
@@ -100,15 +100,15 @@ func TestPlugin_AllTagsSupport(t *testing.T) {
 }
 
 // TestDeployment_NoAllTagsSupport is the symmetric assertion for
-// Deployment — also a mutable namespace/name object. Already
+// Deployment — also a untagged namespace/name object. Already
 // covered by TestGet_AllTags_DeploymentRejected at the CLI surface
 // but pinning it at the registry shape level guards against an
 // accidental ListTags wiring regression.
 func TestDeployment_NoAllTagsSupport(t *testing.T) {
 	k, err := scheme.Lookup("deployment")
 	require.NoError(t, err)
-	require.Nil(t, k.ListTags, "Deployment should not expose ListTags (mutable object kind)")
-	require.Nil(t, k.DeleteAllTags, "Deployment should not expose DeleteAllTags (mutable object kind)")
+	require.Nil(t, k.ListTags, "Deployment should not expose ListTags (untagged resource kind)")
+	require.Nil(t, k.DeleteAllTags, "Deployment should not expose DeleteAllTags (untagged resource kind)")
 }
 
 // tagGetServer serves GET /v0/agents/{name}/{tag} (specific tag)
@@ -235,7 +235,7 @@ func TestGet_Tag_MutuallyExclusiveWithAllTags(t *testing.T) {
 }
 
 // TestGet_Tag_NotSupportedForProvider pins that --tag is rejected
-// for mutable namespace/name kinds (Runtime, Deployment) before any client
+// for untagged namespace/name kinds (Runtime, Deployment) before any client
 // dispatch happens.
 func TestGet_Tag_NotSupportedForProvider(t *testing.T) {
 	setDeclarativeTestClient(t, client.NewClient("http://127.0.0.1:1", ""))
@@ -365,7 +365,7 @@ func TestGet_TagAndLatest_MutuallyExclusive(t *testing.T) {
 }
 
 // TestGet_Latest_NotSupportedForProvider mirrors the --tag guard: --latest
-// is also a tag-shaped filter and should be rejected for mutable kinds
+// is also a tag-shaped filter and should be rejected for untagged kinds
 // before any dispatch.
 func TestGet_Latest_NotSupportedForProvider(t *testing.T) {
 	setDeclarativeTestClient(t, client.NewClient("http://127.0.0.1:1", ""))

--- a/internal/cli/scheme/registry.go
+++ b/internal/cli/scheme/registry.go
@@ -31,7 +31,7 @@ type ListOpts struct {
 	// (tagged content kinds only). Mutually exclusive with LatestOnly.
 	Tag string
 	// LatestOnly restricts the list to the literal "latest" tag (tagged
-	// content kinds) or the latest mutable-object row.
+	// content kinds) or the latest untagged row.
 	LatestOnly bool
 	// Origin filters Deployment rows by provenance. Recognized values:
 	// "managed", "discovered", "all" (both), and "" (unset — the Deployment

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -189,11 +189,11 @@ type ListOpts struct {
 	// Origin, when set, forwards the Deployment origin filter
 	// ("managed" or "discovered"). Empty leaves the server default intact.
 	Origin string
-	// Tag, when set, restricts results to one tag value on tagged-artifact
+	// Tag, when set, restricts results to one tag value on tagged
 	// kinds. Empty means "every tag of every name".
 	Tag string
 	// LatestOnly is equivalent to Tag = "latest" for tagged kinds and also
-	// covers the mutable-object latest-row case.
+	// covers the untagged latest-row case.
 	LatestOnly         bool
 	IncludeTerminating bool
 }
@@ -215,8 +215,8 @@ func namespaceQuery(namespace string) string {
 	return "?namespace=" + url.QueryEscape(namespace)
 }
 
-// Get returns the tagged-artifact resource at (kind, namespace, name, tag).
-// Mutable objects should use GetLatest/name-only semantics.
+// Get returns the tagged resource at (kind, namespace, name, tag).
+// Untagged resources should use GetLatest/name-only semantics.
 func (c *Client) Get(ctx context.Context, kind, namespace, name, tag string) (*v1alpha1.RawObject, error) {
 	path := fmt.Sprintf("/%s/%s/%s%s",
 		v1alpha1.PluralFor(kind),
@@ -227,7 +227,7 @@ func (c *Client) Get(ctx context.Context, kind, namespace, name, tag string) (*v
 }
 
 // GetLatest returns the literal latest tag for taggable resources and the
-// current live row for mutable objects.
+// current live row for untagged resources.
 func (c *Client) GetLatest(ctx context.Context, kind, namespace, name string) (*v1alpha1.RawObject, error) {
 	path := fmt.Sprintf("/%s/%s%s",
 		v1alpha1.PluralFor(kind),
@@ -250,7 +250,7 @@ func (c *Client) getRaw(ctx context.Context, path string) (*v1alpha1.RawObject, 
 }
 
 // ListTags returns every non-deleted tag row for (kind, namespace, name) by
-// GET'ing /v0/{plural}/{name}/tags. Mutable-object kinds do not expose this
+// GET'ing /v0/{plural}/{name}/tags. Untagged kinds do not expose this
 // endpoint; callers should branch on that. The endpoint is unpaginated
 // server-side and returns rows with the latest tag first.
 func (c *Client) ListTags(ctx context.Context, kind, namespace, name string) ([]v1alpha1.RawObject, error) {
@@ -317,7 +317,7 @@ func (c *Client) List(ctx context.Context, kind string, opts ListOpts) ([]v1alph
 }
 
 // Delete soft-deletes a row. When tag is empty it uses the name-only
-// mutable-object route; otherwise it deletes the exact tag route. Returns
+// untagged route; otherwise it deletes the exact tag route. Returns
 // ErrNotFound when the row doesn't exist. See Store.Delete for the
 // soft-delete semantics (the row stays visible with DeletionTimestamp
 // set until the GC pass purges it).

--- a/internal/mcp/registryserver/server_integration_test.go
+++ b/internal/mcp/registryserver/server_integration_test.go
@@ -256,7 +256,7 @@ func TestMCPCatalogTools(t *testing.T) {
 		listTool    string
 		getTool     string
 		name        string
-		expectedTag string // DefaultTag for tagged artifacts; "" for mutable-object kinds.
+		expectedTag string // DefaultTag for tagged resources; "" for untagged kinds.
 		seed        func(t *testing.T, name string)
 	}{
 		{

--- a/internal/registry/api/handlers/v0/crud/crud.go
+++ b/internal/registry/api/handlers/v0/crud/crud.go
@@ -5,8 +5,8 @@
 // handles every per-kind quirk internally (per-kind authz / list
 // filtering / post-upsert / post-delete threaded through PerKindHooks).
 //
-// Scope: only the per-kind CRUD surface. Tagged artifacts use
-// `/v0/{plural}/{name}/{tag}`; mutable objects use `/v0/{plural}/{name}`.
+// Scope: only the per-kind CRUD surface. Tagged resources use
+// `/v0/{plural}/{name}/{tag}`; untagged resources use `/v0/{plural}/{name}`.
 // Other v1alpha1 HTTP endpoints live in sibling packages, for example
 // `/v0/deployments/{name}/logs` in deploymentlogs.
 //

--- a/internal/registry/api/router/v0.go
+++ b/internal/registry/api/router/v0.go
@@ -40,8 +40,8 @@ type Stores = map[string]*v1alpha1store.Store
 // than silently no-op'ing — a misconfigured boot fails loud.
 type RouteOptions struct {
 	// Stores is the per-kind v1alpha1store map that drives the
-	// generic CRUD handlers. Tagged artifacts expose
-	// `/v0/{plural}/{name}/{tag}?namespace={ns}`; mutable objects expose
+	// generic CRUD handlers. Tagged resources expose
+	// `/v0/{plural}/{name}/{tag}?namespace={ns}`; untagged resources expose
 	// `/v0/{plural}/{name}?namespace={ns}`. Namespace defaults to
 	// "default"; `?namespace=all` widens list scope across every
 	// namespace.
@@ -193,8 +193,8 @@ func RegisterRoutes(
 }
 
 // registerKindRoutes wires the generic resource handler for every
-// built-in kind. Tagged artifacts use
-// `{basePrefix}/{plural}/{name}/{tag}`; mutable objects use
+// built-in kind. Tagged resources use
+// `{basePrefix}/{plural}/{name}/{tag}`; untagged resources use
 // `{basePrefix}/{plural}/{name}`. Namespace is a `?namespace={ns}`
 // query param defaulting to "default"; `?namespace=all` on list
 // widens scope across every namespace. The multi-doc apply endpoint

--- a/internal/registry/registry_app.go
+++ b/internal/registry/registry_app.go
@@ -96,7 +96,7 @@ func App(ctx context.Context, opts ...types.AppOptions) error {
 	deploymentAdapters := map[string]types.DeploymentAdapter{}
 	maps.Copy(deploymentAdapters, options.DeploymentAdapters)
 	pool := db.Pool()
-	stores := buildStores(pool, options.V1Alpha1StoreTables, options.V1Alpha1MutableStoreKinds, options.Auditor)
+	stores := buildStores(pool, options.V1Alpha1StoreTables, options.V1Alpha1UntaggedStoreKinds, options.Auditor)
 	controllerConfig := deploymentControllerConfig(cfg)
 	controllerConfig.DependencyKinds = maps.Clone(options.DeploymentDependencyKinds)
 	if _, err := controller.StartDeploymentController(ctx, pool, stores, deploymentAdapters, controllerConfig); err != nil {
@@ -226,7 +226,7 @@ func resolveExtraStoreSchema(table string, ossSchema pkgdb.Schema) (pkgdb.Schema
 	return ossSchema, table
 }
 
-func buildStores(pool *pgxpool.Pool, extraStoreTables map[string]string, mutableExtraKinds map[string]bool, auditor types.Auditor) map[string]*v1alpha1store.Store {
+func buildStores(pool *pgxpool.Pool, extraStoreTables map[string]string, untaggedExtraKinds map[string]bool, auditor types.Auditor) map[string]*v1alpha1store.Store {
 	if auditor == nil {
 		auditor = types.NoopAuditor
 	}
@@ -250,11 +250,11 @@ func buildStores(pool *pgxpool.Pool, extraStoreTables map[string]string, mutable
 			continue
 		}
 		opts := []v1alpha1store.StoreOption{v1alpha1store.WithKind(kind), v1alpha1store.WithAuditor(auditor)}
-		if mutableExtraKinds[kind] {
-			stores[kind] = v1alpha1store.NewMutableObjectStore(pool, sch, tbl, opts...)
+		if untaggedExtraKinds[kind] {
+			stores[kind] = v1alpha1store.NewUntaggedStore(pool, sch, tbl, opts...)
 			continue
 		}
-		stores[kind] = v1alpha1store.NewStore(pool, sch, tbl, opts...)
+		stores[kind] = v1alpha1store.NewTaggedStore(pool, sch, tbl, opts...)
 	}
 
 	// pool == nil is the noop/DatabaseFactory path used by gen-openapi

--- a/internal/registry/registry_app_integration_test.go
+++ b/internal/registry/registry_app_integration_test.go
@@ -92,7 +92,7 @@ spec:
 
 // TestBuildStores_PropagatesAuditor verifies the auditor passed
 // through buildStores (the AppOptions.Auditor field)
-// reaches every constructed Store. We drive a tagged-artifact Upsert
+// reaches every constructed Store. We drive a tagged Upsert
 // and assert the auditor saw the expected ResourceTagCreated event,
 // proving the option survived the
 // NewStores -> NewStore option chain.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1892,13 +1892,13 @@ paths:
         schema:
           description: 'Label selector: key=value,key2=value2.'
           type: string
-      - description: Restrict the result set to one tag value (tagged artifact kinds
+      - description: Restrict the result set to one tag value (tagged resource kinds
           only).
         explode: false
         in: query
         name: tag
         schema:
-          description: Restrict the result set to one tag value (tagged artifact kinds
+          description: Restrict the result set to one tag value (tagged resource kinds
             only).
           type: string
       - description: Only return the literal latest tag per (namespace, name). Equivalent
@@ -2155,13 +2155,13 @@ paths:
         schema:
           description: 'Label selector: key=value,key2=value2.'
           type: string
-      - description: Restrict the result set to one tag value (tagged artifact kinds
+      - description: Restrict the result set to one tag value (tagged resource kinds
           only).
         explode: false
         in: query
         name: tag
         schema:
-          description: Restrict the result set to one tag value (tagged artifact kinds
+          description: Restrict the result set to one tag value (tagged resource kinds
             only).
           type: string
       - description: Only return the literal latest tag per (namespace, name). Equivalent
@@ -2344,13 +2344,13 @@ paths:
         schema:
           description: 'Label selector: key=value,key2=value2.'
           type: string
-      - description: Restrict the result set to one tag value (tagged artifact kinds
+      - description: Restrict the result set to one tag value (tagged resource kinds
           only).
         explode: false
         in: query
         name: tag
         schema:
-          description: Restrict the result set to one tag value (tagged artifact kinds
+          description: Restrict the result set to one tag value (tagged resource kinds
             only).
           type: string
       - description: Only return the literal latest tag per (namespace, name). Equivalent
@@ -2542,13 +2542,13 @@ paths:
         schema:
           description: 'Label selector: key=value,key2=value2.'
           type: string
-      - description: Restrict the result set to one tag value (tagged artifact kinds
+      - description: Restrict the result set to one tag value (tagged resource kinds
           only).
         explode: false
         in: query
         name: tag
         schema:
-          description: Restrict the result set to one tag value (tagged artifact kinds
+          description: Restrict the result set to one tag value (tagged resource kinds
             only).
           type: string
       - description: Only return the literal latest tag per (namespace, name). Equivalent
@@ -2760,13 +2760,13 @@ paths:
         schema:
           description: 'Label selector: key=value,key2=value2.'
           type: string
-      - description: Restrict the result set to one tag value (tagged artifact kinds
+      - description: Restrict the result set to one tag value (tagged resource kinds
           only).
         explode: false
         in: query
         name: tag
         schema:
-          description: Restrict the result set to one tag value (tagged artifact kinds
+          description: Restrict the result set to one tag value (tagged resource kinds
             only).
           type: string
       - description: Only return the literal latest tag per (namespace, name). Equivalent
@@ -2958,13 +2958,13 @@ paths:
         schema:
           description: 'Label selector: key=value,key2=value2.'
           type: string
-      - description: Restrict the result set to one tag value (tagged artifact kinds
+      - description: Restrict the result set to one tag value (tagged resource kinds
           only).
         explode: false
         in: query
         name: tag
         schema:
-          description: Restrict the result set to one tag value (tagged artifact kinds
+          description: Restrict the result set to one tag value (tagged resource kinds
             only).
           type: string
       - description: Only return the literal latest tag per (namespace, name). Equivalent
@@ -3156,13 +3156,13 @@ paths:
         schema:
           description: 'Label selector: key=value,key2=value2.'
           type: string
-      - description: Restrict the result set to one tag value (tagged artifact kinds
+      - description: Restrict the result set to one tag value (tagged resource kinds
           only).
         explode: false
         in: query
         name: tag
         schema:
-          description: Restrict the result set to one tag value (tagged artifact kinds
+          description: Restrict the result set to one tag value (tagged resource kinds
             only).
           type: string
       - description: Only return the literal latest tag per (namespace, name). Equivalent
@@ -3318,13 +3318,13 @@ paths:
         schema:
           description: 'Label selector: key=value,key2=value2.'
           type: string
-      - description: Restrict the result set to one tag value (tagged artifact kinds
+      - description: Restrict the result set to one tag value (tagged resource kinds
           only).
         explode: false
         in: query
         name: tag
         schema:
-          description: Restrict the result set to one tag value (tagged artifact kinds
+          description: Restrict the result set to one tag value (tagged resource kinds
             only).
           type: string
       - description: Only return the literal latest tag per (namespace, name). Equivalent

--- a/pkg/api/v1alpha1/deployment.go
+++ b/pkg/api/v1alpha1/deployment.go
@@ -17,7 +17,7 @@ type Deployment struct {
 func init() {
 	MustRegisterKind[*Deployment, DeploymentSpec](
 		KindDeployment,
-		WithMutableObjectStorage(),
+		WithUntaggedStorage(),
 	)
 }
 

--- a/pkg/api/v1alpha1/kinds.go
+++ b/pkg/api/v1alpha1/kinds.go
@@ -10,13 +10,13 @@ import (
 	"unicode"
 )
 
-// KindStorage describes the private persistence semantics attached to a
-// v1alpha1 kind.
+// KindStorage describes whether metadata.tag participates in a kind's storage
+// identity. Tags are replaceable identity slots, not immutable versions.
 type KindStorage string
 
 const (
-	KindStorageTaggedArtifact KindStorage = "TaggedArtifact"
-	KindStorageMutableObject  KindStorage = "MutableObject"
+	KindStorageTagged   KindStorage = "Tagged"
+	KindStorageUntagged KindStorage = "Untagged"
 )
 
 // KindDescriptor is the single registration record for a v1alpha1 kind. Scheme
@@ -56,10 +56,11 @@ func WithPlural(plural string) KindOption {
 	}
 }
 
-// WithMutableObjectStorage marks the kind as namespace/name mutable state.
-func WithMutableObjectStorage() KindOption {
+// WithUntaggedStorage keys the kind by namespace/name and rejects tag-bearing
+// references.
+func WithUntaggedStorage() KindOption {
 	return func(d *KindDescriptor) {
-		d.Storage = KindStorageMutableObject
+		d.Storage = KindStorageUntagged
 	}
 }
 
@@ -81,7 +82,7 @@ func RegisterKind[T Object, S any](kind string, opts ...KindOption) error {
 		NewObject:  newObject,
 		Plural:     defaultRoutePlural(kind),
 		Table:      defaultTableForKind(kind),
-		Storage:    KindStorageTaggedArtifact,
+		Storage:    KindStorageTagged,
 	}
 	for _, opt := range opts {
 		if opt != nil {
@@ -136,7 +137,7 @@ func (r *KindRegistry) Register(descriptor KindDescriptor) error {
 		descriptor.Table = defaultTableForKind(descriptor.Kind)
 	}
 	if descriptor.Storage == "" {
-		descriptor.Storage = KindStorageTaggedArtifact
+		descriptor.Storage = KindStorageTagged
 	}
 
 	key := strings.ToLower(descriptor.Kind)

--- a/pkg/api/v1alpha1/model.go
+++ b/pkg/api/v1alpha1/model.go
@@ -32,7 +32,7 @@ const (
 // provider-scoped identity, and platform-owned connection posture.
 //
 // Model is a tagged catalog artifact. Provider identity and platform-owned
-// auth/endpoint posture are versioned together so Deployments can pin the
+// auth/endpoint posture are stored under one tag so Deployments can pin the
 // complete model configuration they consume.
 type ModelSpec struct {
 	// Catalog display metadata.

--- a/pkg/api/v1alpha1/model_validate.go
+++ b/pkg/api/v1alpha1/model_validate.go
@@ -26,7 +26,7 @@ var KnownModelProviders = map[string]struct {
 //   - "runtime" only for ambient-identity providers (currently bedrock);
 //     key-based providers must declare secretRef or passthrough.
 //
-// Model is versioned: identity is (namespace, name, tag). Auth/endpoint edits
+// Model is tagged: identity is (namespace, name, tag). Auth/endpoint edits
 // publish a new configuration tag when callers need to preserve existing
 // Deployment pins.
 func (m *Model) Validate() error {

--- a/pkg/api/v1alpha1/object.go
+++ b/pkg/api/v1alpha1/object.go
@@ -22,8 +22,8 @@ const DefaultNamespace = "default"
 //
 // Namespace, Name, Labels, Annotations, and Tag are user-settable. Tag is
 // meaningful for content-registry kinds. UID, Generation, CreatedAt,
-// UpdatedAt, and DeletionTimestamp are server-managed. Content resources use
-// Tag and mutable resources use Namespace/Name.
+// UpdatedAt, and DeletionTimestamp are server-managed. Tagged resources use
+// Namespace/Name/Tag; untagged resources use Namespace/Name.
 //
 // Generation is an internal coordination primitive that drives reconciler
 // convergence (paired with Status.ObservedGeneration). It is populated from the
@@ -36,7 +36,7 @@ const DefaultNamespace = "default"
 // live server. When Tag is omitted, the store fills it with the literal
 // "latest" tag.
 //
-// Mutable-object kinds (Runtime, Deployment, and additional downstream
+// Untagged kinds (Runtime, Deployment, and additional downstream
 // control-plane/config kinds) use Namespace/Name as their full identity.
 // Namespace is an internal
 // detail today — it defaults to "default" on apply and is stripped from

--- a/pkg/api/v1alpha1/plugin.go
+++ b/pkg/api/v1alpha1/plugin.go
@@ -2,7 +2,7 @@ package v1alpha1
 
 // Plugin is the typed envelope for kind=Plugin resources.
 //
-// A Plugin is a self-contained, versioned bundle of harness extensions —
+// A Plugin is a self-contained, tagged bundle of harness extensions —
 // skills, MCP servers, hooks, and sub-agents — modeled on the Claude Code
 // plugin format. The Spec is USER INTENT ONLY: a pinned pointer to an external
 // source (a git commit or — later — an OCI digest), the same source-based model

--- a/pkg/api/v1alpha1/ref.go
+++ b/pkg/api/v1alpha1/ref.go
@@ -2,12 +2,12 @@ package v1alpha1
 
 // ResourceRef is a typed reference to another resource in the registry.
 // Public references use one shape across v1alpha1: {Kind, Namespace, Name,
-// Tag}. Tag is meaningful only for taggable registry artifacts.
+// Tag}. Tag is meaningful only for tagged resources.
 //
 // Namespace is optional: blank means "same namespace as the referencing
 // object" (the common case). Tag is optional: blank means "resolve to the
-// literal latest tag" for taggable artifacts or "resolve by namespace/name"
-// for mutable object kinds.
+// literal latest tag" for tagged resources or "resolve by namespace/name"
+// for untagged resource kinds.
 type ResourceRef struct {
 	Kind      string `json:"kind" yaml:"kind"`
 	Namespace string `json:"namespace,omitempty" yaml:"namespace,omitempty"`
@@ -17,7 +17,7 @@ type ResourceRef struct {
 
 // DeploymentRef is a typed reference to another Deployment resource. Kind
 // is implicit (always Deployment) and Tag is omitted because Deployment is
-// a mutable-object kind keyed by namespace/name.
+// an untagged kind keyed by namespace/name.
 //
 // Namespace is optional: blank means "same namespace as the referencing
 // Deployment".

--- a/pkg/api/v1alpha1/runtime.go
+++ b/pkg/api/v1alpha1/runtime.go
@@ -12,7 +12,7 @@ type Runtime struct {
 }
 
 func init() {
-	MustRegisterKind[*Runtime, RuntimeSpec](KindRuntime, WithMutableObjectStorage())
+	MustRegisterKind[*Runtime, RuntimeSpec](KindRuntime, WithUntaggedStorage())
 }
 
 // TypeKubernetes is the canonical discriminator for Kubernetes runtime

--- a/pkg/api/v1alpha1/scheme.go
+++ b/pkg/api/v1alpha1/scheme.go
@@ -127,17 +127,11 @@ func (s *Scheme) Decode(data []byte) (any, error) {
 	return obj, nil
 }
 
-// IsContentRegistryKind reports whether a kind belongs to the tagged
-// content-registry bucket.
-func IsContentRegistryKind(kind string) bool {
-	return IsTaggedArtifactKind(kind)
-}
-
-// IsTaggedArtifactKind reports whether refs to kind may use tag pinning and
+// IsTaggedKind reports whether refs to kind may use tag pinning and
 // whether the private store behavior keys rows by namespace/name/tag.
-func IsTaggedArtifactKind(kind string) bool {
+func IsTaggedKind(kind string) bool {
 	descriptor, ok := KindDescriptorFor(kind)
-	return ok && descriptor.Storage == KindStorageTaggedArtifact
+	return ok && descriptor.Storage == KindStorageTagged
 }
 
 // DecodeMulti parses a YAML stream (possibly containing multiple `---`-

--- a/pkg/api/v1alpha1/scheme_test.go
+++ b/pkg/api/v1alpha1/scheme_test.go
@@ -37,14 +37,14 @@ func TestKindDescriptorsDriveKindMetadata(t *testing.T) {
 	if !ok {
 		t.Fatalf("missing %s descriptor", KindAgent)
 	}
-	if agent.Storage != KindStorageTaggedArtifact {
-		t.Fatalf("agent storage = %s, want %s", agent.Storage, KindStorageTaggedArtifact)
+	if agent.Storage != KindStorageTagged {
+		t.Fatalf("agent storage = %s, want %s", agent.Storage, KindStorageTagged)
 	}
 	if agent.Plural != "agents" || agent.Table != "v1alpha1.agents" {
 		t.Fatalf("agent routing/storage = %s/%s", agent.Plural, agent.Table)
 	}
-	if !IsTaggedArtifactKind(KindAgent) {
-		t.Fatalf("agent should be tagged artifact kind")
+	if !IsTaggedKind(KindAgent) {
+		t.Fatalf("agent should be tagged resource kind")
 	}
 	mcp, ok := KindDescriptorFor(KindMCPServer)
 	if !ok {
@@ -57,28 +57,28 @@ func TestKindDescriptorsDriveKindMetadata(t *testing.T) {
 	if !ok {
 		t.Fatalf("missing %s descriptor", KindModel)
 	}
-	if model.Storage != KindStorageTaggedArtifact {
-		t.Fatalf("model storage = %s, want %s", model.Storage, KindStorageTaggedArtifact)
+	if model.Storage != KindStorageTagged {
+		t.Fatalf("model storage = %s, want %s", model.Storage, KindStorageTagged)
 	}
 	if model.Plural != "models" || model.Table != "v1alpha1.models" {
 		t.Fatalf("model routing/storage = %s/%s", model.Plural, model.Table)
 	}
-	if !IsTaggedArtifactKind(KindModel) {
-		t.Fatalf("model should be tagged artifact kind")
+	if !IsTaggedKind(KindModel) {
+		t.Fatalf("model should be tagged resource kind")
 	}
 
 	deployment, ok := KindDescriptorFor(KindDeployment)
 	if !ok {
 		t.Fatalf("missing %s descriptor", KindDeployment)
 	}
-	if deployment.Storage != KindStorageMutableObject {
-		t.Fatalf("deployment storage = %s, want %s", deployment.Storage, KindStorageMutableObject)
+	if deployment.Storage != KindStorageUntagged {
+		t.Fatalf("deployment storage = %s, want %s", deployment.Storage, KindStorageUntagged)
 	}
 	if deployment.Plural != "deployments" || deployment.Table != "v1alpha1.deployments" {
 		t.Fatalf("deployment routing/storage = %s/%s", deployment.Plural, deployment.Table)
 	}
-	if IsTaggedArtifactKind(KindDeployment) {
-		t.Fatalf("deployment should not be tagged artifact kind")
+	if IsTaggedKind(KindDeployment) {
+		t.Fatalf("deployment should not be tagged resource kind")
 	}
 }
 

--- a/pkg/api/v1alpha1/validation.go
+++ b/pkg/api/v1alpha1/validation.go
@@ -144,10 +144,10 @@ var UpstreamMCPPackageNameRegex = regexp.MustCompile(UpstreamMCPPackageNamePatte
 
 // ValidateObjectMeta checks the namespace/name format and label shape.
 // Server-managed fields (CreatedAt, UpdatedAt, DeletionTimestamp) are ignored.
-// Content resources use metadata.tag for identity; mutable object kinds expose
+// Content resources use metadata.tag for identity; untagged resource kinds expose
 // only namespace/name.
 //
-// Taggable artifact kinds and mutable object kinds call this same validator
+// Taggable artifact kinds and untagged resource kinds call this same validator
 // because ObjectMeta exposes one public shape for both identities.
 func ValidateObjectMeta(m ObjectMeta) FieldErrors {
 	var errs FieldErrors
@@ -285,7 +285,7 @@ func validateRef(r ResourceRef, allowedKinds ...string) FieldErrors {
 	}
 	// Tag is optional on content refs — blank means "resolve to latest".
 	if r.Tag != "" {
-		if !IsTaggedArtifactKind(r.Kind) {
+		if !IsTaggedKind(r.Kind) {
 			errs.Append("tag", fmt.Errorf("%w: kind %q does not support tag pinning", ErrInvalidRef, r.Kind))
 		} else if err := validateTag(r.Tag); err != nil {
 			errs.Append("tag", err)

--- a/pkg/registry/resource/apply.go
+++ b/pkg/registry/resource/apply.go
@@ -34,7 +34,7 @@ type ApplyConfig struct {
 	Scheme *v1alpha1.Scheme
 	// Authorizers, when non-empty, gates each decoded document on apply
 	// against the same per-kind hook the generic resource handler
-	// consults on direct mutable-object PUT. Without this,
+	// consults on direct untagged PUT. Without this,
 	// /v0/apply (the multi-doc batch endpoint arctl uses) bypasses the
 	// per-kind authz wired through crud.PerKindHooks. Missing keys
 	// authorize-allow (matches resource.Config.Authorize == nil).
@@ -102,7 +102,7 @@ type applyOutput struct {
 //
 // DELETE: for each document, calls Store.Delete on the named resource. Tagged
 // artifacts use metadata.tag when supplied; omitted tag deletes all tags for
-// that namespace/name. Mutable objects delete by namespace/name. Validation
+// that namespace/name. Untagged resources delete by namespace/name. Validation
 // still runs so clients get the same error surface as apply.
 //
 // Both endpoints always return 200 with a per-document Results slice;
@@ -220,9 +220,9 @@ func applyOne(ctx context.Context, cfg ApplyConfig, obj v1alpha1.Object, dryRun 
 // decoded body verbatim — batch callers expecting hook input matching
 // the persisted row should re-apply before deleting.
 //
-// Tagged-artifact batch delete uses the logical tag selector: omitting metadata.tag
+// Tagged batch delete uses the logical tag selector: omitting metadata.tag
 // deletes every tag for (namespace, name); setting metadata.tag deletes that
-// exact tag. Mutable-object rows keep their single-row delete since those rows
+// exact tag. Untagged rows keep their single-row delete since those rows
 // are control-plane state rather than append-only tags.
 func deleteOne(ctx context.Context, cfg ApplyConfig, obj v1alpha1.Object, dryRun bool) arv0.ApplyResult {
 	store, meta, ae := resolveBatchTarget(cfg, obj, "delete")

--- a/pkg/registry/resource/apply_test.go
+++ b/pkg/registry/resource/apply_test.go
@@ -22,8 +22,8 @@ import (
 
 func TestRegisterApply_MultiDocRoundTrip(t *testing.T) {
 	pool := v1alpha1store.NewTestPool(t)
-	agents := v1alpha1store.NewStore(pool, v1alpha1store.TestSchema(), "agents")
-	mcps := v1alpha1store.NewStore(pool, v1alpha1store.TestSchema(), "mcp_servers")
+	agents := v1alpha1store.NewTaggedStore(pool, v1alpha1store.TestSchema(), "agents")
+	mcps := v1alpha1store.NewTaggedStore(pool, v1alpha1store.TestSchema(), "mcp_servers")
 
 	_, api := humatest.New(t)
 	resource.RegisterApply(api, resource.ApplyConfig{
@@ -80,7 +80,7 @@ spec:
 
 func TestRegisterApply_PerDocFailureDoesntAbortBatch(t *testing.T) {
 	pool := v1alpha1store.NewTestPool(t)
-	agents := v1alpha1store.NewStore(pool, v1alpha1store.TestSchema(), "agents")
+	agents := v1alpha1store.NewTaggedStore(pool, v1alpha1store.TestSchema(), "agents")
 
 	_, api := humatest.New(t)
 	resource.RegisterApply(api, resource.ApplyConfig{
@@ -122,7 +122,7 @@ spec:
 
 func TestRegisterApply_AdmissionCanStageInsteadOfProductionUpsert(t *testing.T) {
 	pool := v1alpha1store.NewTestPool(t)
-	agents := v1alpha1store.NewStore(pool, v1alpha1store.TestSchema(), "agents")
+	agents := v1alpha1store.NewTaggedStore(pool, v1alpha1store.TestSchema(), "agents")
 
 	var admitted types.AdmissionInput
 	postUpsertCalled := false
@@ -177,7 +177,7 @@ spec:
 
 func TestRegisterApply_DeleteAdmissionCanStageInsteadOfProductionDelete(t *testing.T) {
 	pool := v1alpha1store.NewTestPool(t)
-	agents := v1alpha1store.NewStore(pool, v1alpha1store.TestSchema(), "agents")
+	agents := v1alpha1store.NewTaggedStore(pool, v1alpha1store.TestSchema(), "agents")
 	_, err := agents.Upsert(t.Context(), &v1alpha1.Agent{
 		Metadata: v1alpha1.ObjectMeta{Namespace: "default", Name: "staged-delete", Tag: "stable"},
 		Spec:     v1alpha1.AgentSpec{Title: "Staged Delete"},
@@ -239,7 +239,7 @@ metadata:
 
 func TestApplyObject_ReusesProductionApplyPath(t *testing.T) {
 	pool := v1alpha1store.NewTestPool(t)
-	agents := v1alpha1store.NewStore(pool, v1alpha1store.TestSchema(), "agents")
+	agents := v1alpha1store.NewTaggedStore(pool, v1alpha1store.TestSchema(), "agents")
 
 	obj := &v1alpha1.Agent{
 		TypeMeta: v1alpha1.TypeMeta{APIVersion: v1alpha1.GroupVersion, Kind: v1alpha1.KindAgent},
@@ -263,10 +263,10 @@ func TestApplyObject_ReusesProductionApplyPath(t *testing.T) {
 	require.Equal(t, "stable", row.Metadata.Tag)
 }
 
-func TestRegisterApply_MutableObjectResultsDoNotExposeVersion(t *testing.T) {
+func TestRegisterApply_UntaggedResultsDoNotExposeVersion(t *testing.T) {
 	pool := v1alpha1store.NewTestPool(t)
-	runtimes := v1alpha1store.NewMutableObjectStore(pool, v1alpha1store.TestSchema(), "runtimes")
-	deployments := v1alpha1store.NewMutableObjectStore(pool, v1alpha1store.TestSchema(), "deployments")
+	runtimes := v1alpha1store.NewUntaggedStore(pool, v1alpha1store.TestSchema(), "runtimes")
+	deployments := v1alpha1store.NewUntaggedStore(pool, v1alpha1store.TestSchema(), "deployments")
 
 	_, api := humatest.New(t)
 	resource.RegisterApply(api, resource.ApplyConfig{
@@ -314,7 +314,7 @@ spec:
 	require.Equal(t, arv0.ApplyStatusCreated, out.Results[1].Status)
 	require.Empty(t, out.Results[1].Tag)
 
-	// Mutable objects are keyed by namespace/name, so applying the same
+	// Untagged resources are keyed by namespace/name, so applying the same
 	// Deployment again must update neither the row nor its generation.
 	resp = api.Post("/v0/apply", "Content-Type: application/yaml", strings.NewReader(string(yaml)))
 	require.Equal(t, http.StatusOK, resp.Code, resp.Body.String())
@@ -335,7 +335,7 @@ spec:
 
 func TestRegisterDeleteApply_OmittedTagDeletesAllTags(t *testing.T) {
 	pool := v1alpha1store.NewTestPool(t)
-	agents := v1alpha1store.NewStore(pool, v1alpha1store.TestSchema(), "agents")
+	agents := v1alpha1store.NewTaggedStore(pool, v1alpha1store.TestSchema(), "agents")
 
 	_, api := humatest.New(t)
 	resource.RegisterApply(api, resource.ApplyConfig{
@@ -380,7 +380,7 @@ metadata:
 
 func TestRegisterDeleteApply_TagDeletesOnlyExactTag(t *testing.T) {
 	pool := v1alpha1store.NewTestPool(t)
-	agents := v1alpha1store.NewStore(pool, v1alpha1store.TestSchema(), "agents")
+	agents := v1alpha1store.NewTaggedStore(pool, v1alpha1store.TestSchema(), "agents")
 
 	_, api := humatest.New(t)
 	resource.RegisterApply(api, resource.ApplyConfig{
@@ -426,7 +426,7 @@ metadata:
 
 func TestRegisterApply_DefaultsRemoteMCPServerTagBeforeAuthorize(t *testing.T) {
 	pool := v1alpha1store.NewTestPool(t)
-	mcpServers := v1alpha1store.NewStore(pool, v1alpha1store.TestSchema(), "mcp_servers")
+	mcpServers := v1alpha1store.NewTaggedStore(pool, v1alpha1store.TestSchema(), "mcp_servers")
 
 	_, err := mcpServers.Upsert(t.Context(), &v1alpha1.MCPServer{
 		Metadata: v1alpha1.ObjectMeta{Namespace: "default", Name: "test-mcp-server"},
@@ -492,8 +492,8 @@ spec:
 // /v0/apply path for the missing kinds.
 func TestRegisterApply_DeniesKindWithNoAuthorizer(t *testing.T) {
 	pool := v1alpha1store.NewTestPool(t)
-	agents := v1alpha1store.NewStore(pool, v1alpha1store.TestSchema(), "agents")
-	mcps := v1alpha1store.NewStore(pool, v1alpha1store.TestSchema(), "mcp_servers")
+	agents := v1alpha1store.NewTaggedStore(pool, v1alpha1store.TestSchema(), "agents")
+	mcps := v1alpha1store.NewTaggedStore(pool, v1alpha1store.TestSchema(), "mcp_servers")
 
 	_, api := humatest.New(t)
 	resource.RegisterApply(api, resource.ApplyConfig{

--- a/pkg/registry/resource/core.go
+++ b/pkg/registry/resource/core.go
@@ -87,7 +87,7 @@ func applyCore(
 		obj.SetMetadata(*meta)
 	}
 
-	if v1alpha1.IsTaggedArtifactKind(kind) && meta.Tag == "" {
+	if v1alpha1.IsTaggedKind(kind) && meta.Tag == "" {
 		meta.Tag = v1alpha1store.DefaultTag()
 		obj.SetMetadata(*meta)
 	}

--- a/pkg/registry/resource/handler.go
+++ b/pkg/registry/resource/handler.go
@@ -9,11 +9,11 @@
 //	GET    {basePrefix}/{pluralKind}/{name}?namespace={ns}            get latest
 //	GET    {basePrefix}/{pluralKind}/{name}/tags?namespace={ns}      list tags of one (tagged content kinds only)
 //	GET    {basePrefix}/{pluralKind}/{name}/{tag}?namespace={ns}     get exact tag (tagged content kinds only)
-//	PUT    {basePrefix}/{pluralKind}/{name}?namespace={ns}           apply mutable object (Provider/Deployment/config)
-//	DELETE {basePrefix}/{pluralKind}/{name}?namespace={ns}           delete mutable object
+//	PUT    {basePrefix}/{pluralKind}/{name}?namespace={ns}           apply untagged resource (Provider/Deployment/config)
+//	DELETE {basePrefix}/{pluralKind}/{name}?namespace={ns}           delete untagged resource
 //	DELETE {basePrefix}/{pluralKind}/{name}/{tag}?namespace={ns}     delete exact tag (tagged content kinds only)
 //
-// Direct PUT is registered only for mutable object stores. Content-registry
+// Direct PUT is registered only for untagged resource stores. Content-registry
 // artifact kinds (Agent, MCPServer, Model, Plugin, Skill, Prompt) use
 // metadata.tag and are
 // written through POST /v0/apply.
@@ -60,7 +60,7 @@ type Config struct {
 	// "mcpservers"). If empty, defaults to strings.ToLower(Kind) + "s".
 	PluralKind string
 	// BasePrefix is the HTTP route prefix shared across kinds (e.g. "/v0").
-	// Routes extend it with `/{plural}/{name}` and, for tagged artifacts,
+	// Routes extend it with `/{plural}/{name}` and, for tagged resources,
 	// `/{plural}/{name}/{tag}`; namespace is
 	// carried as a query param (`?namespace={ns}`, default "default").
 	BasePrefix string
@@ -274,7 +274,7 @@ type ListInput struct {
 	Limit      int    `query:"limit" doc:"Max items to return (default 50)." default:"50"`
 	Cursor     string `query:"cursor" doc:"Opaque pagination cursor."`
 	Labels     string `query:"labels" doc:"Label selector: key=value,key2=value2."`
-	Tag        string `query:"tag" doc:"Restrict the result set to one tag value (tagged artifact kinds only)."`
+	Tag        string `query:"tag" doc:"Restrict the result set to one tag value (tagged resource kinds only)."`
 	LatestOnly bool   `query:"latestOnly" doc:"Only return the literal latest tag per (namespace, name). Equivalent to tag=latest for tagged kinds."`
 	// IncludeTerminating surfaces soft-deleted rows (deletionTimestamp != nil)
 	// which are hidden by default.
@@ -378,21 +378,21 @@ func Register[T v1alpha1.Object](api huma.API, cfg Config, newObj func() T) {
 		return &bodyOutput[T]{Body: obj}, nil
 	})
 
-	// List tags (name only; namespace via query). Tagged-artifact
-	// kinds only — mutable object stores have no concept of
+	// List tags (name only; namespace via query). Tagged
+	// kinds only — untagged resource stores have no concept of
 	// "every tag of a logical resource". Registered before the
 	// get-exact route below so the literal "tags" path segment
 	// wins over the `{tag}` capture in the underlying flow router
 	// (routes match in registration order).
-	if v1alpha1.IsTaggedArtifactKind(kind) {
+	if v1alpha1.IsTaggedKind(kind) {
 		registerListTags(api, cfg, newObj, kind, itemPath)
 	}
 
-	if v1alpha1.IsTaggedArtifactKind(kind) {
+	if v1alpha1.IsTaggedKind(kind) {
 		registerGetTagged(api, cfg, newObj, kind, itemTagPath)
 		registerDeleteTagged(api, cfg, newObj, kind, itemTagPath)
 	} else {
-		registerApplyMutable(api, cfg, newObj, kind, itemPath)
+		registerApplyUntagged(api, cfg, newObj, kind, itemPath)
 		registerDeleteMutable(api, cfg, newObj, kind, itemPath)
 	}
 }
@@ -431,7 +431,7 @@ func registerGetTagged[T v1alpha1.Object](api huma.API, cfg Config, newObj func(
 }
 
 // registerListTags wires the GET /{name}/tags endpoint for a
-// tagged-artifact kind. Extracted from Register to keep the per-kind
+// tagged kind. Extracted from Register to keep the per-kind
 // route registration sequence readable.
 func registerListTags[T v1alpha1.Object](api huma.API, cfg Config, newObj func() T, kind, itemPath string) {
 	huma.Register(api, huma.Operation{
@@ -468,8 +468,8 @@ func registerListTags[T v1alpha1.Object](api huma.API, cfg Config, newObj func()
 	})
 }
 
-// registerApplyMutable wires name-only PUT for mutable object stores.
-func registerApplyMutable[T v1alpha1.Object](api huma.API, cfg Config, newObj func() T, kind, itemPath string) {
+// registerApplyUntagged wires name-only PUT for untagged resource stores.
+func registerApplyUntagged[T v1alpha1.Object](api huma.API, cfg Config, newObj func() T, kind, itemPath string) {
 	huma.Register(api, huma.Operation{
 		OperationID:   "apply-" + strings.ToLower(kind),
 		Method:        http.MethodPut,
@@ -500,7 +500,7 @@ func registerApplyMutable[T v1alpha1.Object](api huma.API, cfg Config, newObj fu
 		}
 
 		// Stamp resolved public identity into metadata so applyCore sees the
-		// resolved namespace/name. The store owns any private mutable-object
+		// resolved namespace/name. The store owns any private untagged
 		// backing-row identity.
 		meta.Namespace = ns
 		meta.Name = name

--- a/pkg/registry/resource/handler_test.go
+++ b/pkg/registry/resource/handler_test.go
@@ -81,7 +81,7 @@ func TestResourceRegister_AgentCRUD(t *testing.T) {
 	t.Helper()
 
 	pool := v1alpha1store.NewTestPool(t)
-	store := v1alpha1store.NewStore(pool, v1alpha1store.TestSchema(), "agents")
+	store := v1alpha1store.NewTaggedStore(pool, v1alpha1store.TestSchema(), "agents")
 
 	_, api := humatest.New(t)
 	registerAgent(api, store)
@@ -173,7 +173,7 @@ spec:
 	require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &gotAgent))
 	require.Equal(t, "Alice v2", gotAgent.Spec.Title)
 
-	// DELETE — tagged-artifact rows have no finalizers, so DELETE
+	// DELETE — tagged rows have no finalizers, so DELETE
 	// hard-deletes the targeted tag immediately.
 	resp = api.Delete("/v0/agents/alice/latest")
 	require.Equal(t, http.StatusNoContent, resp.Code)
@@ -201,7 +201,7 @@ spec:
 
 func TestResourceRegister_DeleteTaggedPassesTagToAuthorizer(t *testing.T) {
 	pool := v1alpha1store.NewTestPool(t)
-	store := v1alpha1store.NewStore(pool, v1alpha1store.TestSchema(), "agents")
+	store := v1alpha1store.NewTaggedStore(pool, v1alpha1store.TestSchema(), "agents")
 	_, err := store.Upsert(t.Context(), &v1alpha1.Agent{
 		Metadata: v1alpha1.ObjectMeta{Namespace: "default", Name: "alice", Tag: "stable"},
 		Spec:     v1alpha1.AgentSpec{Title: "Stable Alice"},
@@ -233,7 +233,7 @@ func TestResourceRegister_DeleteTaggedPassesTagToAuthorizer(t *testing.T) {
 
 func TestResourceRegister_DeleteAdmissionCanStageTaggedDelete(t *testing.T) {
 	pool := v1alpha1store.NewTestPool(t)
-	store := v1alpha1store.NewStore(pool, v1alpha1store.TestSchema(), "agents")
+	store := v1alpha1store.NewTaggedStore(pool, v1alpha1store.TestSchema(), "agents")
 	_, err := store.Upsert(t.Context(), &v1alpha1.Agent{
 		Metadata: v1alpha1.ObjectMeta{Namespace: "default", Name: "alice", Tag: "stable"},
 		Spec:     v1alpha1.AgentSpec{Title: "Stable Alice"},
@@ -277,7 +277,7 @@ func TestResourceRegister_DeleteAdmissionCanStageTaggedDelete(t *testing.T) {
 
 func TestResourceRegister_AgentNamespaceIsolation(t *testing.T) {
 	pool := v1alpha1store.NewTestPool(t)
-	store := v1alpha1store.NewStore(pool, v1alpha1store.TestSchema(), "agents")
+	store := v1alpha1store.NewTaggedStore(pool, v1alpha1store.TestSchema(), "agents")
 
 	_, api := humatest.New(t)
 	registerAgent(api, store)
@@ -336,7 +336,7 @@ spec:
 
 func TestResourceRegister_AgentListCursorPagination(t *testing.T) {
 	pool := v1alpha1store.NewTestPool(t)
-	store := v1alpha1store.NewStore(pool, v1alpha1store.TestSchema(), "agents")
+	store := v1alpha1store.NewTaggedStore(pool, v1alpha1store.TestSchema(), "agents")
 
 	_, api := humatest.New(t)
 	registerAgent(api, store)
@@ -387,7 +387,7 @@ spec:
 // contract: every non-deleted tag row for (namespace, name) is returned.
 func TestResourceRegister_AgentListTags(t *testing.T) {
 	pool := v1alpha1store.NewTestPool(t)
-	store := v1alpha1store.NewStore(pool, v1alpha1store.TestSchema(), "agents")
+	store := v1alpha1store.NewTaggedStore(pool, v1alpha1store.TestSchema(), "agents")
 
 	_, api := humatest.New(t)
 	registerAgent(api, store)
@@ -431,7 +431,7 @@ func TestResourceRegister_AgentListTags(t *testing.T) {
 
 func TestResourceRegister_AgentListRejectsInvalidCursor(t *testing.T) {
 	pool := v1alpha1store.NewTestPool(t)
-	store := v1alpha1store.NewStore(pool, v1alpha1store.TestSchema(), "agents")
+	store := v1alpha1store.NewTaggedStore(pool, v1alpha1store.TestSchema(), "agents")
 
 	_, api := humatest.New(t)
 	registerAgent(api, store)
@@ -443,8 +443,8 @@ func TestResourceRegister_AgentListRejectsInvalidCursor(t *testing.T) {
 
 func TestResourceRegister_OriginFilterIsOptIn(t *testing.T) {
 	pool := v1alpha1store.NewTestPool(t)
-	agents := v1alpha1store.NewStore(pool, v1alpha1store.TestSchema(), "agents")
-	deployments := v1alpha1store.NewMutableObjectStore(pool, v1alpha1store.TestSchema(), "deployments")
+	agents := v1alpha1store.NewTaggedStore(pool, v1alpha1store.TestSchema(), "agents")
+	deployments := v1alpha1store.NewUntaggedStore(pool, v1alpha1store.TestSchema(), "deployments")
 
 	_, plainAPI := humatest.New(t)
 	resource.Register[*v1alpha1.Agent](plainAPI, resource.Config{
@@ -491,7 +491,7 @@ func requireListQueryParam(t *testing.T, api humatest.TestAPI, path, name string
 // the filtered list returns just the two matches.
 func TestResourceRegister_ListFilter(t *testing.T) {
 	pool := v1alpha1store.NewTestPool(t)
-	store := v1alpha1store.NewStore(pool, v1alpha1store.TestSchema(), "agents")
+	store := v1alpha1store.NewTaggedStore(pool, v1alpha1store.TestSchema(), "agents")
 
 	for _, name := range []string{"ok-one", "ok-two", "blocked-three"} {
 		_, err := store.Upsert(t.Context(), &v1alpha1.Agent{
@@ -541,7 +541,7 @@ func TestResourceRegister_ListFilter(t *testing.T) {
 // longer registered for content-registry kinds (Agent, MCPServer,
 // Skill, Prompt). POST /v0/apply is the single
 // create/update entry point — user-controlled tags live in metadata.tag rather
-// than the URL segment of a direct PUT. Runtime/Deployment mutable-object
+// than the URL segment of a direct PUT. Runtime/Deployment untagged
 // stores still expose direct namespace/name PUT.
 //
 // The test issues a PUT against the agents handler and expects 405
@@ -550,7 +550,7 @@ func TestResourceRegister_ListFilter(t *testing.T) {
 // confirms PUT is excluded.
 func TestResourceRegister_PutNotRegisteredForContentKinds(t *testing.T) {
 	pool := v1alpha1store.NewTestPool(t)
-	store := v1alpha1store.NewStore(pool, v1alpha1store.TestSchema(), "agents")
+	store := v1alpha1store.NewTaggedStore(pool, v1alpha1store.TestSchema(), "agents")
 
 	_, api := humatest.New(t)
 	registerAgent(api, store)
@@ -579,9 +579,9 @@ func TestResourceRegister_PutNotRegisteredForContentKinds(t *testing.T) {
 		rec.Code, rec.Body.String())
 }
 
-func TestResourceRegister_MutableObjectUsesNameOnlyRoute(t *testing.T) {
+func TestResourceRegister_UntaggedUsesNameOnlyRoute(t *testing.T) {
 	pool := v1alpha1store.NewTestPool(t)
-	store := v1alpha1store.NewMutableObjectStore(pool, v1alpha1store.TestSchema(), "runtimes")
+	store := v1alpha1store.NewUntaggedStore(pool, v1alpha1store.TestSchema(), "runtimes")
 
 	_, api := humatest.New(t)
 	registerProvider(api, store)
@@ -602,7 +602,7 @@ func TestResourceRegister_MutableObjectUsesNameOnlyRoute(t *testing.T) {
 	require.Equal(t, http.StatusOK, resp.Code, resp.Body.String())
 
 	resp = api.Put("/v0/runtimes/test-runtime/1", runtime)
-	require.Equal(t, http.StatusNotFound, resp.Code, "mutable object route must be name-only")
+	require.Equal(t, http.StatusNotFound, resp.Code, "untagged resource route must be name-only")
 
 	resp = api.Delete("/v0/runtimes/test-runtime")
 	require.Equal(t, http.StatusNoContent, resp.Code, resp.Body.String())
@@ -610,8 +610,8 @@ func TestResourceRegister_MutableObjectUsesNameOnlyRoute(t *testing.T) {
 
 func TestResourceRegister_ResolverDetectsDanglingRef(t *testing.T) {
 	pool := v1alpha1store.NewTestPool(t)
-	agentStore := v1alpha1store.NewStore(pool, v1alpha1store.TestSchema(), "agents")
-	mcpStore := v1alpha1store.NewStore(pool, v1alpha1store.TestSchema(), "mcp_servers")
+	agentStore := v1alpha1store.NewTaggedStore(pool, v1alpha1store.TestSchema(), "agents")
+	mcpStore := v1alpha1store.NewTaggedStore(pool, v1alpha1store.TestSchema(), "mcp_servers")
 
 	// Resolver: only MCPServer "tools" in namespace "default" exists.
 	resolver := func(ctx context.Context, ref v1alpha1.ResourceRef) error {
@@ -677,7 +677,7 @@ spec:
 // for every v1alpha1 kind"); fixed at the Store layer.
 func TestResourceRegister_DeleteHardDeletesFinalizerFree(t *testing.T) {
 	pool := v1alpha1store.NewTestPool(t)
-	store := v1alpha1store.NewStore(pool, v1alpha1store.TestSchema(), "agents")
+	store := v1alpha1store.NewTaggedStore(pool, v1alpha1store.TestSchema(), "agents")
 
 	_, api := humatest.New(t)
 	registerAgent(api, store)
@@ -732,7 +732,7 @@ spec:
 // reviewer awareness.
 func TestResourceRegister_PostUpsertFailureLeavesPersistedRow(t *testing.T) {
 	pool := v1alpha1store.NewTestPool(t)
-	store := v1alpha1store.NewStore(pool, v1alpha1store.TestSchema(), "agents")
+	store := v1alpha1store.NewTaggedStore(pool, v1alpha1store.TestSchema(), "agents")
 
 	hookCalls := 0
 	hookErr := fmt.Errorf("simulated type-adapter failure")
@@ -807,11 +807,11 @@ spec:
 // TestResourceRegister_IncludeTerminatingByDefault pins the opt-in
 // behavior: a kind registered with IncludeTerminatingByDefault=true
 // surfaces terminating rows on plain LIST (no ?includeTerminating=true
-// needed), and ?latestOnly=true remains a no-op for mutable objects because
+// needed), and ?latestOnly=true remains a no-op for untagged resources because
 // namespace/name is already unique.
 func TestResourceRegister_IncludeTerminatingByDefault(t *testing.T) {
 	pool := v1alpha1store.NewTestPool(t)
-	store := v1alpha1store.NewMutableObjectStore(pool, v1alpha1store.TestSchema(), "runtimes")
+	store := v1alpha1store.NewUntaggedStore(pool, v1alpha1store.TestSchema(), "runtimes")
 	const testNamespace = "terminating-test"
 
 	_, api := humatest.New(t)
@@ -850,7 +850,7 @@ func TestResourceRegister_IncludeTerminatingByDefault(t *testing.T) {
 	require.NotNil(t, list.Items[0].Metadata.DeletionTimestamp,
 		"opt-in default must surface the deletionTimestamp so operators see in-flight teardown")
 
-	// LatestOnly is a no-op for mutable objects, so the terminating row remains
+	// LatestOnly is a no-op for untagged resources, so the terminating row remains
 	// visible because the kind opted into IncludeTerminatingByDefault.
 	resp = api.Get("/v0/runtimes?namespace=" + testNamespace + "&latestOnly=true")
 	require.Equal(t, http.StatusOK, resp.Code, resp.Body.String())
@@ -879,13 +879,13 @@ func TestResourceRegister_IncludeTerminatingByDefault(t *testing.T) {
 }
 
 // TestResourceRegister_DeleteIdempotentOnTerminating pins the
-// idempotent-DELETE contract for mutable-object kinds: even without
+// idempotent-DELETE contract for untagged kinds: even without
 // IncludeTerminatingByDefault, a DELETE on an already-terminating row
 // returns 204 rather than 404. The handler uses the terminating-aware
 // lookup so retry scripts get a coherent response shape.
 func TestResourceRegister_DeleteIdempotentOnTerminating(t *testing.T) {
 	pool := v1alpha1store.NewTestPool(t)
-	store := v1alpha1store.NewMutableObjectStore(pool, v1alpha1store.TestSchema(), "runtimes")
+	store := v1alpha1store.NewUntaggedStore(pool, v1alpha1store.TestSchema(), "runtimes")
 	const testNamespace = "delete-idempotent"
 
 	_, api := humatest.New(t)

--- a/pkg/registry/v1alpha1store/annotations_test.go
+++ b/pkg/registry/v1alpha1store/annotations_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestStore_AnnotationsRoundTrip(t *testing.T) {
 	pool := NewTestPool(t)
-	store := NewStore(pool, TestSchema(), testTable)
+	store := NewTaggedStore(pool, TestSchema(), testTable)
 	ctx := context.Background()
 
 	annotations := map[string]string{
@@ -39,7 +39,7 @@ func TestStore_AnnotationsRoundTrip(t *testing.T) {
 // Annotations are user-managed, not server-managed, in the new world.
 func TestStore_AnnotationsReplacedOnReapplyWithEmpty(t *testing.T) {
 	pool := NewTestPool(t)
-	store := NewStore(pool, TestSchema(), testTable)
+	store := NewTaggedStore(pool, TestSchema(), testTable)
 	ctx := context.Background()
 
 	_, err := store.Upsert(ctx, &v1alpha1.Agent{
@@ -66,7 +66,7 @@ func TestStore_AnnotationsReplacedOnReapplyWithEmpty(t *testing.T) {
 
 func TestStore_AnnotationsClearedOnEmptyMap(t *testing.T) {
 	pool := NewTestPool(t)
-	store := NewStore(pool, TestSchema(), testTable)
+	store := NewTaggedStore(pool, TestSchema(), testTable)
 	ctx := context.Background()
 
 	_, err := store.Upsert(ctx, &v1alpha1.Agent{

--- a/pkg/registry/v1alpha1store/helpers.go
+++ b/pkg/registry/v1alpha1store/helpers.go
@@ -25,7 +25,7 @@ type rowScanner interface {
 // wire-form representations so callers can unmarshal into typed structs.
 //
 // tagged reflects the Store's private behavior and decides whether the scanned
-// tag column should populate public metadata.tag. Mutable-object queries
+// tag column should populate public metadata.tag. Untagged queries
 // emit an empty synthetic value to keep the column layout uniform.
 // Tagged content queries emit a synthetic 0::bigint generation and '[]'::jsonb
 // finalizers so the column layout stays uniform across modes.

--- a/pkg/registry/v1alpha1store/migrations/011_models_table.up.sql
+++ b/pkg/registry/v1alpha1store/migrations/011_models_table.up.sql
@@ -1,5 +1,5 @@
 -- Models: admin-owned model definitions (provider-scoped identity
--- plus platform-owned auth/endpoint posture). A mutable-object kind keyed by
+-- plus platform-owned auth/endpoint posture). A untagged kind keyed by
 -- (namespace, name): auth/endpoint edits are routine config mutations, not new
 -- versions. Wires the standard updated-at, status-notify, and control-plane
 -- event triggers used by mutable resources.

--- a/pkg/registry/v1alpha1store/migrations/012_models_tagged_artifact.up.sql
+++ b/pkg/registry/v1alpha1store/migrations/012_models_tagged_artifact.up.sql
@@ -1,5 +1,5 @@
--- Convert Models from mutable namespace/name objects to tagged catalog
--- artifacts. Existing rows become the literal "latest" tag so references
+-- Convert Models from untagged namespace/name rows to tagged rows. Existing
+-- rows become the literal "latest" tag so references
 -- that omit tag preserve their pre-migration behavior.
 
 ALTER TABLE models
@@ -31,7 +31,7 @@ ALTER TABLE models
 ALTER TABLE models
     ADD PRIMARY KEY (namespace, name, tag);
 
--- Finalizers are mutable-object lifecycle state. Tagged artifacts are deleted
+-- Finalizers are untagged lifecycle state. Tagged rows are deleted
 -- by exact tag (or all tags through the batch endpoint) and do not use them.
 ALTER TABLE models
     DROP COLUMN IF EXISTS finalizers;

--- a/pkg/registry/v1alpha1store/migrations_upgrade_test.go
+++ b/pkg/registry/v1alpha1store/migrations_upgrade_test.go
@@ -34,7 +34,7 @@ func TestRemoveLocalRuntimeSeedMigrationUpgradeAndRollback(t *testing.T) {
 
 	require.NoError(t, migrator.Up())
 
-	runtimes := NewMutableObjectStore(pool, TestSchema(), "runtimes")
+	runtimes := NewUntaggedStore(pool, TestSchema(), "runtimes")
 	_, err = runtimes.GetLatest(ctx, "default", "local")
 	require.ErrorIs(t, err, pkgdb.ErrNotFound)
 
@@ -73,7 +73,7 @@ func TestRemoveKubernetesRuntimeSeedMigrationUpgradeAndRollback(t *testing.T) {
 	})
 	require.NoError(t, migrator.Migrate(13))
 
-	runtimes := NewMutableObjectStore(pool, TestSchema(), "runtimes")
+	runtimes := NewUntaggedStore(pool, TestSchema(), "runtimes")
 	_, err = runtimes.GetLatest(ctx, "default", "kubernetes-default")
 	require.NoError(t, err)
 
@@ -109,7 +109,7 @@ func TestRemoveKubernetesRuntimeSeedMigrationPreservesModifiedOrReferencedSeed(t
 		require.NoError(t, err)
 		require.NoError(t, migrator.Up())
 
-		runtimes := NewMutableObjectStore(pool, TestSchema(), "runtimes")
+		runtimes := NewUntaggedStore(pool, TestSchema(), "runtimes")
 		modified, err := runtimes.GetLatest(ctx, "default", "kubernetes-default")
 		require.NoError(t, err)
 		require.Equal(t, "value", modified.Metadata.Annotations["keep"])
@@ -137,7 +137,7 @@ func TestRemoveKubernetesRuntimeSeedMigrationPreservesModifiedOrReferencedSeed(t
 		require.NoError(t, err)
 		require.NoError(t, migrator.Up())
 
-		runtimes := NewMutableObjectStore(pool, TestSchema(), "runtimes")
+		runtimes := NewUntaggedStore(pool, TestSchema(), "runtimes")
 		_, err = runtimes.GetLatest(ctx, "default", "kubernetes-default")
 		require.NoError(t, err)
 	})
@@ -163,7 +163,7 @@ func TestRemoveLocalRuntimeSeedMigrationPreservesModifiedSeed(t *testing.T) {
 
 	require.NoError(t, migrator.Up())
 
-	runtimes := NewMutableObjectStore(pool, TestSchema(), "runtimes")
+	runtimes := NewUntaggedStore(pool, TestSchema(), "runtimes")
 	modifiedLocal, err := runtimes.GetLatest(ctx, "default", "local")
 	require.NoError(t, err)
 	require.Equal(t, "value", modifiedLocal.Metadata.Annotations["keep"])

--- a/pkg/registry/v1alpha1store/store.go
+++ b/pkg/registry/v1alpha1store/store.go
@@ -27,12 +27,12 @@ import (
 type StoreBehavior string
 
 const (
-	// TaggedArtifactStore keys immutable-ish registry artifacts by
-	// namespace/name/tag.
-	TaggedArtifactStore StoreBehavior = "TaggedArtifactStore"
-	// MutableObjectStore keys normal Kubernetes-like objects by namespace/name
-	// in the public API and storage.
-	MutableObjectStore StoreBehavior = "MutableObjectStore"
+	// TaggedStore keys rows by namespace/name/tag. Reapplying a tag may
+	// replace its row; a tag is not an immutability guarantee.
+	TaggedStore StoreBehavior = "TaggedStore"
+	// UntaggedStore keys rows by namespace/name and rejects tag-bearing
+	// references.
+	UntaggedStore StoreBehavior = "UntaggedStore"
 )
 
 // Store is the single generic persistence layer for every v1alpha1 kind.
@@ -41,25 +41,24 @@ const (
 //
 // Store has two private behaviors, picked at construction time:
 //
-//   - TaggedArtifactStore (the default; produced by NewStore).
+//   - TaggedStore (the default; produced by NewTaggedStore).
 //     Storage key is (namespace, name, tag). Users may supply the tag
 //     declaratively; missing tags are filled with the literal "latest".
 //     Re-applying the same tag replaces the prior row atomically when the
-//     content changes. Used for agents, mcp_servers, skills, and prompts.
+//     content changes. Tags provide addressability, not immutable versions.
 //
-//   - MutableObjectStore (produced by NewMutableObjectStore). Storage key is
-//     (namespace, name). Used for Runtime/Deployment and additional
-//     downstream mutable control-plane/config kinds.
+//   - UntaggedStore (produced by NewUntaggedStore). Storage key is
+//     (namespace, name). Tag-bearing references are rejected.
 //
 // PatchStatus is disjoint from Upsert: it touches only status and
 // updated_at, never spec. Reconcilers use PatchStatus exclusively; apply
 // handlers use Upsert exclusively.
 //
-// Delete hard-deletes tagged-artifact rows and mutable rows without finalizers.
-// Mutable rows with finalizers are marked terminating via deletion_timestamp;
+// Delete hard-deletes tagged rows and untagged rows without finalizers.
+// Untagged rows with finalizers are marked terminating via deletion_timestamp;
 // exact Get can still load them, while GetLatest/List hide them unless the
 // caller explicitly includes terminating rows. PurgeFinalized removes
-// terminating mutable rows after finalizers are empty.
+// terminating untagged rows after finalizers are empty.
 type Store struct {
 	pool *pgxpool.Pool
 	// table is the unqualified table name (e.g. "agents") — the identity
@@ -113,24 +112,24 @@ func WithKind(kind string) StoreOption {
 	return func(s *Store) { s.kind = kind }
 }
 
-// NewStore constructs a tagged-artifact Store bound to a single table
-// (e.g. "agents") in schema. The table must exist; NewStore does not
+// NewTaggedStore constructs a tagged Store bound to a single table
+// (e.g. "agents") in schema. The table must exist; NewTaggedStore does not
 // validate it. Queries qualify the table with schema explicitly, so the
 // Store does not depend on the connection's search_path.
 //
-// For mutable object tables, use NewMutableObjectStore.
-func NewStore(pool *pgxpool.Pool, schema pkgdb.Schema, table string, opts ...StoreOption) *Store {
-	s := &Store{pool: pool, table: table, qualified: schema.Qualify(table), behavior: TaggedArtifactStore, auditor: types.NoopAuditor}
+// For untagged resource tables, use NewUntaggedStore.
+func NewTaggedStore(pool *pgxpool.Pool, schema pkgdb.Schema, table string, opts ...StoreOption) *Store {
+	s := &Store{pool: pool, table: table, qualified: schema.Qualify(table), behavior: TaggedStore, auditor: types.NoopAuditor}
 	for _, opt := range opts {
 		opt(s)
 	}
 	return s
 }
 
-// NewMutableObjectStore constructs a mutable-object Store for tables keyed by
+// NewUntaggedStore constructs an untagged Store for tables keyed by
 // namespace/name in schema.
-func NewMutableObjectStore(pool *pgxpool.Pool, schema pkgdb.Schema, table string, opts ...StoreOption) *Store {
-	s := &Store{pool: pool, table: table, qualified: schema.Qualify(table), behavior: MutableObjectStore, auditor: types.NoopAuditor}
+func NewUntaggedStore(pool *pgxpool.Pool, schema pkgdb.Schema, table string, opts ...StoreOption) *Store {
+	s := &Store{pool: pool, table: table, qualified: schema.Qualify(table), behavior: UntaggedStore, auditor: types.NoopAuditor}
 	for _, opt := range opts {
 		opt(s)
 	}
@@ -153,7 +152,7 @@ const (
 
 // UpsertResult is the outcome of Upsert.
 type UpsertResult struct {
-	// Tag is the content tag after the call for tagged-artifact tables.
+	// Tag is the content tag after the call for tagged tables.
 	Tag string
 	// UID is the server-managed row identity after the write.
 	UID string
@@ -165,7 +164,7 @@ type UpsertResult struct {
 
 // UpsertOpts customizes create-time behavior for Store.Upsert.
 type UpsertOpts struct {
-	// InitialFinalizers is applied only on the create path for mutable-object
+	// InitialFinalizers is applied only on the create path for untagged
 	// stores. Updates preserve existing finalizers.
 	InitialFinalizers []string
 }
@@ -198,17 +197,17 @@ type ListOpts struct {
 	Limit int
 	// Cursor is an opaque pagination token. Empty starts from the beginning.
 	Cursor string
-	// Tag restricts the result set to a single tag value on tagged-artifact
+	// Tag restricts the result set to a single tag value on tagged
 	// stores. Empty means "no tag filter" — every tag of every name is
-	// returned. Ignored on mutable-object stores (they have no tag column).
+	// returned. Ignored on untagged stores (they have no tag column).
 	// Mutually exclusive with LatestOnly (validated at the caller level;
 	// the store treats LatestOnly as the literal `Tag = "latest"` filter
 	// when both are set, but new callers should pick one).
 	Tag string
 	// LatestOnly restricts to the literal "latest" tag per (namespace, name),
-	// or the private latest row for mutable-object stores. Equivalent to
+	// or the private latest row for untagged stores. Equivalent to
 	// `Tag = "latest"` on tagged stores; kept as a separate field because
-	// it also covers the mutable-object latest-row case (where there's no
+	// it also covers the untagged latest-row case (where there's no
 	// user-facing tag column).
 	LatestOnly bool
 	// IncludeTerminating includes rows with deletion_timestamp set. Default
@@ -238,9 +237,9 @@ type ListOpts struct {
 	ExtraArgs []any
 }
 
-// listCursor is the opaque pagination position for List. Tagged-artifact
+// listCursor is the opaque pagination position for List. Tagged
 // stores include Tag because their sort key is (namespace, name, tag,
-// updated_at); mutable-object stores sort by (namespace, name, updated_at).
+// updated_at); untagged stores sort by (namespace, name, updated_at).
 type listCursor struct {
 	Namespace string    `json:"namespace"`
 	Name      string    `json:"name"`
@@ -251,13 +250,13 @@ type listCursor struct {
 // Upsert applies obj into the Store. Behaviour depends on the table's
 // persistence behavior:
 //
-//   - Tagged-artifact tables (agents, mcp_servers, etc.) follow
+//   - Tagged tables (agents, mcp_servers, etc.) follow
 //     declarative tag semantics:
 //   - missing metadata.tag → default to the literal "latest" tag
 //   - new (namespace, name, tag) → insert the row
 //   - same tag and same canonical content hash → no-op
 //   - same tag and different content hash → replace the row in place
-//   - Mutable-object tables follow Kubernetes-like update-in-place
+//   - Untagged tables follow Kubernetes-like update-in-place
 //     semantics behind namespace/name key.
 //
 // Status is never touched by Upsert — use PatchStatus for that.
@@ -282,7 +281,7 @@ func (s *Store) Upsert(ctx context.Context, obj v1alpha1.Object, opts ...UpsertO
 		opt = opts[0]
 	}
 
-	if s.behavior == TaggedArtifactStore {
+	if s.behavior == TaggedStore {
 		res, err := s.upsertTagged(ctx, meta, specJSON)
 		if err != nil {
 			return res, err
@@ -296,7 +295,7 @@ func (s *Store) Upsert(ctx context.Context, obj v1alpha1.Object, opts ...UpsertO
 		}
 		return res, nil
 	}
-	return s.upsertMutable(ctx, meta, specJSON, opt)
+	return s.upsertUntagged(ctx, meta, specJSON, opt)
 }
 
 // kindFor returns the canonical Kind name to attach to audit events.
@@ -310,7 +309,7 @@ func (s *Store) kindFor(obj v1alpha1.Object) string {
 	return obj.GetKind()
 }
 
-// upsertTagged implements the tag apply semantics for tagged artifact tables.
+// upsertTagged implements the tag apply semantics for tagged resource tables.
 // See Upsert for the full state machine.
 func (s *Store) upsertTagged(ctx context.Context, meta *v1alpha1.ObjectMeta, specJSON json.RawMessage) (UpsertResult, error) {
 	if meta.Tag == "" {
@@ -411,8 +410,8 @@ func (s *Store) upsertTagged(ctx context.Context, meta *v1alpha1.ObjectMeta, spe
 	return result, nil
 }
 
-// upsertMutable implements in-place semantics for mutable-object tables.
-func (s *Store) upsertMutable(ctx context.Context, meta *v1alpha1.ObjectMeta, specJSON json.RawMessage, opts UpsertOpts) (UpsertResult, error) {
+// upsertUntagged implements in-place semantics for untagged tables.
+func (s *Store) upsertUntagged(ctx context.Context, meta *v1alpha1.ObjectMeta, specJSON json.RawMessage, opts UpsertOpts) (UpsertResult, error) {
 	labelsJSON, err := canonicalJSONMap(meta.Labels)
 	if err != nil {
 		return UpsertResult{}, fmt.Errorf("v1alpha1 store: marshal labels: %w", err)
@@ -526,23 +525,23 @@ type PatchOpts struct {
 	Finalizers  func([]string) []string
 }
 
-// ApplyPatch atomically applies PatchOpts to one row. Tagged-artifact stores
-// require tag=metadata.tag; mutable-object stores ignore tag and use
+// ApplyPatch atomically applies PatchOpts to one row. Tagged stores
+// require tag=metadata.tag; untagged stores ignore tag and use
 // namespace/name. Columns whose mutator is nil are left untouched. Returns
 // pkgdb.ErrNotFound if the row doesn't exist.
 //
 // Finalizers patching is supported only on the deployments table; the
-// tagged-artifact tables don't carry a finalizers column. Calling
-// PatchFinalizers on a tagged-artifact Store returns an error to
+// tagged tables don't carry a finalizers column. Calling
+// PatchFinalizers on a tagged Store returns an error to
 // surface the misconfiguration loudly rather than silently no-op.
 func (s *Store) ApplyPatch(ctx context.Context, namespace, name, tag string, patch PatchOpts) error {
 	if patch.Status == nil && patch.Annotations == nil && patch.Finalizers == nil {
 		return nil
 	}
-	if patch.Finalizers != nil && s.behavior == TaggedArtifactStore {
-		return errors.New("v1alpha1 store: finalizers patching not supported on tagged-artifact tables")
+	if patch.Finalizers != nil && s.behavior == TaggedStore {
+		return errors.New("v1alpha1 store: finalizers patching not supported on tagged tables")
 	}
-	if tag == "" && s.behavior == TaggedArtifactStore {
+	if tag == "" && s.behavior == TaggedStore {
 		return errors.New("v1alpha1 store: tag is required")
 	}
 	return runInTx(ctx, s.pool, func(tx pgx.Tx) error {
@@ -554,7 +553,7 @@ func (s *Store) ApplyPatch(ctx context.Context, namespace, name, tag string, pat
 		setClauses := make([]string, 0, 3)
 		args := []any{namespace, name}
 		where := "namespace=$1 AND name=$2"
-		if s.behavior == TaggedArtifactStore {
+		if s.behavior == TaggedStore {
 			args = append(args, tag)
 			where += " AND tag=$3"
 		}
@@ -608,11 +607,11 @@ func (s *Store) ApplyPatch(ctx context.Context, namespace, name, tag string, pat
 }
 
 // loadPatchRow loads the columns ApplyPatch may mutate
-// (status, annotations, and on mutable-object stores finalizers) and returns
+// (status, annotations, and on untagged stores finalizers) and returns
 // pkgdb.ErrNotFound if no row matches. The finalizers payload is empty
-// for tagged-artifact stores.
+// for tagged stores.
 func (s *Store) loadPatchRow(ctx context.Context, tx pgx.Tx, namespace, name, tag string) (statusJSON, annotationsJSON, finalizersJSON []byte, err error) {
-	if s.behavior == MutableObjectStore {
+	if s.behavior == UntaggedStore {
 		err = tx.QueryRow(ctx,
 			fmt.Sprintf(`
 				SELECT status, annotations, finalizers FROM %s
@@ -712,11 +711,11 @@ func (s *Store) PatchAnnotations(ctx context.Context, namespace, name, tag strin
 	return s.ApplyPatch(ctx, namespace, name, tag, PatchOpts{Annotations: mutate})
 }
 
-// Get returns a single row, including terminating rows. For tagged-artifact
-// stores, tag is metadata.tag. Mutable-object stores ignore tag and
+// Get returns a single row, including terminating rows. For tagged
+// stores, tag is metadata.tag. Untagged stores ignore tag and
 // load by namespace/name. Returns pkgdb.ErrNotFound if missing.
 func (s *Store) Get(ctx context.Context, namespace, name, tag string) (*v1alpha1.RawObject, error) {
-	if s.behavior == TaggedArtifactStore {
+	if s.behavior == TaggedStore {
 		if tag == "" {
 			return nil, errors.New("v1alpha1 store: tag is required")
 		}
@@ -738,26 +737,26 @@ func (s *Store) Get(ctx context.Context, namespace, name, tag string) (*v1alpha1
 }
 
 // GetByRef resolves the public reference shape shared by v1alpha1 resources.
-// Blank tag means the current live row: literal "latest" for tagged artifacts,
-// namespace/name for mutable objects. Non-empty tag selects a tagged artifact
-// row and is invalid for mutable-object stores.
+// Blank tag means the current live row: literal "latest" for tagged resources,
+// namespace/name for untagged resources. Non-empty tag selects a tagged resource
+// row and is invalid for untagged stores.
 func (s *Store) GetByRef(ctx context.Context, namespace, name, tag string) (*v1alpha1.RawObject, error) {
 	if tag == "" {
 		return s.GetLatest(ctx, namespace, name)
 	}
-	if s.behavior == MutableObjectStore {
-		return nil, errors.New("v1alpha1 store: tag pinning is not supported on mutable-object stores")
+	if s.behavior == UntaggedStore {
+		return nil, errors.New("v1alpha1 store: tag pinning is not supported on untagged stores")
 	}
 	return s.Get(ctx, namespace, name, tag)
 }
 
 // GetLatest returns the literal "latest" live tag for (namespace, name) on
-// tagged-artifact tables, or the current live row for mutable-object stores.
+// tagged tables, or the current live row for untagged stores.
 // Returns pkgdb.ErrNotFound if no live row exists.
 // Terminating rows are excluded.
 func (s *Store) GetLatest(ctx context.Context, namespace, name string) (*v1alpha1.RawObject, error) {
 	var query string
-	if s.behavior == TaggedArtifactStore {
+	if s.behavior == TaggedStore {
 		query = fmt.Sprintf(`
 			SELECT %s
 			FROM %s
@@ -782,7 +781,7 @@ func (s *Store) GetLatest(ctx context.Context, namespace, name string) (*v1alpha
 // Returns pkgdb.ErrNotFound only when no row exists at all.
 func (s *Store) GetLatestIncludingTerminating(ctx context.Context, namespace, name string) (*v1alpha1.RawObject, error) {
 	var query string
-	if s.behavior == TaggedArtifactStore {
+	if s.behavior == TaggedStore {
 		query = fmt.Sprintf(`
 			SELECT %s
 			FROM %s
@@ -798,12 +797,12 @@ func (s *Store) GetLatestIncludingTerminating(ctx context.Context, namespace, na
 	return scanRow(row, false)
 }
 
-// Delete removes a single row. Mutable-object stores may use soft-delete plus
-// finalizer drain. Tagged-artifact rows have no finalizers and are hard-deleted
+// Delete removes a single row. Untagged stores may use soft-delete plus
+// finalizer drain. Tagged rows have no finalizers and are hard-deleted
 // immediately so name/tag can be reapplied without waiting for GC. Returns
 // pkgdb.ErrNotFound if the row doesn't exist.
 func (s *Store) Delete(ctx context.Context, namespace, name, tag string) error {
-	if s.behavior == TaggedArtifactStore {
+	if s.behavior == TaggedStore {
 		if tag == "" {
 			return errors.New("v1alpha1 store: tag is required")
 		}
@@ -814,33 +813,33 @@ func (s *Store) Delete(ctx context.Context, namespace, name, tag string) error {
 }
 
 // DeleteByRef applies the public reference/delete shape shared by v1alpha1
-// resources. For tagged artifacts, blank tag deletes every tag for
+// resources. For tagged resources, blank tag deletes every tag for
 // (namespace, name), while a non-empty tag deletes that exact tag. Mutable
 // objects delete by namespace/name and reject explicit tag pins.
 func (s *Store) DeleteByRef(ctx context.Context, namespace, name, tag string) error {
-	if s.behavior == TaggedArtifactStore {
+	if s.behavior == TaggedStore {
 		if tag == "" {
 			return s.DeleteAllTags(ctx, namespace, name)
 		}
 		return s.Delete(ctx, namespace, name, tag)
 	}
 	if tag != "" {
-		return errors.New("v1alpha1 store: tag pinning is not supported on mutable-object stores")
+		return errors.New("v1alpha1 store: tag pinning is not supported on untagged stores")
 	}
 	return s.Delete(ctx, namespace, name, "")
 }
 
 // ListTags returns every non-deleted tag row for (namespace,
-// name), ordered by most recently applied first. Tagged-artifact mode
-// only — mutable-object stores do not model "list every tag of a logical
+// name), ordered by most recently applied first. Tagged mode
+// only — untagged stores do not model "list every tag of a logical
 // resource" and report an error.
 //
 // Returns an empty slice (no error) when no rows exist for the
 // tag: list semantics differ from the single-row Get path. The
 // HTTP layer surfaces empty results as 200 with `{"items": []}`.
 func (s *Store) ListTags(ctx context.Context, namespace, name string) ([]*v1alpha1.RawObject, error) {
-	if s.behavior == MutableObjectStore {
-		return nil, errors.New("v1alpha1 store: ListTags is not supported on mutable-object stores")
+	if s.behavior == UntaggedStore {
+		return nil, errors.New("v1alpha1 store: ListTags is not supported on untagged stores")
 	}
 	if namespace == "" || name == "" {
 		return nil, errors.New("v1alpha1 store: namespace and name are required")
@@ -859,7 +858,7 @@ func (s *Store) ListTags(ctx context.Context, namespace, name string) ([]*v1alph
 
 	out := make([]*v1alpha1.RawObject, 0, 4)
 	for rows.Next() {
-		obj, err := scanRow(rows, s.behavior == TaggedArtifactStore)
+		obj, err := scanRow(rows, s.behavior == TaggedStore)
 		if err != nil {
 			return nil, err
 		}
@@ -872,17 +871,17 @@ func (s *Store) ListTags(ctx context.Context, namespace, name string) ([]*v1alph
 }
 
 // DeleteAllTags hard-deletes every tag row for (namespace, name)
-// on a tagged-artifact table. This is the contract of the
+// on a tagged table. This is the contract of the
 // batch DELETE endpoint when metadata.tag is omitted; callers delete a
 // single tag by including metadata.tag. Returns pkgdb.ErrNotFound
 // when no row exists for (namespace, name).
 //
-// Calling on a mutable-object Store is a programming error; the per-kind Store
-// hands mutable objects to the single-row Delete path
+// Calling on a untagged Store is a programming error; the per-kind Store
+// hands untagged resources to the single-row Delete path
 // instead.
 func (s *Store) DeleteAllTags(ctx context.Context, namespace, name string) error {
-	if s.behavior == MutableObjectStore {
-		return errors.New("v1alpha1 store: DeleteAllTags is not supported on mutable-object stores")
+	if s.behavior == UntaggedStore {
+		return errors.New("v1alpha1 store: DeleteAllTags is not supported on untagged stores")
 	}
 	if namespace == "" || name == "" {
 		return errors.New("v1alpha1 store: namespace and name are required")
@@ -918,7 +917,7 @@ func (s *Store) deleteTagged(ctx context.Context, args []any) error {
 			return fmt.Errorf("load row: %w", err)
 		}
 
-		// Tagged-artifact tables have no finalizers — hard-delete
+		// Tagged tables have no finalizers — hard-delete
 		// immediately. This matches the OSS fast-path for finalizer-free
 		// rows: `arctl delete X` then `arctl apply X` works without any
 		// background GC.
@@ -992,12 +991,12 @@ func jsonArrayNonEmpty(raw []byte) (bool, error) {
 }
 
 // PurgeFinalized hard-deletes terminating rows. For deployments this
-// requires finalizers to be empty; for tagged-artifact tables there is
+// requires finalizers to be empty; for tagged tables there is
 // no finalizers column, so any row past deletion_timestamp is purged.
 // Returns the number of rows purged.
 func (s *Store) PurgeFinalized(ctx context.Context) (int64, error) {
 	var query string
-	if s.behavior == TaggedArtifactStore {
+	if s.behavior == TaggedStore {
 		query = fmt.Sprintf(`DELETE FROM %s WHERE deletion_timestamp IS NOT NULL`, s.qualified)
 	} else {
 		query = fmt.Sprintf(`
@@ -1030,7 +1029,7 @@ func (s *Store) List(ctx context.Context, opts ListOpts) ([]*v1alpha1.RawObject,
 		args = append(args, opts.Namespace)
 		where = append(where, fmt.Sprintf("namespace = $%d", len(args)))
 	}
-	if s.behavior == TaggedArtifactStore {
+	if s.behavior == TaggedStore {
 		// Tag wins when set; otherwise LatestOnly falls back to the literal
 		// "latest" filter for callers that pre-date the Tag field.
 		switch {
@@ -1058,7 +1057,7 @@ func (s *Store) List(ctx context.Context, opts ListOpts) ([]*v1alpha1.RawObject,
 		if err != nil {
 			return nil, "", err
 		}
-		if s.behavior == TaggedArtifactStore {
+		if s.behavior == TaggedStore {
 			// Order by stable tag before updated_at so status patches do not
 			// let a row skip across pages.
 			args = append(args, cursor.Namespace, cursor.Name, cursor.Tag, cursor.UpdatedAt)
@@ -1105,7 +1104,7 @@ func (s *Store) List(ctx context.Context, opts ListOpts) ([]*v1alpha1.RawObject,
 
 	out := make([]*v1alpha1.RawObject, 0, limit)
 	for rows.Next() {
-		obj, err := scanRow(rows, s.behavior == TaggedArtifactStore)
+		obj, err := scanRow(rows, s.behavior == TaggedStore)
 		if err != nil {
 			return nil, "", err
 		}
@@ -1174,7 +1173,7 @@ func (s *Store) decodeListCursor(token string) (listCursor, error) {
 	if cursor.UpdatedAt.IsZero() || cursor.Namespace == "" || cursor.Name == "" {
 		return listCursor{}, fmt.Errorf("%w: missing position fields", ErrInvalidCursor)
 	}
-	if s.behavior == TaggedArtifactStore && cursor.Tag == "" {
+	if s.behavior == TaggedStore && cursor.Tag == "" {
 		return listCursor{}, fmt.Errorf("%w: missing position fields", ErrInvalidCursor)
 	}
 	return cursor, nil
@@ -1189,13 +1188,13 @@ func (s *Store) encodeListCursor(obj *v1alpha1.RawObject) (string, error) {
 		Namespace: obj.Metadata.Namespace,
 		Name:      obj.Metadata.Name,
 	}
-	if s.behavior == TaggedArtifactStore {
+	if s.behavior == TaggedStore {
 		cursor.Tag = obj.Metadata.Tag
 	}
 	if cursor.UpdatedAt.IsZero() || cursor.Namespace == "" || cursor.Name == "" {
 		return "", errors.New("missing row position")
 	}
-	if s.behavior == TaggedArtifactStore && cursor.Tag == "" {
+	if s.behavior == TaggedStore && cursor.Tag == "" {
 		return "", errors.New("missing row position")
 	}
 	payload, err := json.Marshal(cursor)
@@ -1206,7 +1205,7 @@ func (s *Store) encodeListCursor(obj *v1alpha1.RawObject) (string, error) {
 }
 
 func (s *Store) listOrderBy() string {
-	if s.behavior == TaggedArtifactStore {
+	if s.behavior == TaggedStore {
 		return "namespace, name, tag, updated_at"
 	}
 	return "namespace, name, updated_at"
@@ -1217,7 +1216,7 @@ type FindReferrersOpts struct {
 	// Namespace, when non-empty, restricts results to a single namespace.
 	Namespace string
 	// LatestOnly, when true, restricts to the literal "latest" tag per
-	// (namespace, name), or the private latest row for mutable-object stores.
+	// (namespace, name), or the private latest row for untagged stores.
 	LatestOnly bool
 	// IncludeTerminating, when true, keeps rows whose deletion_timestamp
 	// is set. Default (false) excludes them.
@@ -1240,7 +1239,7 @@ func (s *Store) FindReferrers(ctx context.Context, pathJSON json.RawMessage, opt
 		query += fmt.Sprintf(" AND namespace = $%d", len(args))
 	}
 	if opts.LatestOnly {
-		if s.behavior == TaggedArtifactStore {
+		if s.behavior == TaggedStore {
 			args = append(args, DefaultTag())
 			query += fmt.Sprintf(" AND tag = $%d", len(args))
 		}
@@ -1255,7 +1254,7 @@ func (s *Store) FindReferrers(ctx context.Context, pathJSON json.RawMessage, opt
 
 	out := make([]*v1alpha1.RawObject, 0, 8)
 	for rows.Next() {
-		obj, err := scanRow(rows, s.behavior == TaggedArtifactStore)
+		obj, err := scanRow(rows, s.behavior == TaggedStore)
 		if err != nil {
 			return nil, err
 		}
@@ -1265,11 +1264,11 @@ func (s *Store) FindReferrers(ctx context.Context, pathJSON json.RawMessage, opt
 }
 
 // selectColumns returns the column list emitted by Get/List/FindReferrers
-// queries. Mutable-object tables include generation/finalizers columns;
-// tagged-artifact tables emit synthetic placeholders for them so scanRow's
+// queries. Untagged tables include generation/finalizers columns;
+// tagged tables emit synthetic placeholders for them so scanRow's
 // column layout stays uniform.
 func (s *Store) selectColumns() string {
-	if s.behavior == TaggedArtifactStore {
+	if s.behavior == TaggedStore {
 		return `namespace, name, tag, uid::text, generation, labels, annotations, spec, status,
 		       deletion_timestamp, '[]'::jsonb AS finalizers, created_at, updated_at`
 	}
@@ -1310,7 +1309,7 @@ func equalJSONMap(existing, incoming []byte) bool {
 }
 
 // equalSpecJSON reports whether two JSON byte slices represent the same
-// canonical spec content. Used by the mutable-object path to
+// canonical spec content. Used by the untagged path to
 // detect spec-no-op apply.
 func equalSpecJSON(existing []byte, incoming json.RawMessage) bool {
 	return SpecHash(existing) == SpecHash(incoming)

--- a/pkg/registry/v1alpha1store/store_tagging_test.go
+++ b/pkg/registry/v1alpha1store/store_tagging_test.go
@@ -35,7 +35,7 @@ func taggedAgentObj(name, tag, title string, labels map[string]string) *v1alpha1
 func setupAgentStore(t *testing.T) *v1alpha1store.Store {
 	t.Helper()
 	pool := v1alpha1store.NewTestPool(t)
-	return v1alpha1store.NewStore(pool, v1alpha1store.TestSchema(), "agents")
+	return v1alpha1store.NewTaggedStore(pool, v1alpha1store.TestSchema(), "agents")
 }
 
 func TestUpsert_NewName_DefaultsTagLatest(t *testing.T) {
@@ -191,7 +191,7 @@ func TestUpsert_IdempotentAcrossRestarts(t *testing.T) {
 	pool := v1alpha1store.NewTestPool(t)
 	ctx := context.Background()
 
-	s1 := v1alpha1store.NewStore(pool, v1alpha1store.TestSchema(), "agents")
+	s1 := v1alpha1store.NewTaggedStore(pool, v1alpha1store.TestSchema(), "agents")
 	res1, err := s1.Upsert(ctx, agentObj("foo", "model-a", nil))
 	require.NoError(t, err)
 	require.Equal(t, v1alpha1store.DefaultTag(), res1.Tag)
@@ -199,7 +199,7 @@ func TestUpsert_IdempotentAcrossRestarts(t *testing.T) {
 
 	// Simulate a restart: drop s1, build a fresh Store against the same
 	// underlying database. Re-applying the same spec must dedupe to no-op.
-	s2 := v1alpha1store.NewStore(pool, v1alpha1store.TestSchema(), "agents")
+	s2 := v1alpha1store.NewTaggedStore(pool, v1alpha1store.TestSchema(), "agents")
 	res2, err := s2.Upsert(ctx, agentObj("foo", "model-a", nil))
 	require.NoError(t, err)
 	require.Equal(t, res1.Tag, res2.Tag)
@@ -209,7 +209,7 @@ func TestUpsert_IdempotentAcrossRestarts(t *testing.T) {
 func setupAgentStoreWithAuditor(t *testing.T, a types.Auditor) *v1alpha1store.Store {
 	t.Helper()
 	pool := v1alpha1store.NewTestPool(t)
-	return v1alpha1store.NewStore(pool, v1alpha1store.TestSchema(), "agents",
+	return v1alpha1store.NewTaggedStore(pool, v1alpha1store.TestSchema(), "agents",
 		v1alpha1store.WithKind(v1alpha1.KindAgent),
 		v1alpha1store.WithAuditor(a),
 	)
@@ -218,7 +218,7 @@ func setupAgentStoreWithAuditor(t *testing.T, a types.Auditor) *v1alpha1store.St
 func setupProviderStoreWithAuditor(t *testing.T, a types.Auditor) *v1alpha1store.Store {
 	t.Helper()
 	pool := v1alpha1store.NewTestPool(t)
-	return v1alpha1store.NewMutableObjectStore(pool, v1alpha1store.TestSchema(), "runtimes",
+	return v1alpha1store.NewUntaggedStore(pool, v1alpha1store.TestSchema(), "runtimes",
 		v1alpha1store.WithKind(v1alpha1.KindRuntime),
 		v1alpha1store.WithAuditor(a),
 	)
@@ -261,10 +261,10 @@ func TestUpsert_AuditorCalledOnUpsertCreated(t *testing.T) {
 	require.Equal(t, "stable", auditor.Events()[1].Tag)
 }
 
-// TestUpsert_AuditorNotCalledForMutableObjectKinds verifies the
+// TestUpsert_AuditorNotCalledForUntaggedKinds verifies the
 // Runtime/Deployment upsert path does not fire ResourceTagCreated; those kinds
 // model lifecycle state and are out of scope for tag-creation audit events.
-func TestUpsert_AuditorNotCalledForMutableObjectKinds(t *testing.T) {
+func TestUpsert_AuditorNotCalledForUntaggedKinds(t *testing.T) {
 	auditor := &typestest.RecordingAuditor{}
 	store := setupProviderStoreWithAuditor(t, auditor)
 	ctx := context.Background()
@@ -275,5 +275,5 @@ func TestUpsert_AuditorNotCalledForMutableObjectKinds(t *testing.T) {
 		Spec:     v1alpha1.RuntimeSpec{Type: "Test"},
 	})
 	require.NoError(t, err)
-	require.Empty(t, auditor.Events(), "mutable-object kinds must not emit ResourceTagCreated")
+	require.Empty(t, auditor.Events(), "untagged kinds must not emit ResourceTagCreated")
 }

--- a/pkg/registry/v1alpha1store/store_test.go
+++ b/pkg/registry/v1alpha1store/store_test.go
@@ -34,7 +34,7 @@ func upsertAgent(t *testing.T, store *Store, name string, spec v1alpha1.AgentSpe
 
 func TestStore_UpsertCreatesRow(t *testing.T) {
 	pool := NewTestPool(t)
-	store := NewStore(pool, TestSchema(), testTable)
+	store := NewTaggedStore(pool, TestSchema(), testTable)
 	ctx := context.Background()
 
 	res, err := store.Upsert(ctx, &v1alpha1.Agent{
@@ -57,7 +57,7 @@ func TestStore_UpsertCreatesRow(t *testing.T) {
 // semantics: same spec_hash + same labels/annotations is a no-op.
 func TestStore_UpsertNoOpOnIdenticalSpec(t *testing.T) {
 	pool := NewTestPool(t)
-	store := NewStore(pool, TestSchema(), testTable)
+	store := NewTaggedStore(pool, TestSchema(), testTable)
 
 	upsertAgent(t, store, "foo", v1alpha1.AgentSpec{Title: "alpha"}, nil)
 	res := upsertAgent(t, store, "foo", v1alpha1.AgentSpec{Title: "alpha"}, nil)
@@ -69,7 +69,7 @@ func TestStore_UpsertNoOpOnIdenticalSpec(t *testing.T) {
 // for the same default tag atomically replaces the previous latest row.
 func TestStore_UpsertReplacesLatestOnSpecChange(t *testing.T) {
 	pool := NewTestPool(t)
-	store := NewStore(pool, TestSchema(), testTable)
+	store := NewTaggedStore(pool, TestSchema(), testTable)
 
 	upsertAgent(t, store, "foo", v1alpha1.AgentSpec{Title: "first"}, nil)
 	res := upsertAgent(t, store, "foo", v1alpha1.AgentSpec{Title: "second"}, nil)
@@ -85,7 +85,7 @@ func TestStore_UpsertReplacesLatestOnSpecChange(t *testing.T) {
 // row tagged "latest", not the newest or lexicographically highest tag.
 func TestStore_GetLatestReadsLiteralLatestTag(t *testing.T) {
 	pool := NewTestPool(t)
-	store := NewStore(pool, TestSchema(), testTable)
+	store := NewTaggedStore(pool, TestSchema(), testTable)
 
 	for _, tag := range []string{"stable", "candidate"} {
 		_, err := store.Upsert(context.Background(), &v1alpha1.Agent{
@@ -103,7 +103,7 @@ func TestStore_GetLatestReadsLiteralLatestTag(t *testing.T) {
 
 func TestStore_GetByRefResolvesBlankTagToLatest(t *testing.T) {
 	pool := NewTestPool(t)
-	store := NewStore(pool, TestSchema(), testTable)
+	store := NewTaggedStore(pool, TestSchema(), testTable)
 	ctx := context.Background()
 
 	_, err := store.Upsert(ctx, &v1alpha1.Agent{
@@ -124,7 +124,7 @@ func TestStore_GetByRefResolvesBlankTagToLatest(t *testing.T) {
 
 func TestStore_GetByRefMutableRejectsTag(t *testing.T) {
 	pool := NewTestPool(t)
-	runtimes := NewMutableObjectStore(pool, TestSchema(), "runtimes")
+	runtimes := NewUntaggedStore(pool, TestSchema(), "runtimes")
 	ctx := context.Background()
 
 	_, err := runtimes.Upsert(ctx, &v1alpha1.Runtime{
@@ -143,7 +143,7 @@ func TestStore_GetByRefMutableRejectsTag(t *testing.T) {
 
 func TestStore_DeleteByRefTaggedBlankDeletesAllTags(t *testing.T) {
 	pool := NewTestPool(t)
-	store := NewStore(pool, TestSchema(), testTable)
+	store := NewTaggedStore(pool, TestSchema(), testTable)
 	ctx := context.Background()
 
 	_, err := store.Upsert(ctx, &v1alpha1.Agent{
@@ -162,7 +162,7 @@ func TestStore_DeleteByRefTaggedBlankDeletesAllTags(t *testing.T) {
 
 func TestStore_DeleteByRefMutableDeletesByName(t *testing.T) {
 	pool := NewTestPool(t)
-	runtimes := NewMutableObjectStore(pool, TestSchema(), "runtimes")
+	runtimes := NewUntaggedStore(pool, TestSchema(), "runtimes")
 	ctx := context.Background()
 
 	_, err := runtimes.Upsert(ctx, &v1alpha1.Runtime{
@@ -181,7 +181,7 @@ func TestStore_DeleteByRefMutableDeletesByName(t *testing.T) {
 
 func TestStore_PatchStatusDisjointFromSpec(t *testing.T) {
 	pool := NewTestPool(t)
-	store := NewStore(pool, TestSchema(), testTable)
+	store := NewTaggedStore(pool, TestSchema(), testTable)
 	ctx := context.Background()
 
 	upsertAgent(t, store, "foo", v1alpha1.AgentSpec{Title: "alpha"}, nil)
@@ -204,7 +204,7 @@ func TestStore_PatchStatusDisjointFromSpec(t *testing.T) {
 
 func TestStore_PatchStatusNotFound(t *testing.T) {
 	pool := NewTestPool(t)
-	store := NewStore(pool, TestSchema(), testTable)
+	store := NewTaggedStore(pool, TestSchema(), testTable)
 	ctx := context.Background()
 
 	err := store.PatchStatus(ctx, testNS, "nope", "1", v1alpha1.StatusPatcher(func(*v1alpha1.Status) {}))
@@ -217,7 +217,7 @@ func TestStore_PatchStatusNotFound(t *testing.T) {
 // would churn updated_at and WAL with no content change.
 func TestStore_ApplyPatchSkipsUnchangedWrites(t *testing.T) {
 	pool := NewTestPool(t)
-	store := NewStore(pool, TestSchema(), testTable)
+	store := NewTaggedStore(pool, TestSchema(), testTable)
 	ctx := context.Background()
 
 	upsertAgent(t, store, "steady", v1alpha1.AgentSpec{Title: "alpha"}, nil)
@@ -247,7 +247,7 @@ func TestStore_ApplyPatchSkipsUnchangedWrites(t *testing.T) {
 
 func TestStore_GetNotFound(t *testing.T) {
 	pool := NewTestPool(t)
-	store := NewStore(pool, TestSchema(), testTable)
+	store := NewTaggedStore(pool, TestSchema(), testTable)
 	ctx := context.Background()
 
 	_, err := store.Get(ctx, testNS, "nope", "1")
@@ -257,13 +257,13 @@ func TestStore_GetNotFound(t *testing.T) {
 	require.True(t, errors.Is(err, pkgdb.ErrNotFound))
 }
 
-// TestStore_DeleteHardDeletesTaggedRow guards the tagged-artifact fast path:
+// TestStore_DeleteHardDeletesTaggedRow guards the tagged fast path:
 // rows have no finalizers and Delete
 // hard-deletes immediately. arctl delete + arctl apply works without any
 // background GC pass.
 func TestStore_DeleteHardDeletesTaggedRow(t *testing.T) {
 	pool := NewTestPool(t)
-	store := NewStore(pool, TestSchema(), testTable)
+	store := NewTaggedStore(pool, TestSchema(), testTable)
 	ctx := context.Background()
 
 	_, err := store.Upsert(ctx, &v1alpha1.Agent{
@@ -299,7 +299,7 @@ func TestStore_DeleteHardDeletesTaggedRow(t *testing.T) {
 
 func TestStore_List(t *testing.T) {
 	pool := NewTestPool(t)
-	store := NewStore(pool, TestSchema(), testTable)
+	store := NewTaggedStore(pool, TestSchema(), testTable)
 	ctx := context.Background()
 
 	_, err := store.Upsert(ctx, &v1alpha1.Agent{
@@ -343,7 +343,7 @@ func TestStore_List(t *testing.T) {
 
 func TestStore_ListExtraWhereRebasesPlaceholders(t *testing.T) {
 	pool := NewTestPool(t)
-	store := NewStore(pool, TestSchema(), testTable)
+	store := NewTaggedStore(pool, TestSchema(), testTable)
 	ctx := context.Background()
 
 	for _, name := range []string{"a", "b", "c"} {
@@ -385,7 +385,7 @@ func TestStore_ListExtraWhereRebasesPlaceholders(t *testing.T) {
 // wrong query.
 func TestStore_ListExtraWhereRejectsMismatch(t *testing.T) {
 	pool := NewTestPool(t)
-	store := NewStore(pool, TestSchema(), testTable)
+	store := NewTaggedStore(pool, TestSchema(), testTable)
 	ctx := context.Background()
 
 	cases := []struct {
@@ -419,7 +419,7 @@ func TestStore_ListExtraWhereRejectsMismatch(t *testing.T) {
 
 func TestStore_ListCursorPagination(t *testing.T) {
 	pool := NewTestPool(t)
-	store := NewStore(pool, TestSchema(), testTable)
+	store := NewTaggedStore(pool, TestSchema(), testTable)
 	ctx := context.Background()
 
 	for _, name := range []string{"first", "second", "third"} {
@@ -446,7 +446,7 @@ func TestStore_ListCursorPagination(t *testing.T) {
 
 func TestStore_ListRejectsInvalidCursor(t *testing.T) {
 	pool := NewTestPool(t)
-	store := NewStore(pool, TestSchema(), testTable)
+	store := NewTaggedStore(pool, TestSchema(), testTable)
 
 	_, _, err := store.List(context.Background(), ListOpts{Cursor: "not-a-valid-cursor"})
 	require.ErrorIs(t, err, ErrInvalidCursor)
@@ -458,7 +458,7 @@ func TestStore_ListRejectsInvalidCursor(t *testing.T) {
 // concurrent PatchStatus must not jump pages or get returned twice.
 func TestStore_ListCursorStableUnderStatusChurn(t *testing.T) {
 	pool := NewTestPool(t)
-	store := NewStore(pool, TestSchema(), testTable)
+	store := NewTaggedStore(pool, TestSchema(), testTable)
 	ctx := context.Background()
 
 	names := []string{"alpha", "beta", "gamma", "delta"} // lexical order: alpha, beta, delta, gamma
@@ -494,7 +494,7 @@ func TestStore_ListCursorStableUnderStatusChurn(t *testing.T) {
 
 func TestStore_PatchAnnotationsPreservesExistingKeys(t *testing.T) {
 	pool := NewTestPool(t)
-	store := NewStore(pool, TestSchema(), testTable)
+	store := NewTaggedStore(pool, TestSchema(), testTable)
 	ctx := context.Background()
 
 	_, err := store.Upsert(ctx, &v1alpha1.Agent{
@@ -519,7 +519,7 @@ func TestStore_PatchAnnotationsPreservesExistingKeys(t *testing.T) {
 
 func TestStore_FindReferrers(t *testing.T) {
 	pool := NewTestPool(t)
-	agents := NewStore(pool, TestSchema(), "agents")
+	agents := NewTaggedStore(pool, TestSchema(), "agents")
 	ctx := context.Background()
 
 	_, err := agents.Upsert(ctx, &v1alpha1.Agent{
@@ -551,8 +551,8 @@ func TestStore_FindReferrers(t *testing.T) {
 
 func TestStore_NoSeededRuntimes(t *testing.T) {
 	pool := NewTestPool(t)
-	// Runtime is a mutable object keyed by namespace/name.
-	runtimes := NewMutableObjectStore(pool, TestSchema(), "runtimes")
+	// Runtime is a untagged resource keyed by namespace/name.
+	runtimes := NewUntaggedStore(pool, TestSchema(), "runtimes")
 	ctx := context.Background()
 
 	_, err := runtimes.GetLatest(ctx, "default", "kubernetes-default")
@@ -567,7 +567,7 @@ func TestStore_NoSeededRuntimes(t *testing.T) {
 // discrete JSON fields instead of a concatenated "ns/name/tag" string.
 func TestStore_NotifyPayloadDiscreteFields(t *testing.T) {
 	pool := NewTestPool(t)
-	store := NewStore(pool, TestSchema(), testTable)
+	store := NewTaggedStore(pool, TestSchema(), testTable)
 	ctx := context.Background()
 
 	conn, err := pool.Acquire(ctx)
@@ -607,7 +607,7 @@ func TestStore_NotifyPayloadDiscreteFields(t *testing.T) {
 
 func TestStore_ControlPlaneEventsTrackSourceWritesOnly(t *testing.T) {
 	pool := NewTestPool(t)
-	store := NewStore(pool, TestSchema(), testTable)
+	store := NewTaggedStore(pool, TestSchema(), testTable)
 	events := NewControlPlaneEventStore(pool, TestSchema())
 	ctx := context.Background()
 
@@ -671,7 +671,7 @@ func TestStore_ControlPlaneEventTracksResolvedSourceStatusChanges(t *testing.T) 
 			name:    "plugin",
 			kind:    v1alpha1.KindPlugin,
 			rowName: "plugin",
-			store:   NewStore(pool, TestSchema(), "plugins"),
+			store:   NewTaggedStore(pool, TestSchema(), "plugins"),
 			upsert: func(t *testing.T, store *Store) {
 				t.Helper()
 				_, err := store.Upsert(ctx, &v1alpha1.Plugin{
@@ -719,7 +719,7 @@ func TestStore_ControlPlaneEventTracksResolvedSourceStatusChanges(t *testing.T) 
 			name:    "skill",
 			kind:    v1alpha1.KindSkill,
 			rowName: "skill",
-			store:   NewStore(pool, TestSchema(), "skills"),
+			store:   NewTaggedStore(pool, TestSchema(), "skills"),
 			upsert: func(t *testing.T, store *Store) {
 				t.Helper()
 				_, err := store.Upsert(ctx, &v1alpha1.Skill{
@@ -800,7 +800,7 @@ func TestStore_ControlPlaneEventTracksResolvedSourceStatusChanges(t *testing.T) 
 
 func TestControlPlaneEventStore_PruneBeforeHonorsKeepAfterRevision(t *testing.T) {
 	pool := NewTestPool(t)
-	store := NewStore(pool, TestSchema(), testTable)
+	store := NewTaggedStore(pool, TestSchema(), testTable)
 	events := NewControlPlaneEventStore(pool, TestSchema())
 	ctx := context.Background()
 
@@ -828,11 +828,11 @@ func TestControlPlaneEventStore_PruneBeforeHonorsKeepAfterRevision(t *testing.T)
 	require.Equal(t, keep, remaining[0].Revision)
 }
 
-// TestStore_ModelTaggedArtifactCRUD covers Model's tagged storage: distinct
+// TestStore_ModelTaggedCRUD covers Model's tagged storage: distinct
 // configuration tags coexist and each write records a control-plane event.
-func TestStore_ModelTaggedArtifactCRUD(t *testing.T) {
+func TestStore_ModelTaggedCRUD(t *testing.T) {
 	pool := NewTestPool(t)
-	models := NewStore(pool, TestSchema(), "models")
+	models := NewTaggedStore(pool, TestSchema(), "models")
 	events := NewControlPlaneEventStore(pool, TestSchema())
 	ctx := context.Background()
 

--- a/pkg/registry/v1alpha1store/tables.go
+++ b/pkg/registry/v1alpha1store/tables.go
@@ -28,9 +28,9 @@ var builtInKinds = map[string]struct{}{
 // "MCPServer") and is the single input the router/apply layers take. They
 // never look up tables by string literal themselves.
 //
-// Kinds whose descriptors use KindStorageMutableObject are bound through
-// NewMutableObjectStore. Every other built-in kind uses NewStore
-// (tagged-artifact behavior). Extension kinds are intentionally not built here;
+// Kinds whose descriptors use KindStorageUntagged are bound through
+// NewUntaggedStore. Every other built-in kind uses NewTaggedStore.
+// Extension kinds are intentionally not built here;
 // the composition root wires them from V1Alpha1StoreTables after this function
 // returns.
 //
@@ -58,11 +58,11 @@ func NewStores(pool *pgxpool.Pool, schemas *pkgdb.SchemaRegistry, opts ...StoreO
 		// Caller-supplied opts win (they appear after WithKind in the
 		// option chain).
 		kindOpts := append([]StoreOption{WithKind(kind)}, opts...)
-		if descriptor.Storage == v1alpha1.KindStorageMutableObject {
-			out[kind] = NewMutableObjectStore(pool, ossSchema, table, kindOpts...)
+		if descriptor.Storage == v1alpha1.KindStorageUntagged {
+			out[kind] = NewUntaggedStore(pool, ossSchema, table, kindOpts...)
 			continue
 		}
-		out[kind] = NewStore(pool, ossSchema, table, kindOpts...)
+		out[kind] = NewTaggedStore(pool, ossSchema, table, kindOpts...)
 	}
 	for kind := range builtInKinds {
 		if _, ok := out[kind]; !ok {

--- a/pkg/registry/v1alpha1store/tables_test.go
+++ b/pkg/registry/v1alpha1store/tables_test.go
@@ -70,9 +70,9 @@ func TestNewStoresDerivesBuiltInTablesFromKindDescriptors(t *testing.T) {
 		if got, want := store.kind, kind; got != want {
 			t.Fatalf("%s store kind = %q, want %q", kind, got, want)
 		}
-		wantBehavior := TaggedArtifactStore
-		if descriptor.Storage == v1alpha1.KindStorageMutableObject {
-			wantBehavior = MutableObjectStore
+		wantBehavior := TaggedStore
+		if descriptor.Storage == v1alpha1.KindStorageUntagged {
+			wantBehavior = UntaggedStore
 		}
 		if got := store.Behavior(); got != wantBehavior {
 			t.Fatalf("%s store behavior = %q, want %q", kind, got, wantBehavior)

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -156,7 +156,7 @@ type ResourceRouteContext struct {
 
 // Auditor receives audit events for state changes that the OSS layer
 // considers significant. The default OSS implementation is a no-op;
-// downstream builds plug in a real audit sink via NewStore options.
+// downstream builds plug in a real audit sink via Store options.
 //
 // Audit completeness is enforced at the source: every code path that
 // produces a recordable state change calls into Auditor directly,
@@ -164,7 +164,7 @@ type ResourceRouteContext struct {
 // to log.
 type Auditor interface {
 	// ResourceTagCreated is invoked when Store.Upsert creates a new tag row
-	// for a content-registry kind. Mutable-object kinds do not produce this
+	// for a content-registry kind. Untagged kinds do not produce this
 	// event.
 	ResourceTagCreated(ctx context.Context, kind, namespace, name, tag string)
 }
@@ -304,11 +304,9 @@ type AppOptions struct {
 	// or server startup panics.
 	V1Alpha1StoreTables map[string]string
 
-	// V1Alpha1MutableStoreKinds marks extra v1alpha1 kinds that use mutable
-	// namespace/name object behavior instead of tagged artifact semantics.
-	// Downstream control-plane/config kinds are v1alpha1-shaped but are not
-	// content artifacts.
-	V1Alpha1MutableStoreKinds map[string]bool
+	// V1Alpha1UntaggedStoreKinds marks extra kinds whose identity omits
+	// metadata.tag. Their storage key is namespace/name.
+	V1Alpha1UntaggedStoreKinds map[string]bool
 
 	// RegistryValidator overrides the per-package registry
 	// validator (the dispatcher consulted on apply to confirm

--- a/test/e2e/declarative_test.go
+++ b/test/e2e/declarative_test.go
@@ -1800,9 +1800,9 @@ spec:
 	}
 }
 
-// TestSkill_DeleteTaggedArtifactKeepsLatest asserts that deleting an explicit
+// TestSkill_DeleteTaggedKeepsLatest asserts that deleting an explicit
 // non-latest tag does not disturb the literal latest tag.
-func TestSkill_DeleteTaggedArtifactKeepsLatest(t *testing.T) {
+func TestSkill_DeleteTaggedKeepsLatest(t *testing.T) {
 	regURL := RegistryURL(t)
 	tmpDir := t.TempDir()
 	skillName := UniqueNameWithPrefix("e2epromoteskill")

--- a/ui/lib/api/types.gen.ts
+++ b/ui/lib/api/types.gen.ts
@@ -952,7 +952,7 @@ export type ListAgentsData = {
          */
         labels?: string;
         /**
-         * Restrict the result set to one tag value (tagged artifact kinds only).
+         * Restrict the result set to one tag value (tagged resource kinds only).
          */
         tag?: string;
         /**
@@ -1196,7 +1196,7 @@ export type ListDeploymentsData = {
          */
         labels?: string;
         /**
-         * Restrict the result set to one tag value (tagged artifact kinds only).
+         * Restrict the result set to one tag value (tagged resource kinds only).
          */
         tag?: string;
         /**
@@ -1375,7 +1375,7 @@ export type ListMcpserversData = {
          */
         labels?: string;
         /**
-         * Restrict the result set to one tag value (tagged artifact kinds only).
+         * Restrict the result set to one tag value (tagged resource kinds only).
          */
         tag?: string;
         /**
@@ -1559,7 +1559,7 @@ export type ListModelsData = {
          */
         labels?: string;
         /**
-         * Restrict the result set to one tag value (tagged artifact kinds only).
+         * Restrict the result set to one tag value (tagged resource kinds only).
          */
         tag?: string;
         /**
@@ -1768,7 +1768,7 @@ export type ListPluginsData = {
          */
         labels?: string;
         /**
-         * Restrict the result set to one tag value (tagged artifact kinds only).
+         * Restrict the result set to one tag value (tagged resource kinds only).
          */
         tag?: string;
         /**
@@ -1952,7 +1952,7 @@ export type ListPromptsData = {
          */
         labels?: string;
         /**
-         * Restrict the result set to one tag value (tagged artifact kinds only).
+         * Restrict the result set to one tag value (tagged resource kinds only).
          */
         tag?: string;
         /**
@@ -2136,7 +2136,7 @@ export type ListRuntimesData = {
          */
         labels?: string;
         /**
-         * Restrict the result set to one tag value (tagged artifact kinds only).
+         * Restrict the result set to one tag value (tagged resource kinds only).
          */
         tag?: string;
         /**
@@ -2286,7 +2286,7 @@ export type ListSkillsData = {
          */
         labels?: string;
         /**
-         * Restrict the result set to one tag value (tagged artifact kinds only).
+         * Restrict the result set to one tag value (tagged resource kinds only).
          */
         tag?: string;
         /**


### PR DESCRIPTION
# Description

Rename the v1alpha1 storage classification from "tagged artifact" and
"mutable object" to "tagged" and "untagged". The old pairing implied that
tags provided an immutability guarantee, but applying changed content to an
existing tag replaces that row.

This is a terminology cleanup only. Tagged storage remains keyed by
namespace/name/tag, while untagged storage remains keyed by namespace/name.

# Change Type

/kind cleanup

# Changelog

```release-note
NONE
```

# Additional Notes

There are no database migrations, HTTP API changes, manifest changes, or
persistence behavior changes. Exported Go identifiers are renamed without
compatibility aliases, so embedders should update those call sites with the
dependency bump.

Focused tests passed for the v1alpha1 API, store, resource handlers, CLI,
client, and API routing packages. OpenAPI and the generated TypeScript client
were regenerated.
