### PR TITLE
fix(gitutil): accept plain clone URLs on any git host

### DIFF
--- a/internal/cli/common/gitutil/gitutil.go
+++ b/internal/cli/common/gitutil/gitutil.go
@@ -16,9 +16,11 @@ import (
 )
 
 var (
-	// ErrUnsupportedHost is returned for a non-GitHub/non-GitLab host. It is a
-	// permanent condition: callers can errors.Is it to avoid retrying hosts that
-	// are not supported.
+	// ErrUnsupportedHost is returned for a web URL on a host whose layout is not
+	// understood — every host but github.com and GitLab. Such a host is still
+	// usable through its plain clone URL (see ParseGitURL). It is a permanent
+	// condition: callers can errors.Is it to avoid retrying a URL that cannot
+	// be parsed.
 	ErrUnsupportedHost = errors.New("unsupported git host")
 	// ErrRefNotFound is returned when a ref resolves to no commit on the remote
 	// (deleted branch/tag, typo, or a short/non-existent SHA). Terminal:
@@ -32,6 +34,13 @@ var (
 // Branch names containing slashes (e.g. feature/my-branch) are supported when
 // encoded as %2F in the URL. The raw (escaped) path is used for splitting so
 // the encoded branch segment is preserved, then unescaped for the return value.
+//
+// Any other host — Bitbucket Server, Gitea, GitHub Enterprise on a company
+// domain — is accepted through its plain clone URL, the path ending in ".git".
+// There is no web-URL layout to infer a branch or subdirectory from in that
+// case, so both come back empty and the caller supplies them explicitly
+// (Repository.Branch and Repository.Subfolder). A non-clone URL on such a host
+// returns ErrUnsupportedHost.
 func ParseGitURL(rawURL string) (cloneURL, branch, subPath string, err error) {
 	u, err := url.Parse(rawURL)
 	if err != nil {
@@ -60,13 +69,19 @@ func ParseGitURL(rawURL string) (cloneURL, branch, subPath string, err error) {
 		return parseGitLabStyleURL(u, parts, gitLabMarker)
 	}
 	if strings.Contains(strings.ToLower(u.Host), "gitlab") {
-		return parseGitLabRootURL(u, parts)
+		return parseRepoRootURL(u, parts)
 	}
-	if u.Host != "github.com" {
-		return "", "", "", fmt.Errorf("%w: %q", ErrUnsupportedHost, u.Host)
+	if u.Host == "github.com" {
+		return parseGitHubStyleURL(u, parts)
+	}
+	// Unknown host: accept it only as a plain clone URL, which is unambiguous
+	// on every git server. Guessing a web layout instead would silently
+	// mis-parse namespaces (Bitbucket Server's /scm/ prefix, Gitea's /raw/).
+	if strings.HasSuffix(parts[len(parts)-1], ".git") {
+		return parseRepoRootURL(u, parts)
 	}
 
-	return parseGitHubStyleURL(u, parts)
+	return "", "", "", fmt.Errorf("%w: %q (pass the repository clone URL, ending in .git)", ErrUnsupportedHost, u.Host)
 }
 
 func parseGitHubStyleURL(u *url.URL, parts []string) (cloneURL, branch, subPath string, err error) {
@@ -88,7 +103,10 @@ func parseGitHubStyleURL(u *url.URL, parts []string) (cloneURL, branch, subPath 
 	return cloneURL, branch, subPath, nil
 }
 
-func parseGitLabRootURL(u *url.URL, parts []string) (cloneURL, branch, subPath string, err error) {
+// parseRepoRootURL treats the whole path as the repository, so it carries no
+// branch or subdirectory. It is host-agnostic: a GitLab project root and a
+// plain clone URL on any other host reduce to the same shape.
+func parseRepoRootURL(u *url.URL, parts []string) (cloneURL, branch, subPath string, err error) {
 	repoParts := append([]string(nil), parts...)
 	repoParts[len(repoParts)-1] = strings.TrimSuffix(repoParts[len(repoParts)-1], ".git")
 	cloneURL = fmt.Sprintf("%s://%s/%s.git", u.Scheme, u.Host, strings.Join(repoParts, "/"))

--- a/internal/cli/common/gitutil/gitutil_test.go
+++ b/internal/cli/common/gitutil/gitutil_test.go
@@ -218,9 +218,12 @@ func TestParseGitURL(t *testing.T) {
 // it: the Skill controller and the plugin source treat ErrUnsupportedHost as
 // terminal and stop retrying.
 func TestParseGitURLUnsupportedHost(t *testing.T) {
-	_, _, _, err := ParseGitURL("https://bitbucket.example.com/projects/PROJ/repos/repo/browse")
+	gotURL, gotRef, gotPath, err := ParseGitURL("https://bitbucket.example.com/projects/PROJ/repos/repo/browse")
 	if !errors.Is(err, ErrUnsupportedHost) {
 		t.Fatalf("error = %v, want ErrUnsupportedHost", err)
+	}
+	if gotURL != "" || gotRef != "" || gotPath != "" {
+		t.Errorf("got (%q, %q, %q), want zero values on error", gotURL, gotRef, gotPath)
 	}
 }
 

--- a/internal/cli/common/gitutil/gitutil_test.go
+++ b/internal/cli/common/gitutil/gitutil_test.go
@@ -1,6 +1,7 @@
 package gitutil
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -135,6 +136,41 @@ func TestParseGitURL(t *testing.T) {
 			wantPath: "cursor/skill",
 		},
 		{
+			name:    "bitbucket server clone URL",
+			rawURL:  "https://bitbucket.example.com/scm/proj/repo.git",
+			wantURL: "https://bitbucket.example.com/scm/proj/repo.git",
+		},
+		{
+			name:    "bitbucket server clone URL with trailing slash",
+			rawURL:  "https://bitbucket.example.com/scm/proj/repo.git/",
+			wantURL: "https://bitbucket.example.com/scm/proj/repo.git",
+		},
+		{
+			name:    "bitbucket cloud clone URL",
+			rawURL:  "https://bitbucket.org/workspace/repo.git",
+			wantURL: "https://bitbucket.org/workspace/repo.git",
+		},
+		{
+			name:    "gitea clone URL",
+			rawURL:  "https://git.example.com/org/repo.git",
+			wantURL: "https://git.example.com/org/repo.git",
+		},
+		{
+			name:    "github enterprise clone URL on company domain",
+			rawURL:  "https://github.corp.example.com/org/repo.git",
+			wantURL: "https://github.corp.example.com/org/repo.git",
+		},
+		{
+			name:    "bitbucket server web URL is not a clone URL",
+			rawURL:  "https://bitbucket.example.com/projects/PROJ/repos/repo/browse",
+			wantErr: true,
+		},
+		{
+			name:    "unknown host repo root without .git",
+			rawURL:  "https://git.example.com/org/repo",
+			wantErr: true,
+		},
+		{
 			name:    "missing repo in path",
 			rawURL:  "https://github.com/owner",
 			wantErr: true,
@@ -175,6 +211,16 @@ func TestParseGitURL(t *testing.T) {
 				t.Errorf("subPath = %q, want %q", gotPath, tt.wantPath)
 			}
 		})
+	}
+}
+
+// TestParseGitURLUnsupportedHost pins the sentinel, since callers classify on
+// it: the Skill controller and the plugin source treat ErrUnsupportedHost as
+// terminal and stop retrying.
+func TestParseGitURLUnsupportedHost(t *testing.T) {
+	_, _, _, err := ParseGitURL("https://bitbucket.example.com/projects/PROJ/repos/repo/browse")
+	if !errors.Is(err, ErrUnsupportedHost) {
+		t.Fatalf("error = %v, want ErrUnsupportedHost", err)
 	}
 }
 


### PR DESCRIPTION
# Description

**Motivation:** `gitutil.ParseGitURL` gates on a host allowlist — `github.com` exactly, or any host containing the substring `gitlab` — so Bitbucket Server / Data Center, Gitea, and GitHub Enterprise on a company domain are rejected with `ErrUnsupportedHost`. `ssh://` is rejected by the scheme check as well, so an organisation whose only git hosting is Bitbucket has no way to publish a skill at all. The same parser backs the server-side controllers, so the resource never leaves `Ready=False` / `SourceUnsupported`.

**What changed:** the allowlist only ever selected a *path shape*. The GitHub and GitLab parsers exist to infer a branch and subdirectory from a web URL's layout; a plain clone URL has no layout to infer, and `Repository` already carries `Branch`, `Commit` and `Subfolder` explicitly. So an unknown host needs no parser of its own — only its clone URL:

- a path whose last segment ends in `.git` is accepted on **any** host and reduced to the repository root
- the GitHub and GitLab parsers are untouched, so pasted browser URLs keep working
- a non-clone URL on an unknown host still returns `ErrUnsupportedHost`, now with a message pointing at the clone URL
- `parseGitLabRootURL` → `parseRepoRootURL`: a GitLab project root and a plain clone URL reduce to the same shape, so the two paths share one host-agnostic helper

Worth noting for reviewers: the allowlist was already bypassable, which is part of why it looks non-load-bearing. The GitLab `/-/` marker branch runs *before* the host check, so `https://bitbucket.example.com/scm/proj/repo.git/-/tree/master/skills/my-skill` parses today and yields a correct Bitbucket clone URL. That undocumented parse-order detail is the only workaround available on v0.4.0. This PR makes the supported spelling — the plain clone URL — work instead.

**Related issues:** Fixes #631

# Change Type

/kind fix

# Changelog

```release-note
Git sources on hosts other than GitHub and GitLab (Bitbucket Server, Bitbucket Cloud, Gitea, GitHub Enterprise on a company domain) are now accepted when the URL is the repository clone URL ending in `.git`; branch and subfolder come from the explicit `Repository` fields.
```

# Additional Notes

**Verified end to end against a real Bitbucket Server instance.** Same registry, same `Skill`, `url: https://<host>/scm/<proj>/<repo>.git` with `branch: master` and `subfolder: skills/vm-to-pod`:

```
--- released arctl v0.4.0 ---
Cloning https://<host>/scm/<proj>/<repo>.git (branch master) into /tmp/p_old
Error: parse Git URL: unsupported git host: "<host>"

--- this branch ---
(subfolder hint: skills/vm-to-pod)
Pulled fixtest
SKILL.md  assets  references  skill.yaml
```

**Tests:** eight cases added to the `TestParseGitURL` table — Bitbucket Server (with and without a trailing slash), Bitbucket Cloud, Gitea, GitHub Enterprise on a company domain, plus two rejections (a Bitbucket Server `/projects/…/browse` web URL and an unknown-host repo root without `.git`). `TestParseGitURLUnsupportedHost` pins the sentinel, because `skill_controller.go` and `plugins/source` classify on `errors.Is(err, ErrUnsupportedHost)` to decide the failure is terminal.

**Not addressed here:** #627 (the server image ships no `git` binary) blocks `Ready=True` for every git-backed resource regardless of host, so a Bitbucket source still will not reconcile server-side until that is fixed. Client-side `arctl pull` is unaffected and works with this change.

**Scope choice:** I kept `Repository.provider` out of it. The `.git` suffix is a sufficient and unambiguous signal on every git server, and adding an API field would be a larger surface change than the bug needs. Happy to add it if you would rather have the explicit hint.
