### PR TITLE
runtime: decouple deployment discovery sources

### DIFF
--- a/internal/registry/controller/discovery.go
+++ b/internal/registry/controller/discovery.go
@@ -34,12 +34,12 @@ const (
 	defaultDeploymentDiscoveryDeleteAfterMisses = 5
 )
 
-// DeploymentDiscoveryController materializes adapter discovery snapshots into
+// DeploymentDiscoveryController materializes provider discovery snapshots into
 // persisted Deployment rows. It owns provider-observed state; the normal
 // DeploymentController skips these rows so they do not become desired state.
 type DeploymentDiscoveryController struct {
 	Stores            map[string]*v1alpha1store.Store
-	Adapters          map[string]types.DeploymentAdapter
+	Sources           map[string]types.DeploymentDiscoverySource
 	StaleAfterMisses  int
 	DeleteAfterMisses int
 }
@@ -106,12 +106,8 @@ func (c *DeploymentDiscoveryController) Sync(ctx context.Context) (DeploymentDis
 			continue
 		}
 		knownRuntimes[runtimeDiscoveryKey(runtime.Metadata.NamespaceOrDefault(), runtime.Metadata.Name)] = struct{}{}
-		adapter := c.Adapters[strings.TrimSpace(runtime.Spec.Type)]
-		if adapter == nil {
-			continue
-		}
-		source, ok := adapter.(types.DeploymentDiscoverySource)
-		if !ok {
+		source := c.Sources[strings.TrimSpace(runtime.Spec.Type)]
+		if source == nil {
 			continue
 		}
 		discovered, err := source.Discover(ctx, types.DiscoverInput{Runtime: runtime})
@@ -198,9 +194,11 @@ func (c *DeploymentDiscoveryController) Sync(ctx context.Context) (DeploymentDis
 }
 
 type deploymentDiscoveryIndex struct {
-	discovered     map[string]*v1alpha1.Deployment
-	managedNames   map[string]struct{}
-	managedTargets map[string]struct{}
+	discovered          map[string]*v1alpha1.Deployment
+	discoveredRemoteIDs map[string]*v1alpha1.Deployment
+	managedNames        map[string]struct{}
+	managedTargets      map[string]struct{}
+	managedRemoteIDs    map[string]struct{}
 }
 
 func (c *DeploymentDiscoveryController) listRuntimes(ctx context.Context) ([]*v1alpha1.Runtime, error) {
@@ -237,9 +235,11 @@ func (c *DeploymentDiscoveryController) loadDiscoveryIndex(ctx context.Context) 
 		return deploymentDiscoveryIndex{}, fmt.Errorf("deployment discovery controller: no Deployment store registered")
 	}
 	index := deploymentDiscoveryIndex{
-		discovered:     map[string]*v1alpha1.Deployment{},
-		managedNames:   map[string]struct{}{},
-		managedTargets: map[string]struct{}{},
+		discovered:          map[string]*v1alpha1.Deployment{},
+		discoveredRemoteIDs: map[string]*v1alpha1.Deployment{},
+		managedNames:        map[string]struct{}{},
+		managedTargets:      map[string]struct{}{},
+		managedRemoteIDs:    map[string]struct{}{},
 	}
 	opts := v1alpha1store.ListOpts{Limit: defaultControllerListPageSize}
 	for {
@@ -257,6 +257,9 @@ func (c *DeploymentDiscoveryController) loadDiscoveryIndex(ctx context.Context) 
 			key := deploymentKey(deployment.Metadata.NamespaceOrDefault(), deployment.Metadata.Name)
 			if v1alpha1.IsDiscoveredDeployment(deployment) {
 				index.discovered[key] = deployment
+				if remoteID := deploymentDiscoveryRemoteID(deployment); remoteID != "" {
+					index.discoveredRemoteIDs[deploymentRemoteIDKey(deployment, remoteID)] = deployment
+				}
 				continue
 			}
 			index.managedNames[key] = struct{}{}
@@ -267,6 +270,9 @@ func (c *DeploymentDiscoveryController) loadDiscoveryIndex(ctx context.Context) 
 					deployment.Spec.TargetRef.Kind,
 					targetName,
 				)] = struct{}{}
+			}
+			if remoteID := deploymentDiscoveryRemoteID(deployment); remoteID != "" {
+				index.managedRemoteIDs[deploymentRemoteIDKey(deployment, remoteID)] = struct{}{}
 			}
 		}
 		if cursor == "" {
@@ -307,8 +313,18 @@ func discoveredDeploymentFromResult(
 	if _, ok := index.managedTargets[managedDeploymentTargetKey(ns, runtimeName, targetKind, targetName)]; ok {
 		return nil, false
 	}
+	remoteID := strings.TrimSpace(result.RuntimeMetadata[types.RuntimeMetadataRemoteIDKey])
+	remoteKey := discoveryRemoteIDKey(ns, runtimeName, targetKind, remoteID)
+	if remoteID != "" {
+		if _, ok := index.managedRemoteIDs[remoteKey]; ok {
+			return nil, false
+		}
+	}
 
 	name := discoveredDeploymentName(runtimeName, targetKind, targetName, tag, ns)
+	if existing := index.discoveredRemoteIDs[remoteKey]; remoteID != "" && existing != nil {
+		name = existing.Metadata.Name
+	}
 	if _, ok := index.managedNames[deploymentKey(ns, name)]; ok {
 		return nil, false
 	}
@@ -342,6 +358,55 @@ func discoveredDeploymentFromResult(
 			DesiredState: v1alpha1.DesiredStateDeployed,
 		},
 	}, true
+}
+
+// deploymentDiscoveryRemoteID reads the provider identity from the storage
+// location owned by the deployment's controller. Discovery persists runtime
+// metadata in status details, while managed adapters persist it in namespaced
+// annotations.
+func deploymentDiscoveryRemoteID(deployment *v1alpha1.Deployment) string {
+	if deployment == nil {
+		return ""
+	}
+	if !v1alpha1.IsDiscoveredDeployment(deployment) {
+		for key, value := range deployment.Metadata.Annotations {
+			if strings.HasSuffix(strings.TrimSpace(key), "/"+types.RuntimeMetadataRemoteIDKey) {
+				if remoteID := strings.TrimSpace(value); remoteID != "" {
+					return remoteID
+				}
+			}
+		}
+		return ""
+	}
+	var metadata map[string]string
+	found, err := deployment.Status.GetDetailsKey(deploymentRuntimeDetailsKey, &metadata)
+	if err != nil || !found {
+		return ""
+	}
+	return strings.TrimSpace(metadata[types.RuntimeMetadataRemoteIDKey])
+}
+
+// deploymentRemoteIDKey scopes a provider identity to its deployment runtime.
+func deploymentRemoteIDKey(deployment *v1alpha1.Deployment, remoteID string) string {
+	if deployment == nil {
+		return ""
+	}
+	return discoveryRemoteIDKey(
+		deployment.Metadata.NamespaceOrDefault(),
+		deployment.Spec.RuntimeRef.Name,
+		deployment.Spec.TargetRef.Kind,
+		remoteID,
+	)
+}
+
+// discoveryRemoteIDKey prevents unrelated runtimes and target kinds from colliding.
+func discoveryRemoteIDKey(namespace, runtimeName, targetKind, remoteID string) string {
+	return strings.Join([]string{
+		strings.TrimSpace(namespace),
+		strings.TrimSpace(runtimeName),
+		strings.TrimSpace(targetKind),
+		strings.TrimSpace(remoteID),
+	}, "\x00")
 }
 
 func (c *DeploymentDiscoveryController) patchDiscoveredStatus(
@@ -477,7 +542,7 @@ func discoveredTargetName(result types.DiscoveryResult) string {
 	if name := strings.TrimSpace(result.Name); name != "" {
 		return name
 	}
-	for _, key := range []string{"remoteName", "remoteId"} {
+	for _, key := range []string{"remoteName", types.RuntimeMetadataRemoteIDKey} {
 		if value := strings.TrimSpace(result.RuntimeMetadata[key]); value != "" {
 			return value
 		}
@@ -492,7 +557,7 @@ func managedDeploymentTargetNames(deployment *v1alpha1.Deployment) []string {
 	names := []string{deployment.Spec.TargetRef.Name}
 	for key, value := range deployment.Metadata.Annotations {
 		key = strings.TrimSpace(key)
-		if strings.HasSuffix(key, "/remoteName") || strings.HasSuffix(key, "/remoteId") {
+		if strings.HasSuffix(key, "/remoteName") || strings.HasSuffix(key, "/"+types.RuntimeMetadataRemoteIDKey) {
 			if value = strings.TrimSpace(value); value != "" {
 				names = append(names, value)
 			}

--- a/internal/registry/controller/discovery_integration_test.go
+++ b/internal/registry/controller/discovery_integration_test.go
@@ -24,7 +24,7 @@ func TestDeploymentDiscoveryController_MaterializesDiscoveredDeployment(t *testi
 		TargetKind: v1alpha1.KindAgent,
 		Name:       "external-agent",
 		RuntimeMetadata: map[string]string{
-			"remoteId": "agent-123",
+			types.RuntimeMetadataRemoteIDKey: "agent-123",
 		},
 	}}}
 	discovery := newDeploymentDiscoveryTestController(stores, adapter)
@@ -50,7 +50,7 @@ func TestDeploymentDiscoveryController_MaterializesDiscoveredDeployment(t *testi
 	ok, err := deployment.Status.GetDetailsKey(deploymentRuntimeDetailsKey, &runtimeMetadata)
 	require.NoError(t, err)
 	require.True(t, ok)
-	require.Equal(t, "agent-123", runtimeMetadata["remoteId"])
+	require.Equal(t, "agent-123", runtimeMetadata[types.RuntimeMetadataRemoteIDKey])
 }
 
 func TestDeploymentDiscoveryController_MarksRowsStaleAfterConsecutiveMisses(t *testing.T) {
@@ -238,10 +238,10 @@ func TestDeploymentDiscoveryController_ErrorDoesNotMarkRowsStale(t *testing.T) {
 	require.Zero(t, discoveredMissCount(deployment), "errored polls must not count as misses")
 }
 
-func TestDeploymentDiscoveryController_SkipsAdaptersWithoutDiscoverySource(t *testing.T) {
+func TestDeploymentDiscoveryController_SkipsRuntimeWithoutDiscoverySource(t *testing.T) {
 	ctx := context.Background()
 	stores := newControllerTestStores(t)
-	discovery := newDeploymentDiscoveryTestController(stores, &lifecycleOnlyDiscoveryTestAdapter{})
+	discovery := &DeploymentDiscoveryController{Stores: stores}
 
 	result, err := discovery.Sync(ctx)
 	require.NoError(t, err)
@@ -263,6 +263,56 @@ func TestDeploymentDiscoveryController_DedupesManagedDeploymentTargets(t *testin
 		Name:       "weather",
 	}}}
 	discovery := newDeploymentDiscoveryTestController(stores, adapter)
+
+	result, err := discovery.Sync(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 1, result.Runtimes)
+	require.Zero(t, result.Discovered)
+}
+
+func TestDeploymentDiscoveryController_PreservesNameForRemoteID(t *testing.T) {
+	ctx := context.Background()
+	stores := newControllerTestStores(t)
+	source := &discoveryTestAdapter{results: []types.DiscoveryResult{{
+		TargetKind:      v1alpha1.KindAgent,
+		Name:            "original-name",
+		RuntimeMetadata: map[string]string{types.RuntimeMetadataRemoteIDKey: "agent-123"},
+	}}}
+	discovery := newDeploymentDiscoveryTestController(stores, source)
+	_, err := discovery.Sync(ctx)
+	require.NoError(t, err)
+
+	originalName := discoveredDeploymentName(discoveryTestRuntimeName, v1alpha1.KindAgent, "original-name", "unknown", "default")
+	original := loadDeployment(t, stores, originalName)
+	source.results[0].Name = "renamed-agent"
+	_, err = discovery.Sync(ctx)
+	require.NoError(t, err)
+
+	adopted := loadDeployment(t, stores, originalName)
+	require.Equal(t, original.Metadata.UID, adopted.Metadata.UID)
+	require.Equal(t, "renamed-agent", adopted.Spec.TargetRef.Name)
+	renamed := discoveredDeploymentName(discoveryTestRuntimeName, v1alpha1.KindAgent, "renamed-agent", "unknown", "default")
+	requireDeploymentMissing(t, stores, renamed)
+}
+
+func TestDeploymentDiscoveryController_DedupesManagedDeploymentRemoteID(t *testing.T) {
+	ctx := context.Background()
+	stores := newControllerTestStores(t)
+	seedAgentDeployment(t, stores, "managed-agent", "managed-agent", v1alpha1.DesiredStateDeployed)
+	managed := loadDeployment(t, stores, "managed-agent")
+	require.NoError(t, stores[v1alpha1.KindDeployment].PatchAnnotations(ctx, "default", managed.Metadata.Name, "", func(annotations map[string]string) map[string]string {
+		if annotations == nil {
+			annotations = map[string]string{}
+		}
+		annotations["runtimes.agentregistry.solo.io/test/"+types.RuntimeMetadataRemoteIDKey] = "agent-123"
+		return annotations
+	}))
+	source := &discoveryTestAdapter{results: []types.DiscoveryResult{{
+		TargetKind:      v1alpha1.KindAgent,
+		Name:            "provider-name",
+		RuntimeMetadata: map[string]string{types.RuntimeMetadataRemoteIDKey: "agent-123"},
+	}}}
+	discovery := newDeploymentDiscoveryTestController(stores, source)
 
 	result, err := discovery.Sync(ctx)
 	require.NoError(t, err)
@@ -300,11 +350,11 @@ func TestDeploymentController_SkipsDiscoveredRows(t *testing.T) {
 
 func newDeploymentDiscoveryTestController(
 	stores map[string]*v1alpha1store.Store,
-	adapter types.DeploymentAdapter,
+	source types.DeploymentDiscoverySource,
 ) *DeploymentDiscoveryController {
 	return &DeploymentDiscoveryController{
-		Stores:   stores,
-		Adapters: map[string]types.DeploymentAdapter{"Test": adapter},
+		Stores:  stores,
+		Sources: map[string]types.DeploymentDiscoverySource{"Test": source},
 	}
 }
 
@@ -313,51 +363,9 @@ type discoveryTestAdapter struct {
 	err     error
 }
 
-func (a *discoveryTestAdapter) Type() string { return "Test" }
-
-func (a *discoveryTestAdapter) SupportedTargetKinds() []string {
-	return []string{v1alpha1.KindMCPServer, v1alpha1.KindAgent}
-}
-
-func (a *discoveryTestAdapter) Apply(context.Context, types.ApplyInput) (*types.ApplyResult, error) {
-	return &types.ApplyResult{}, nil
-}
-
-func (a *discoveryTestAdapter) Remove(context.Context, types.RemoveInput) (*types.RemoveResult, error) {
-	return &types.RemoveResult{}, nil
-}
-
-func (a *discoveryTestAdapter) Logs(context.Context, types.LogsInput) (<-chan types.LogLine, error) {
-	ch := make(chan types.LogLine)
-	close(ch)
-	return ch, nil
-}
-
 func (a *discoveryTestAdapter) Discover(context.Context, types.DiscoverInput) ([]types.DiscoveryResult, error) {
 	if a.err != nil {
 		return nil, a.err
 	}
 	return a.results, nil
-}
-
-type lifecycleOnlyDiscoveryTestAdapter struct{}
-
-func (a *lifecycleOnlyDiscoveryTestAdapter) Type() string { return "Test" }
-
-func (a *lifecycleOnlyDiscoveryTestAdapter) SupportedTargetKinds() []string {
-	return []string{v1alpha1.KindMCPServer, v1alpha1.KindAgent}
-}
-
-func (a *lifecycleOnlyDiscoveryTestAdapter) Apply(context.Context, types.ApplyInput) (*types.ApplyResult, error) {
-	return &types.ApplyResult{}, nil
-}
-
-func (a *lifecycleOnlyDiscoveryTestAdapter) Remove(context.Context, types.RemoveInput) (*types.RemoveResult, error) {
-	return &types.RemoveResult{}, nil
-}
-
-func (a *lifecycleOnlyDiscoveryTestAdapter) Logs(context.Context, types.LogsInput) (<-chan types.LogLine, error) {
-	ch := make(chan types.LogLine)
-	close(ch)
-	return ch, nil
 }

--- a/internal/registry/controller/runner.go
+++ b/internal/registry/controller/runner.go
@@ -51,6 +51,7 @@ func StartDeploymentController(
 	pool *pgxpool.Pool,
 	stores map[string]*v1alpha1store.Store,
 	adapters map[string]types.DeploymentAdapter,
+	discoverySources map[string]types.DeploymentDiscoverySource,
 	config ControllerConfig,
 ) (*ControllerHandle, error) {
 	if pool == nil {
@@ -74,7 +75,7 @@ func StartDeploymentController(
 	controller.Wakeups = controlPlaneWakeups(ctx, pool)
 	discovery := &DeploymentDiscoveryController{
 		Stores:            stores,
-		Adapters:          adapters,
+		Sources:           discoverySources,
 		StaleAfterMisses:  config.DiscoveryStaleAfterMisses,
 		DeleteAfterMisses: config.DiscoveryDeleteAfterMisses,
 	}

--- a/internal/registry/registry_app.go
+++ b/internal/registry/registry_app.go
@@ -95,11 +95,13 @@ func App(ctx context.Context, opts ...types.AppOptions) error {
 	// user-supplied case at admission so adapter lookup can use exact-match.
 	deploymentAdapters := map[string]types.DeploymentAdapter{}
 	maps.Copy(deploymentAdapters, options.DeploymentAdapters)
+	discoverySources := map[string]types.DeploymentDiscoverySource{}
+	maps.Copy(discoverySources, options.DeploymentDiscoverySources)
 	pool := db.Pool()
 	stores := buildStores(pool, options.V1Alpha1StoreTables, options.V1Alpha1MutableStoreKinds, options.Auditor)
 	controllerConfig := deploymentControllerConfig(cfg)
 	controllerConfig.DependencyKinds = maps.Clone(options.DeploymentDependencyKinds)
-	if _, err := controller.StartDeploymentController(ctx, pool, stores, deploymentAdapters, controllerConfig); err != nil {
+	if _, err := controller.StartDeploymentController(ctx, pool, stores, deploymentAdapters, discoverySources, controllerConfig); err != nil {
 		return fmt.Errorf("start deployment controller: %w", err)
 	}
 	// The Plugin controller resolves each plugin's pinned source pointer to a

--- a/pkg/types/adapter.go
+++ b/pkg/types/adapter.go
@@ -132,6 +132,9 @@ type ApplyResult struct {
 	Details map[string]json.RawMessage
 }
 
+// RuntimeMetadataRemoteIDKey is the stable provider identity used to correlate discoveries.
+const RuntimeMetadataRemoteIDKey = "remoteId"
+
 // RemoveInput carries the Deployment being torn down plus its resolved
 // Runtime (the Target has already been dereferenced and is not
 // included; teardown operates on the recorded runtime state).

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -227,6 +227,10 @@ type AppOptions struct {
 	// adapters here.
 	DeploymentAdapters map[string]DeploymentAdapter
 
+	// DeploymentDiscoverySources registers discovery by Runtime.Spec.Type,
+	// independently of managed deployment support.
+	DeploymentDiscoverySources map[string]DeploymentDiscoverySource
+
 	// DeploymentDependencyKinds registers additional resource kinds whose
 	// durable control-plane events may change a Deployment's desired inputs.
 	// The Deployment controller requeues current Deployments for these events;


### PR DESCRIPTION
# Description

Register runtime discovery independently from managed deployment adapters.
Preserve discovered deployment identity across provider renames and avoid
duplicating managed deployments using the stable remote ID.

# Change Type

```
/kind cleanup
```

# Changelog

```release-note
NONE
```

# Additional Notes

NONE
