### PR TITLE
internal: Add label filter and display to arctl get

### DIFF
--- a/internal/cli/declarative/get.go
+++ b/internal/cli/declarative/get.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"sort"
+	"slices"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -369,7 +369,7 @@ func formatLabels(item any) string {
 	for key := range meta.Labels {
 		keys = append(keys, key)
 	}
-	sort.Strings(keys)
+	slices.Sort(keys)
 	pairs := make([]string, len(keys))
 	for i, key := range keys {
 		pairs[i] = key + "=" + meta.Labels[key]

--- a/internal/cli/declarative/get.go
+++ b/internal/cli/declarative/get.go
@@ -52,7 +52,7 @@ Examples:
 	}
 	cmd.Flags().StringP("output", "o", "table", "Output format: table, yaml, json")
 	cmd.Flags().StringVarP(&labels, "labels", "l", "", "Content kinds only: filter list rows by comma-separated key=value labels.")
-	cmd.Flags().Bool("show-labels", false, "Table output only: print an additional LABELS column with each resource's labels.")
+	cmd.Flags().Bool("show-labels", false, "Print an additional LABELS column with each resource's labels; ignored for -o yaml/json, which already include labels.")
 	cmd.Flags().String("tag", "", "Tagged kinds only. With NAME: fetch one tag (defaults to latest). Without NAME: filter the list to this tag.")
 	cmd.Flags().Bool("latest", false, "List mode only: restrict to rows pinned to the literal 'latest' tag (equivalent to --tag latest).")
 	cmd.Flags().Bool("all-tags", false, "List every tag of NAME (tagged content kinds only)")

--- a/internal/cli/declarative/get.go
+++ b/internal/cli/declarative/get.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -18,6 +19,7 @@ import (
 
 // NewGetCmd returns a new "get" cobra command.
 func NewGetCmd(deps cliruntime.Deps) *cobra.Command {
+	var labels string
 	cmd := &cobra.Command{
 		Use:   "get TYPE [NAME]",
 		Short: "List or retrieve registry resources",
@@ -29,6 +31,8 @@ Supported types: agents, mcps, skills, prompts, runtimes, deployments
 Examples:
   arctl get all
   arctl get agents
+  arctl get agents -l team=platform,tier=production
+  arctl get agents --show-labels         # list rows with a LABELS column
   arctl get agents --tag stable          # list rows with a specific tag
   arctl get agents --latest              # list rows pinned to the "latest" tag
   arctl get mcps
@@ -47,6 +51,8 @@ Examples:
 		},
 	}
 	cmd.Flags().StringP("output", "o", "table", "Output format: table, yaml, json")
+	cmd.Flags().StringVarP(&labels, "labels", "l", "", "Content kinds only: filter list rows by comma-separated key=value labels.")
+	cmd.Flags().Bool("show-labels", false, "Table output only: print an additional LABELS column with each resource's labels.")
 	cmd.Flags().String("tag", "", "Tagged kinds only. With NAME: fetch one tag (defaults to latest). Without NAME: filter the list to this tag.")
 	cmd.Flags().Bool("latest", false, "List mode only: restrict to rows pinned to the literal 'latest' tag (equivalent to --tag latest).")
 	cmd.Flags().Bool("all-tags", false, "List every tag of NAME (tagged content kinds only)")
@@ -59,6 +65,7 @@ func runGet(cmd *cobra.Command, deps cliruntime.Deps, args []string) error {
 	outputFormat, _ := cmd.Flags().GetString("output")
 	allTags, _ := cmd.Flags().GetBool("all-tags")
 	latest, _ := cmd.Flags().GetBool("latest")
+	labels, _ := cmd.Flags().GetString("labels")
 	tag, _ := cmd.Flags().GetString("tag")
 	origin, _ := cmd.Flags().GetString("origin")
 	allTagsFlag := "--all-tags"
@@ -70,6 +77,9 @@ func runGet(cmd *cobra.Command, deps cliruntime.Deps, args []string) error {
 	}
 	if allTags && latest {
 		return fmt.Errorf("%s and %s are mutually exclusive", latestFlag, allTagsFlag)
+	}
+	if allTags && labels != "" {
+		return fmt.Errorf("--labels and %s are mutually exclusive", allTagsFlag)
 	}
 	if latest && tag != "" {
 		return fmt.Errorf("%s and %s are mutually exclusive", tagFlag, latestFlag)
@@ -86,6 +96,7 @@ func runGet(cmd *cobra.Command, deps cliruntime.Deps, args []string) error {
 		}
 		return runGetAllArg(cmd, deps, kinds, outputFormat, getFlags{
 			allTags: allTags,
+			labels:  labels,
 			latest:  latest,
 			tag:     tag,
 		})
@@ -110,6 +121,12 @@ func runGet(cmd *cobra.Command, deps cliruntime.Deps, args []string) error {
 	}
 	if latest && k.ListTags == nil {
 		return fmt.Errorf("%s not supported for kind %q (resource is not tagged)", latestFlag, k.Kind)
+	}
+	if labels != "" && k.ListTags == nil {
+		return fmt.Errorf("--labels not supported for kind %q (resource is not a content kind)", k.Kind)
+	}
+	if labels != "" && len(args) == 2 {
+		return fmt.Errorf("--labels is a list filter and cannot be combined with a resource NAME")
 	}
 
 	// --origin filters Deployment provenance and is meaningless elsewhere.
@@ -141,7 +158,7 @@ func runGet(cmd *cobra.Command, deps cliruntime.Deps, args []string) error {
 		return printItem(cmd, k, item, outputFormat)
 	}
 
-	listOpts := scheme.ListOpts{Tag: tag, LatestOnly: latest, Origin: originOpt}
+	listOpts := scheme.ListOpts{Labels: labels, Tag: tag, LatestOnly: latest, Origin: originOpt}
 	items, err := listItems(cmd.Context(), c, k, listOpts)
 	if err != nil {
 		return fmt.Errorf("listing %s: %w", kindPlural(k), err)
@@ -155,6 +172,7 @@ func runGet(cmd *cobra.Command, deps cliruntime.Deps, args []string) error {
 
 type getFlags struct {
 	allTags bool
+	labels  string
 	latest  bool
 	tag     string
 }
@@ -187,6 +205,9 @@ func runGetAllArg(cmd *cobra.Command, deps cliruntime.Deps, kinds *scheme.Regist
 	}
 	if flags.latest {
 		return fmt.Errorf("--latest cannot be used with `get all`")
+	}
+	if flags.labels != "" {
+		return fmt.Errorf("--labels cannot be used with `get all`")
 	}
 	c, err := registryClient(cmd, deps)
 	if err != nil {
@@ -275,9 +296,10 @@ func printItem(cmd *cobra.Command, k *scheme.Kind, item any, outputFormat string
 	case "json":
 		return marshalJSON(cmd, item)
 	default:
+		showLabels, _ := cmd.Flags().GetBool("show-labels")
 		t := printer.NewTablePrinter(cmd.OutOrStdout())
-		t.SetHeaders(tableColumns(k)...)
-		t.AddRow(stringsToAny(tableRow(k, item))...)
+		t.SetHeaders(tableHeaders(k, showLabels)...)
+		t.AddRow(stringsToAny(tableRowWithLabels(k, item, showLabels))...)
 		return t.Render()
 	}
 }
@@ -302,13 +324,57 @@ func printItems(cmd *cobra.Command, k *scheme.Kind, items []any, outputFormat st
 	case "json":
 		return marshalJSON(cmd, items)
 	default:
+		showLabels, _ := cmd.Flags().GetBool("show-labels")
 		t := printer.NewTablePrinter(cmd.OutOrStdout())
-		t.SetHeaders(tableColumns(k)...)
+		t.SetHeaders(tableHeaders(k, showLabels)...)
 		for _, item := range items {
-			t.AddRow(stringsToAny(tableRow(k, item))...)
+			t.AddRow(stringsToAny(tableRowWithLabels(k, item, showLabels))...)
 		}
 		return t.Render()
 	}
+}
+
+// tableHeaders returns the kind's table columns, with a trailing LABELS
+// column appended when --show-labels is set.
+func tableHeaders(k *scheme.Kind, showLabels bool) []string {
+	headers := tableColumns(k)
+	if showLabels {
+		headers = append(headers, "LABELS")
+	}
+	return headers
+}
+
+// tableRowWithLabels returns the kind's row, with the item's labels appended
+// as a trailing column when --show-labels is set.
+func tableRowWithLabels(k *scheme.Kind, item any, showLabels bool) []string {
+	row := tableRow(k, item)
+	if showLabels {
+		row = append(row, formatLabels(item))
+	}
+	return row
+}
+
+// formatLabels renders an item's metadata labels as a sorted,
+// comma-separated "key=value" list, matching kubectl's --show-labels output.
+func formatLabels(item any) string {
+	obj, ok := item.(v1alpha1.Object)
+	if !ok {
+		return "<none>"
+	}
+	meta := obj.GetMetadata()
+	if meta == nil || len(meta.Labels) == 0 {
+		return "<none>"
+	}
+	keys := make([]string, 0, len(meta.Labels))
+	for key := range meta.Labels {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	pairs := make([]string, len(keys))
+	for i, key := range keys {
+		pairs[i] = key + "=" + meta.Labels[key]
+	}
+	return strings.Join(pairs, ",")
 }
 
 func stringsToAny(ss []string) []any {

--- a/internal/cli/declarative/get_test.go
+++ b/internal/cli/declarative/get_test.go
@@ -42,6 +42,97 @@ func TestGetCmd_NoAPIClientErrors(t *testing.T) {
 	assert.ErrorContains(t, err, "registry runtime not configured")
 }
 
+func TestGet_Labels_ListModeForwardsSelector(t *testing.T) {
+	for _, flag := range []string{"--labels", "-l"} {
+		t.Run(flag, func(t *testing.T) {
+			var got string
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				got = r.URL.Query().Get("labels")
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"items":[]}`))
+			}))
+			t.Cleanup(srv.Close)
+			setupClientForServer(t, srv)
+
+			cmd := declarative.NewGetCmd(declarativeTestDeps(nil))
+			cmd.SetArgs([]string{"agents", flag, "team=platform,tier=production"})
+			require.NoError(t, cmd.Execute())
+			assert.Equal(t, "team=platform,tier=production", got)
+		})
+	}
+}
+
+func TestGet_Labels_RejectsNonListUses(t *testing.T) {
+	setDeclarativeTestClient(t, client.NewClient("http://127.0.0.1:1", ""))
+
+	for _, tc := range []struct {
+		name string
+		args []string
+		want string
+	}{
+		{name: "named resource", args: []string{"agent", "acme-bot", "-l", "team=platform"}, want: "cannot be combined with a resource NAME"},
+		{name: "all tags", args: []string{"agent", "acme-bot", "--all-tags", "-l", "team=platform"}, want: "mutually exclusive"},
+		{name: "get all", args: []string{"all", "-l", "team=platform"}, want: "cannot be used with `get all`"},
+		{name: "non-content kind", args: []string{"runtime", "-l", "team=platform"}, want: "not supported for kind \"runtime\""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := declarative.NewGetCmd(declarativeTestDeps(nil))
+			cmd.SetArgs(tc.args)
+			err := cmd.Execute()
+			require.Error(t, err)
+			assert.ErrorContains(t, err, tc.want)
+		})
+	}
+}
+
+func TestGet_ShowLabels(t *testing.T) {
+	rows := []v1alpha1.Agent{
+		func() v1alpha1.Agent {
+			a := agentTagFixture("acme-bot", "latest")
+			a.Metadata.Labels = map[string]string{"tier": "production", "team": "platform"}
+			return a
+		}(),
+		agentTagFixture("beta-bot", "latest"),
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"items": rows})
+	}))
+	t.Cleanup(srv.Close)
+	setupClientForServer(t, srv)
+
+	out := &bytes.Buffer{}
+	cmd := declarative.NewGetCmd(declarativeTestDeps(nil))
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.SetArgs([]string{"agents", "--show-labels"})
+	require.NoError(t, cmd.Execute())
+
+	got := out.String()
+	assert.Contains(t, got, "LABELS")
+	assert.Contains(t, got, "team=platform,tier=production")
+	assert.Contains(t, got, "<none>")
+}
+
+func TestGet_ShowLabels_OmittedByDefault(t *testing.T) {
+	rows := []v1alpha1.Agent{agentTagFixture("acme-bot", "latest")}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"items": rows})
+	}))
+	t.Cleanup(srv.Close)
+	setupClientForServer(t, srv)
+
+	out := &bytes.Buffer{}
+	cmd := declarative.NewGetCmd(declarativeTestDeps(nil))
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.SetArgs([]string{"agents"})
+	require.NoError(t, cmd.Execute())
+
+	assert.NotContains(t, out.String(), "LABELS")
+}
+
 // TestGetCmd_RegistryDrivenColumnLookup verifies the package-level scheme
 // registry resolves declarative-known kinds (declarative's init() registered
 // them at process start), so `arctl get agents` gets past kind validation

--- a/internal/cli/declarative/resources.go
+++ b/internal/cli/declarative/resources.go
@@ -29,6 +29,7 @@ func listAny[T v1alpha1.Object](ctx context.Context, c *client.Client, kind stri
 		kind,
 		client.ListOpts{
 			Namespace:  v1alpha1.DefaultNamespace,
+			Labels:     opts.Labels,
 			Tag:        opts.Tag,
 			LatestOnly: opts.LatestOnly,
 			Limit:      200,

--- a/internal/cli/scheme/registry.go
+++ b/internal/cli/scheme/registry.go
@@ -27,6 +27,8 @@ type Column struct {
 // Empty fields mean "no filter" — the default `arctl get <plural>` lists
 // every row of the kind.
 type ListOpts struct {
+	// Labels is an equality selector forwarded to the registry API.
+	Labels string
 	// Tag, when set, restricts the list to rows with this tag value
 	// (tagged content kinds only). Mutually exclusive with LatestOnly.
 	Tag string


### PR DESCRIPTION
# Description

`arctl get` had no way to filter or display resource labels, even though
content-registry kinds (agents, mcps, skills, prompts, plugins, models)
already carry a queryable `labels` map on their metadata.

This adds two flags:

- `-l/--labels`: filters list output by comma-separated `key=value` pairs,
  forwarded through `scheme.ListOpts` into the existing
  `client.ListOpts.Labels` query param. It's restricted to content kinds
  (those with `ListTags` set) and to list mode, mirroring the existing
  `--tag`/`--latest` guards. It's rejected under `get all` for now since
  that command builds a fresh `ListOpts` per kind and mixes in kinds that
  don't support the filter at all — extending it there is a natural
  follow-up.
- `--show-labels`: a kubectl-style flag that appends a trailing `LABELS`
  column to table output with each row's sorted `key=value` pairs (or
  `<none>`). It reads metadata directly off the `v1alpha1.Object`
  interface, so it works uniformly across every registered kind without
  touching per-kind `RowFunc` implementations.

# Change Type

/kind feature

# Changelog

```release-note
Add `-l/--labels` and `--show-labels` flags to `arctl get` for filtering and
displaying resource labels.
```

# Additional Notes

Follow-ups intentionally left out of this PR:

- `arctl get all -l <label>` selection support. `runGetAll` currently builds
  a fresh `ListOpts` per kind itself rather than threading the caller's
  flags through, and mixes in non-content kinds that don't support the
  filter at all — extending it needs a small refactor of that dispatch path.
- `arctl delete -l <label>` (bulk delete by label selector). `delete` has no
  list mode today — it requires an explicit `TYPE NAME` or `-f FILE` — so
  this would be a new list-then-delete flow with its own safety
  considerations (partial-failure handling, possibly a confirmation or
  `--dry-run`), not a small addition.
- Revisiting whether `--all-tags` should be reworked or removed, possibly in
  the same pass as the `get all -l` refactor above.
- Label selection intentionally stays simple key=value equality matching,
  not kubectl's fuller `--selector` expression language (set-based
  `in`/`notin`/exists operators). The current v1alpha1 metadata envelope
  doesn't need that expressiveness yet.
- `internal/cli/declarative` could use some general cleanup/TLC independent
  of this change.
