### PR TITLE
ci: Stop running workflows on develop

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,7 +2,7 @@ name: Build and Test
 
 on:
   push:
-    branches: [ main, develop ]
+    branches: [ main ]
   pull_request:
     branches: [ main ]
   merge_group:

--- a/.github/workflows/chart-tests.yaml
+++ b/.github/workflows/chart-tests.yaml
@@ -2,7 +2,7 @@ name: Chart Tests
 
 on:
   push:
-    branches: [ main, develop ]
+    branches: [ main ]
     paths:
       - 'charts/**'
       - '.github/workflows/chart-tests.yml'

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -2,7 +2,7 @@ name: Lint
 
 on:
   push:
-    branches: [main, develop]
+    branches: [main]
   pull_request:
     branches: [main]
   merge_group:

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -2,7 +2,7 @@ name: Verify
 
 on:
   push:
-    branches: [main, develop]
+    branches: [main]
   pull_request:
     branches: [main]
   merge_group:


### PR DESCRIPTION
# Description

Stop running push-triggered build, chart, lint, and verification workflows on
the retired `develop` branch. Push validation now targets `main` only, while
pull request and merge-group coverage remain unchanged.

# Change Type

/kind cleanup

# Changelog

```release-note
NONE
```

# Additional Notes

Validated all workflow files with actionlint v1.7.12 while ignoring only the
pre-existing `actions/cache@v3` runner compatibility diagnostics. No other
workflow errors were reported.
