### PR TITLE
internal: Require auth for plugin marketplace

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,9 +36,9 @@ AGENT_REGISTRY_MCP_REGISTRY_COMPAT_PATH_PREFIX=
 # Claude Code Plugin Marketplace Compatibility (read-only)
 # Re-exposes resolved Plugin resources as a Claude Code marketplace.json at
 # /plugin-marketplace/marketplace.json so the URL can be registered directly
-# with `claude plugin marketplace add`. Anonymous and flattens all namespaces
-# into one catalogue. OFF by default; enable only where a Plugin catalogue at
-# this scope is acceptable.
+# with `claude plugin marketplace add`. Uses configured authentication and
+# flattens all namespaces into one catalogue. OFF by default; enable only where
+# a Plugin catalogue at this scope is acceptable.
 # See docs/plugin-marketplace-compatibility.md.
 AGENT_REGISTRY_PLUGIN_MARKETPLACE_COMPAT_ENABLED=false
 # Optional base prefix to mount the compatibility API under (e.g. /plugins).

--- a/docs/plugin-marketplace-compatibility.md
+++ b/docs/plugin-marketplace-compatibility.md
@@ -41,5 +41,5 @@ claude plugin marketplace add https://registry.example.com/plugin-marketplace/ma
 ## Caveats
 
 - **Off by default; RBAC-aware via the same hook as the native read path.** The endpoint reuses the per-kind `ListFilter` that the native Plugin read path uses. In the **OSS** build this hook is not wired, so the catalogue is flat and unfiltered across all namespaces. A **downstream** build that wires `crud.PerKindHooks` for Plugin gets the same RBAC/tenancy scoping automatically.
-- **Anonymous by design, even with an authn provider.** When enabled, its route is registered as an authn public path: requests bypass credential authentication and carry an `auth.PublicSession` instead, so `ListFilter` still receives a session and decides what the public catalogue exposes.
+- **Uses configured authentication.** OSS does not configure an authn provider, so its catalogue remains permissive. A downstream build that configures one protects this route with the normal authn middleware; its authenticated session reaches the `ListFilter` for RBAC or tenancy scoping.
 - **Best-effort field mapping.** Description/version prefer the scanned `plugin.json` manifest, falling back to the Plugin spec's description and an empty version (Claude Code falls back to the resolved commit SHA).

--- a/internal/registry/api/router/router.go
+++ b/internal/registry/api/router/router.go
@@ -15,7 +15,6 @@ import (
 	"go.opentelemetry.io/otel/metric"
 
 	mcpregistrycompat "github.com/agentregistry-dev/agentregistry/internal/registry/api/handlers/mcpregistry"
-	pluginmarketplacecompat "github.com/agentregistry-dev/agentregistry/internal/registry/api/handlers/pluginmarketplace"
 	"github.com/agentregistry-dev/agentregistry/internal/registry/config"
 	"github.com/agentregistry-dev/agentregistry/internal/registry/telemetry"
 	arv0 "github.com/agentregistry-dev/agentregistry/pkg/api/v0"
@@ -171,14 +170,6 @@ func NewHumaAPI(
 			// PublicSession, allowing it to successfully pass authz hooks on anonymous sessions.
 			middlewareOpts = append(middlewareOpts, auth.WithPublicPaths(
 				mcpregistrycompat.BasePath(cfg.MCPRegistryCompatPathPrefix)+"/"))
-		}
-		if cfg.PluginMarketplaceCompatEnabled {
-			// The /plugin-marketplace compatibility API is a public catalogue that
-			// still goes through authorization (for listing resources), so add to
-			// public paths and append a PublicSession, allowing it to successfully
-			// pass authz hooks on anonymous sessions.
-			middlewareOpts = append(middlewareOpts, auth.WithPublicPaths(
-				pluginmarketplacecompat.BasePath(cfg.PluginMarketplaceCompatPathPrefix)+"/"))
 		}
 		api.UseMiddleware(auth.AuthnMiddleware(authnProvider, middlewareOpts...))
 	}

--- a/internal/registry/api/router/router_test.go
+++ b/internal/registry/api/router/router_test.go
@@ -1,0 +1,63 @@
+package router
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+
+	"github.com/agentregistry-dev/agentregistry/internal/registry/config"
+	"github.com/agentregistry-dev/agentregistry/internal/registry/telemetry"
+	arv0 "github.com/agentregistry-dev/agentregistry/pkg/api/v0"
+	"github.com/agentregistry-dev/agentregistry/pkg/api/v1alpha1"
+	"github.com/agentregistry-dev/agentregistry/pkg/registry/auth"
+	"github.com/agentregistry-dev/agentregistry/pkg/registry/v1alpha1store"
+)
+
+type rejectingAuthnProvider struct {
+	calls int
+}
+
+func (p *rejectingAuthnProvider) Authenticate(context.Context, func(string) string, url.Values) (auth.Session, error) {
+	p.calls++
+	return nil, auth.ErrUnauthenticated
+}
+
+func TestNewHumaAPIAuthenticationBoundaries(t *testing.T) {
+	metrics, err := telemetry.NewMetrics(otel.GetMeterProvider().Meter("router-test"))
+	require.NoError(t, err)
+
+	mux := http.NewServeMux()
+	provider := &rejectingAuthnProvider{}
+	_, err = NewHumaAPI(
+		&config.Config{PluginMarketplaceCompatEnabled: true},
+		mux,
+		metrics,
+		&arv0.VersionBody{},
+		nil,
+		provider,
+		&RouteOptions{Stores: Stores{v1alpha1.KindPlugin: &v1alpha1store.Store{}}},
+		nil,
+	)
+	require.NoError(t, err)
+
+	t.Run("marketplace uses configured authentication", func(t *testing.T) {
+		recorder := httptest.NewRecorder()
+		mux.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/plugin-marketplace/marketplace.json", nil))
+
+		require.Equal(t, http.StatusUnauthorized, recorder.Code)
+		require.Equal(t, 1, provider.calls)
+	})
+
+	t.Run("skip route remains unauthenticated", func(t *testing.T) {
+		recorder := httptest.NewRecorder()
+		mux.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/v0/ping", nil))
+
+		require.Equal(t, http.StatusOK, recorder.Code)
+		require.Equal(t, 1, provider.calls)
+	})
+}

--- a/internal/registry/api/router/v0.go
+++ b/internal/registry/api/router/v0.go
@@ -177,11 +177,8 @@ func RegisterRoutes(
 			// path uses, so a downstream build that gates Plugin reads gates the
 			// compat endpoint identically. nil hook = public OSS behavior.
 			//
-			// This route is registered as an authn public path (see
-			// NewHumaAPI): where an authn provider is configured, requests
-			// under it carry an auth.PublicSession instead of requiring
-			// credentials, so ListFilter still receives a session and scopes
-			// what anonymous callers may see.
+			// The normal authn middleware applies when a provider is configured.
+			// OSS remains permissive when no provider is configured.
 			pluginmarketplacecompat.Register(api, pluginmarketplacecompat.Config{
 				PathPrefix: cfg.PluginMarketplaceCompatPathPrefix,
 				Store:      store,


### PR DESCRIPTION
# Description

Enabling Claude Code marketplace compatibility currently adds the endpoint to
the public-path bypass. That replaces authenticated requests with a public
session before the existing Plugin list filter runs.

Keep the marketplace endpoint in the normal middleware chain so a configured
authentication provider can establish the caller session. OSS deployments that
do not configure a provider remain permissive, while the regular public skip
routes and MCP catalog behavior remain unchanged.

# Change Type

/kind fix

# Changelog

```release-note
Configured authentication providers now protect the Claude Code plugin marketplace endpoint.
```

# Additional Notes

Focused router tests cover authenticated marketplace requests and the existing
public ping bypass.
