### PR TITLE
docker: Install git in server image

### DIFF
--- a/docker/server.Dockerfile
+++ b/docker/server.Dockerfile
@@ -42,6 +42,7 @@ FROM ubuntu:22.04 AS runtime
 
 RUN apt-get update && apt-get install -y \
     curl \
+    git \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /app/bin/arctl-server /app/bin/arctl-server


### PR DESCRIPTION
# Description

Git-backed Plugin reconciliation shells out to the system `git` executable to
resolve and inspect source repositories. The server runtime image did not
include Git, so deployed controllers failed every Git-backed Plugin before
reaching its repository.

Install Git in the runtime image so the controller can reconcile supported
Plugin sources.

# Change Type

/kind fix

# Changelog

```release-note
Deployed AgentRegistry servers can now reconcile Plugins sourced from Git repositories.
```

# Additional Notes

The runtime package addition is the only image change.
