### PR TITLE
internal: Make configure clients subcommands

### DIFF
--- a/internal/cli/configure/configure.go
+++ b/internal/cli/configure/configure.go
@@ -20,31 +20,28 @@ var clientConfigurers = map[string]ClientConfigurer{
 	"kiro":        &KiroConfigurer{},
 }
 
-func NewCommand(deps cliruntime.Deps) *cobra.Command {
+func NewCommand(_ cliruntime.Deps) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   cliruntime.CommandConfigure,
+		Short: "Configure a client",
+		Long:  `Creates the .json configuration for each client, so it can connect to arctl.`,
+	}
+
+	for name, configurer := range clientConfigurers {
+		cmd.AddCommand(newClientCommand(name, configurer))
+	}
+
+	return cmd
+}
+
+func newClientCommand(clientName string, configurer ClientConfigurer) *cobra.Command {
 	var configureURL, configurePort, configureTokenEnv string
 
 	cmd := &cobra.Command{
-		Use:   cliruntime.CommandConfigure + " [client-name]",
-		Short: "Configure a client",
-		Long:  `Creates the .json configuration for each client, so it can connect to arctl.`,
-		Args:  cobra.MaximumNArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			if len(args) == 0 {
-				out := cmd.OutOrStdout()
-				fmt.Fprintln(out, "Supported clients:")
-				for name, configurer := range clientConfigurers {
-					fmt.Fprintf(out, "  %-15s - %s\n", name, configurer.GetClientName())
-				}
-				fmt.Fprintf(out, "\nUsage:\n  %s <client-name>\n", cmd.CommandPath())
-				return nil
-			}
-
-			clientName := args[0]
-			configurer, ok := clientConfigurers[clientName]
-			if !ok {
-				return fmt.Errorf("client %q is not supported; run 'arctl configure' to see supported clients", clientName)
-			}
-
+		Use:   clientName,
+		Short: "Configure " + configurer.GetClientName(),
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			url := fmt.Sprintf("http://localhost:%s/mcp", configurePort)
 			if configureURL != "" {
 				if cmd.Flags().Changed("port") {

--- a/internal/cli/configure/configure_test.go
+++ b/internal/cli/configure/configure_test.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/spf13/cobra"
+
 	cliruntime "github.com/agentregistry-dev/agentregistry/pkg/cli/runtime"
 )
 
@@ -395,6 +397,31 @@ func TestConfigure_ListsSupportedClients(t *testing.T) {
 	for _, client := range []string{"vscode", "cursor", "claude-code", "kiro"} {
 		if !strings.Contains(output, client) {
 			t.Errorf("client listing missing %q\ngot:\n%s", client, output)
+		}
+	}
+}
+
+func TestConfigure_ClientsAreSubcommands(t *testing.T) {
+	cmd := NewCommand(cliruntime.Deps{})
+	if cmd.Use != cliruntime.CommandConfigure {
+		t.Fatalf("Use = %q, want %q", cmd.Use, cliruntime.CommandConfigure)
+	}
+	if cmd.Flags().Lookup("url") != nil {
+		t.Fatal("configure parent unexpectedly has client flags")
+	}
+	for _, name := range []string{"vscode", "cursor", "claude-code", "kiro"} {
+		var client *cobra.Command
+		for _, candidate := range cmd.Commands() {
+			if candidate.Name() == name {
+				client = candidate
+				break
+			}
+		}
+		if client == nil {
+			t.Fatalf("missing %q subcommand", name)
+		}
+		if client.Flags().Lookup("url") == nil {
+			t.Fatalf("%q subcommand is missing --url", name)
 		}
 	}
 }


### PR DESCRIPTION
# Description

Represent each supported configure client as a Cobra child command while
preserving the existing `arctl configure <client>` invocation syntax. The
command help now exposes supported clients directly, and client-specific flags
are scoped to the command that owns them.

# Change Type

/kind cleanup

# Changelog

```release-note
NONE
```

# Additional Notes

`go test ./internal/cli/configure` passes.
