### PR TITLE
chore: add .mcp.json to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,10 @@ internal/registry/api/ui/dist/
 # arctl specific
 .arctl/
 
+# arctl configure writes a project-local .mcp.json with the developer's
+# registry connection details; it is per-developer and should not be committed.
+.mcp.json
+
 # IDE
 .claude
 .vscode/


### PR DESCRIPTION
# Description

Add .mcp.json to .gitignore with a short rationale.

arctl configure claude-code writes a project-local .mcp.json containing the developer's registry connection details. This file is per-developer and should not be committed to the repository.

/kind cleanup

```release-note
NONE
```


Fixes #647