### PR TITLE
internal: Support private Git catalog sources

### DIFF
--- a/internal/cli/common/gitutil/credentials.go
+++ b/internal/cli/common/gitutil/credentials.go
@@ -1,0 +1,60 @@
+package gitutil
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/agentregistry-dev/agentregistry/pkg/api/v1alpha1"
+	"github.com/agentregistry-dev/agentregistry/pkg/secret"
+	"github.com/agentregistry-dev/agentregistry/pkg/types"
+)
+
+// NewSecretCredentialResolver resolves repository credentials from the
+// namespace-local Secret named by CredentialsRef.
+func NewSecretCredentialResolver(resolver secret.Resolver) types.GitCredentialFunc {
+	return func(ctx context.Context, namespace string, repo *v1alpha1.Repository) (*url.Userinfo, error) {
+		if repo == nil || repo.CredentialsRef == nil || repo.CredentialsRef.Name == "" {
+			return nil, nil
+		}
+		if resolver == nil {
+			return nil, fmt.Errorf("secret resolver is not configured")
+		}
+		if namespace == "" {
+			namespace = v1alpha1.DefaultNamespace
+		}
+		values, err := resolver.ResolveAll(ctx, v1alpha1.SecretRef{
+			Namespace: namespace,
+			Name:      repo.CredentialsRef.Name,
+		})
+		if err != nil {
+			return nil, err
+		}
+		passwordValue, ok := values["password"]
+		if !ok {
+			return nil, fmt.Errorf(
+				"resolve secret %s/%s: key %q: %w",
+				namespace,
+				repo.CredentialsRef.Name,
+				"password",
+				secret.ErrNotFound,
+			)
+		}
+
+		username := strings.TrimSpace(string(values["username"].Reveal()))
+		password := strings.TrimSpace(string(passwordValue.Reveal()))
+		switch {
+		case username != "" && password == "":
+			return nil, fmt.Errorf("username set without password")
+		case username == "" && strings.Contains(password, ":"):
+			return nil, fmt.Errorf("password contains ':'; set username separately")
+		case username != "":
+			return url.UserPassword(username, password), nil
+		case password != "":
+			return url.User(password), nil
+		default:
+			return nil, nil
+		}
+	}
+}

--- a/internal/cli/common/gitutil/credentials_test.go
+++ b/internal/cli/common/gitutil/credentials_test.go
@@ -1,0 +1,159 @@
+package gitutil
+
+import (
+	"context"
+	"errors"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/agentregistry-dev/agentregistry/pkg/api/v1alpha1"
+	"github.com/agentregistry-dev/agentregistry/pkg/secret"
+)
+
+type fakeSecretResolver struct {
+	values map[string]secret.SensitiveValue
+	err    error
+	ref    v1alpha1.SecretRef
+}
+
+func (*fakeSecretResolver) Resolve(context.Context, v1alpha1.SecretRef) (secret.SensitiveValue, error) {
+	return secret.SensitiveValue{}, errors.New("unexpected Resolve call")
+}
+
+func (r *fakeSecretResolver) ResolveAll(_ context.Context, ref v1alpha1.SecretRef) (map[string]secret.SensitiveValue, error) {
+	r.ref = ref
+	return r.values, r.err
+}
+
+func TestSecretCredentialResolver(t *testing.T) {
+	tests := []struct {
+		name      string
+		namespace string
+		repo      *v1alpha1.Repository
+		resolver  *fakeSecretResolver
+		want      *url.Userinfo
+		wantRef   v1alpha1.SecretRef
+		wantErr   string
+	}{
+		{
+			name:     "no credentials ref is anonymous",
+			repo:     &v1alpha1.Repository{},
+			resolver: &fakeSecretResolver{},
+		},
+		{
+			name: "password uses token-only authentication",
+			repo: repositoryWithCredentials("github"),
+			resolver: &fakeSecretResolver{values: map[string]secret.SensitiveValue{
+				"password": secret.NewSensitiveValue([]byte("ghp-secret")),
+			}},
+			want:    url.User("ghp-secret"),
+			wantRef: v1alpha1.SecretRef{Namespace: v1alpha1.DefaultNamespace, Name: "github"},
+		},
+		{
+			name:      "username and password use basic authentication",
+			namespace: "team-a",
+			repo:      repositoryWithCredentials("gitlab"),
+			resolver: &fakeSecretResolver{values: map[string]secret.SensitiveValue{
+				"username": secret.NewSensitiveValue([]byte("oauth2")),
+				"password": secret.NewSensitiveValue([]byte("glpat-secret")),
+			}},
+			want:    url.UserPassword("oauth2", "glpat-secret"),
+			wantRef: v1alpha1.SecretRef{Namespace: "team-a", Name: "gitlab"},
+		},
+		{
+			name:     "missing password is an error",
+			repo:     repositoryWithCredentials("github"),
+			resolver: &fakeSecretResolver{values: map[string]secret.SensitiveValue{}},
+			wantRef:  v1alpha1.SecretRef{Namespace: v1alpha1.DefaultNamespace, Name: "github"},
+			wantErr:  `key "password"`,
+		},
+		{
+			name: "username without password is an error",
+			repo: repositoryWithCredentials("github"),
+			resolver: &fakeSecretResolver{values: map[string]secret.SensitiveValue{
+				"username": secret.NewSensitiveValue([]byte("git")),
+				"password": secret.NewSensitiveValue(nil),
+			}},
+			wantRef: v1alpha1.SecretRef{Namespace: v1alpha1.DefaultNamespace, Name: "github"},
+			wantErr: "username set without password",
+		},
+		{
+			name: "token-only password containing colon is an error",
+			repo: repositoryWithCredentials("github"),
+			resolver: &fakeSecretResolver{values: map[string]secret.SensitiveValue{
+				"password": secret.NewSensitiveValue([]byte("git:ghp-secret")),
+			}},
+			wantRef: v1alpha1.SecretRef{Namespace: v1alpha1.DefaultNamespace, Name: "github"},
+			wantErr: "password contains ':'",
+		},
+		{
+			name:     "secret resolution failure is returned",
+			repo:     repositoryWithCredentials("github"),
+			resolver: &fakeSecretResolver{err: secret.ErrNotFound},
+			wantRef:  v1alpha1.SecretRef{Namespace: v1alpha1.DefaultNamespace, Name: "github"},
+			wantErr:  secret.ErrNotFound.Error(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NewSecretCredentialResolver(tt.resolver)(t.Context(), tt.namespace, tt.repo)
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("error = %v, want it to contain %q", err, tt.wantErr)
+				}
+			} else if err != nil {
+				t.Fatalf("resolve credentials: %v", err)
+			}
+			if userinfoString(got) != userinfoString(tt.want) {
+				t.Fatalf("credentials = %q, want %q", userinfoString(got), userinfoString(tt.want))
+			}
+			if tt.resolver.ref != tt.wantRef {
+				t.Fatalf("secret ref = %#v, want %#v", tt.resolver.ref, tt.wantRef)
+			}
+		})
+	}
+}
+
+func TestSourceUsesSecretCredentials(t *testing.T) {
+	installFakeGit(t, `if [ "$2" != "https://x-access-token:ghp-secret@github.com/org/private.git" ]; then
+  printf 'unexpected URL: %s\n' "$2" >&2
+  exit 1
+fi
+printf '0123456789abcdef0123456789abcdef01234567\trefs/heads/main\n'
+`)
+	resolver := &fakeSecretResolver{values: map[string]secret.SensitiveValue{
+		"username": secret.NewSensitiveValue([]byte("x-access-token")),
+		"password": secret.NewSensitiveValue([]byte("ghp-secret")),
+	}}
+	source := NewSource(NewSecretCredentialResolver(resolver))
+
+	got, err := source.Pin(t.Context(), "team-a", &v1alpha1.Repository{
+		URL:            "https://github.com/org/private.git",
+		Branch:         "main",
+		CredentialsRef: &v1alpha1.LocalSecretReference{Name: "github"},
+	})
+	if err != nil {
+		t.Fatalf("pin private repository: %v", err)
+	}
+	if got != "0123456789abcdef0123456789abcdef01234567" {
+		t.Fatalf("commit = %q, want fake Git commit", got)
+	}
+	if resolver.ref != (v1alpha1.SecretRef{Namespace: "team-a", Name: "github"}) {
+		t.Fatalf("secret ref = %#v, want namespace-local reference", resolver.ref)
+	}
+}
+
+func repositoryWithCredentials(name string) *v1alpha1.Repository {
+	return &v1alpha1.Repository{
+		CredentialsRef: &v1alpha1.LocalSecretReference{Name: name},
+	}
+}
+
+func userinfoString(value *url.Userinfo) string {
+	if value == nil {
+		return ""
+	}
+	return value.String()
+}

--- a/internal/cli/common/gitutil/gitutil.go
+++ b/internal/cli/common/gitutil/gitutil.go
@@ -3,6 +3,7 @@
 package gitutil
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -14,6 +15,8 @@ import (
 	"slices"
 	"strings"
 )
+
+const maxGitDiagnosticRunes = 4096
 
 var (
 	// ErrUnsupportedHost is returned for a web URL on a host whose layout is not
@@ -183,35 +186,73 @@ func CloneAndCopyContext(ctx context.Context, repoURL, branch, commit, subPath, 
 	cloneArgs = append(cloneArgs, cloneURL, tempDir)
 
 	gitCmd := exec.CommandContext(ctx, "git", cloneArgs...)
-	if verbose {
-		gitCmd.Stdout = os.Stdout
-		gitCmd.Stderr = os.Stderr
-	}
-	if err := gitCmd.Run(); err != nil {
-		return fmt.Errorf("clone repository %s: %w", safeURL, err)
+	output, err := runGitCommand(gitCmd, verbose)
+	if err != nil {
+		return gitCommandError("clone repository "+safeURL, err, output, cloneURL, safeURL, auth)
 	}
 
 	if commit != "" {
 		fetchCmd := exec.CommandContext(ctx, "git", "-C", tempDir, "fetch", "--depth", "1", "origin", commit)
-		if verbose {
-			fetchCmd.Stdout = os.Stdout
-			fetchCmd.Stderr = os.Stderr
-		}
-		if err := fetchCmd.Run(); err != nil {
-			return fmt.Errorf("fetch commit %s: %w", commit, err)
+		output, err := runGitCommand(fetchCmd, verbose)
+		if err != nil {
+			return gitCommandError("fetch commit "+commit, err, output, cloneURL, safeURL, auth)
 		}
 
 		checkoutCmd := exec.CommandContext(ctx, "git", "-C", tempDir, "checkout", "FETCH_HEAD")
-		if verbose {
-			checkoutCmd.Stdout = os.Stdout
-			checkoutCmd.Stderr = os.Stderr
-		}
-		if err := checkoutCmd.Run(); err != nil {
-			return fmt.Errorf("checkout commit %s: %w", commit, err)
+		output, err = runGitCommand(checkoutCmd, verbose)
+		if err != nil {
+			return gitCommandError("checkout commit "+commit, err, output, cloneURL, safeURL, auth)
 		}
 	}
 
 	return CopyRepoContents(tempDir, subPath, targetDir)
+}
+
+func runGitCommand(cmd *exec.Cmd, verbose bool) ([]byte, error) {
+	if !verbose {
+		return cmd.CombinedOutput()
+	}
+	var output bytes.Buffer
+	cmd.Stdout = io.MultiWriter(os.Stdout, &output)
+	cmd.Stderr = io.MultiWriter(os.Stderr, &output)
+	err := cmd.Run()
+	return output.Bytes(), err
+}
+
+func gitCommandError(action string, err error, output []byte, execURL, safeURL string, auth *url.Userinfo) error {
+	diagnostic := sanitizeGitDiagnostic(string(output), execURL, safeURL, auth)
+	if diagnostic == "" {
+		return fmt.Errorf("%s: %w", action, err)
+	}
+	return fmt.Errorf("%s: %w: %s", action, err, diagnostic)
+}
+
+func sanitizeGitDiagnostic(diagnostic, execURL, safeURL string, auth *url.Userinfo) string {
+	diagnostic = strings.ReplaceAll(diagnostic, execURL, safeURL)
+	if auth != nil {
+		diagnostic = strings.ReplaceAll(diagnostic, auth.String(), "xxxxx")
+		if password, ok := auth.Password(); ok {
+			diagnostic = redactCredential(diagnostic, password)
+		} else {
+			diagnostic = redactCredential(diagnostic, auth.Username())
+		}
+	}
+	diagnostic = strings.TrimSpace(diagnostic)
+	runes := []rune(diagnostic)
+	if len(runes) > maxGitDiagnosticRunes {
+		diagnostic = "..." + string(runes[len(runes)-maxGitDiagnosticRunes:])
+	}
+	return diagnostic
+}
+
+func redactCredential(value, credential string) string {
+	if credential == "" {
+		return value
+	}
+	for _, encoded := range []string{credential, url.PathEscape(credential), url.QueryEscape(credential)} {
+		value = strings.ReplaceAll(value, encoded, "xxxxx")
+	}
+	return value
 }
 
 // authenticate splices auth into a clone URL and returns it with a redacted
@@ -225,7 +266,9 @@ func authenticate(cloneURL string, auth *url.Userinfo) (execURL, safeURL string,
 		return "", "", fmt.Errorf("invalid clone URL: %w", err)
 	}
 	u.User = auth
-	return u.String(), u.Redacted(), nil
+	execURL = u.String()
+	u.User = url.User("xxxxx")
+	return execURL, u.String(), nil
 }
 
 // safeGitRef rejects a ref/branch/commit that git could mis-parse as a
@@ -282,9 +325,19 @@ func ResolveRefContext(ctx context.Context, repoURL, ref string, auth *url.Useri
 	if err != nil {
 		return "", err
 	}
-	out, err := exec.CommandContext(ctx, "git", "ls-remote", cloneURL, lsRef).Output()
+	cmd := exec.CommandContext(ctx, "git", "ls-remote", cloneURL, lsRef)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
 	if err != nil {
-		return "", fmt.Errorf("git ls-remote %s %q: %w", safeURL, lsRef, err)
+		return "", gitCommandError(
+			fmt.Sprintf("git ls-remote %s %q", safeURL, lsRef),
+			err,
+			stderr.Bytes(),
+			cloneURL,
+			safeURL,
+			auth,
+		)
 	}
 	sha := firstLSRemoteSHA(string(out), lsRef)
 	if sha == "" {

--- a/internal/cli/common/gitutil/resolve_test.go
+++ b/internal/cli/common/gitutil/resolve_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"net/url"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -110,6 +112,9 @@ func TestAuthenticate(t *testing.T) {
 	if strings.Contains(safeURL, "ghp_secret") {
 		t.Fatalf("safe URL = %q, must not carry the token", safeURL)
 	}
+	if safeURL != "https://xxxxx@github.com/org/repo.git" {
+		t.Fatalf("safe URL = %q, want all userinfo redacted", safeURL)
+	}
 }
 
 func TestResolveRefRedactsCredentialsInErrors(t *testing.T) {
@@ -125,6 +130,85 @@ func TestResolveRefRedactsCredentialsInErrors(t *testing.T) {
 	if strings.Contains(err.Error(), "ghp_secret") {
 		t.Fatalf("error leaks the token: %v", err)
 	}
+}
+
+func TestResolveRefIncludesRedactedStderr(t *testing.T) {
+	installFakeGit(t, `printf 'fatal: unable to access %s: authentication failed\n' "$2" >&2
+exit 128
+`)
+
+	_, err := ResolveRefContext(
+		context.Background(),
+		"https://github.com/org/private.git",
+		"main",
+		url.UserPassword("x-access-token", "ghp_secret"),
+	)
+	if err == nil {
+		t.Fatal("expected ls-remote to fail")
+	}
+	if !strings.Contains(err.Error(), "fatal: unable to access") || !strings.Contains(err.Error(), "authentication failed") {
+		t.Fatalf("error = %v, want Git stderr", err)
+	}
+	if strings.Contains(err.Error(), "ghp_secret") || strings.Contains(err.Error(), "x-access-token") {
+		t.Fatalf("error leaks credentials: %v", err)
+	}
+	if !strings.Contains(err.Error(), "https://xxxxx@github.com/org/private.git") {
+		t.Fatalf("error = %v, want redacted authenticated URL", err)
+	}
+}
+
+func TestCloneIncludesRedactedOutput(t *testing.T) {
+	installFakeGit(t, `printf 'fatal: clone failed for %s\n' "$*" >&2
+exit 128
+`)
+
+	err := CloneAndCopyContext(
+		context.Background(),
+		"https://github.com/org/private.git",
+		"main",
+		"",
+		"",
+		t.TempDir(),
+		false,
+		url.UserPassword("x-access-token", "ghp_secret"),
+	)
+	if err == nil {
+		t.Fatal("expected clone to fail")
+	}
+	if !strings.Contains(err.Error(), "fatal: clone failed") {
+		t.Fatalf("error = %v, want Git output", err)
+	}
+	if strings.Contains(err.Error(), "ghp_secret") || strings.Contains(err.Error(), "x-access-token") {
+		t.Fatalf("error leaks credentials: %v", err)
+	}
+	if !strings.Contains(err.Error(), "https://xxxxx@github.com/org/private.git") {
+		t.Fatalf("error = %v, want redacted authenticated URL", err)
+	}
+}
+
+func TestSanitizeGitDiagnosticBoundsOutputAndRedactsTokenOnlyAuth(t *testing.T) {
+	auth := url.User("ghp_secret")
+	diagnostic := strings.Repeat("x", maxGitDiagnosticRunes+100) + " ghp_secret"
+	got := sanitizeGitDiagnostic(diagnostic, "", "", auth)
+	if strings.Contains(got, "ghp_secret") {
+		t.Fatalf("diagnostic leaks token-only auth: %q", got)
+	}
+	if len([]rune(got)) > maxGitDiagnosticRunes+3 {
+		t.Fatalf("diagnostic length = %d, want at most %d", len([]rune(got)), maxGitDiagnosticRunes+3)
+	}
+	if !strings.HasPrefix(got, "...") {
+		t.Fatalf("diagnostic = %q, want truncation marker", got)
+	}
+}
+
+func installFakeGit(t *testing.T, body string) {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "git")
+	if err := os.WriteFile(path, []byte("#!/bin/sh\n"+body), 0o755); err != nil {
+		t.Fatalf("write fake git: %v", err)
+	}
+	t.Setenv("PATH", dir)
 }
 
 func TestSourceCredentialFailureIsWrapped(t *testing.T) {

--- a/internal/cli/common/gitutil/source.go
+++ b/internal/cli/common/gitutil/source.go
@@ -18,7 +18,7 @@ type Source struct {
 }
 
 // NewSource returns a Source that authenticates through credentials. A nil hook
-// (the OSS default) fetches anonymously, so private repositories fail.
+// fetches anonymously, so private repositories fail.
 func NewSource(credentials types.GitCredentialFunc) *Source {
 	return &Source{credentials: credentials}
 }
@@ -60,9 +60,8 @@ func (s *Source) Fetch(ctx context.Context, namespace string, repo *v1alpha1.Rep
 	return commit, nil
 }
 
-// auth looks up credentials for repo. A nil hook (OSS) or a nil result means
-// fetch anonymously. A lookup failure is retryable: a credential created after
-// the resource recovers on the next resync.
+// auth looks up credentials for repo. A nil hook or result means fetch
+// anonymously. Lookup failures are retried on the next resync.
 func (s *Source) auth(ctx context.Context, namespace string, repo *v1alpha1.Repository) (*url.Userinfo, error) {
 	if s == nil || s.credentials == nil {
 		return nil, nil

--- a/internal/registry/registry_app.go
+++ b/internal/registry/registry_app.go
@@ -129,7 +129,11 @@ func App(ctx context.Context, opts ...types.AppOptions) error {
 	// out of band of the API write — same pattern as the Deployment controller.
 	// One git source carries the credential hook for every consumer, so private
 	// repositories are configured in exactly one place.
-	gitSource := gitutil.NewSource(options.GitCredentials)
+	gitCredentials := options.GitCredentials
+	if gitCredentials == nil && secretStore != nil {
+		gitCredentials = gitutil.NewSecretCredentialResolver(secretResolver)
+	}
+	gitSource := gitutil.NewSource(gitCredentials)
 	pluginController, err := controller.NewPluginController(pool, stores, controller.PluginControllerDeps{Git: gitSource})
 	if err != nil {
 		return fmt.Errorf("create plugin controller: %w", err)

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -295,8 +295,8 @@ type AppOptions struct {
 	// reconciler admission/staging.
 	DeleteAdmission DeleteAdmission
 
-	// GitCredentials resolves Repository.CredentialsRef for source resolution.
-	// Nil (the default) fetches anonymously, so private repositories stay broken.
+	// GitCredentials overrides Secret-backed Repository.CredentialsRef resolution.
+	// Nil uses the registry's configured Secret store when available.
 	GitCredentials GitCredentialFunc
 
 	// ResolverWrapper decorates the shared ResourceRef resolver before route

--- a/test/e2e/private_git_sources_test.go
+++ b/test/e2e/private_git_sources_test.go
@@ -1,0 +1,201 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"text/template"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/agentregistry-dev/agentregistry/pkg/api/v1alpha1"
+)
+
+const (
+	privateGitFixtureName      = "git-fixture"
+	privateGitFixtureNamespace = "agentregistry"
+	privateGitInvalidPassword  = "invalid-e2e-token"
+)
+
+func TestPrivateGitCatalogSources(t *testing.T) {
+	t.Logf("Setting up private Git fixture %s/%s", privateGitFixtureNamespace, privateGitFixtureName)
+	requirePrivateGitFixture(t)
+
+	regURL := RegistryURL(t)
+	tmpDir := t.TempDir()
+	secretName := UniqueNameWithPrefix("e2e-git-creds")
+	invalidSecretName := UniqueNameWithPrefix("e2e-git-invalid-creds")
+	pluginAuthName := UniqueNameWithPrefix("e2e-plugin-auth")
+	pluginInvalidAuthName := UniqueNameWithPrefix("e2e-plugin-invalid-auth")
+	pluginAnonName := UniqueNameWithPrefix("e2e-plugin-anon")
+	skillAuthName := UniqueNameWithPrefix("e2e-skill-auth")
+	skillAnonName := UniqueNameWithPrefix("e2e-skill-anon")
+
+	path := renderPrivateGitSources(t, tmpDir, map[string]string{
+		"SecretName":            secretName,
+		"InvalidSecretName":     invalidSecretName,
+		"PluginAuthName":        pluginAuthName,
+		"PluginInvalidAuthName": pluginInvalidAuthName,
+		"PluginAnonName":        pluginAnonName,
+		"SkillAuthName":         skillAuthName,
+		"SkillAnonName":         skillAnonName,
+	})
+	t.Cleanup(func() {
+		t.Logf("Deleting private Git catalog resources from %s", path)
+		RunArctl(t, tmpDir, "delete", "-f", path)
+	})
+	t.Logf("Applying private Git catalog resources from %s", path)
+	RequireSuccess(t, RunArctl(t, tmpDir, "apply", "-f", path))
+
+	t.Logf("Verifying authenticated Plugin %q resolves the private source", pluginAuthName)
+	plugin, pluginRaw := waitForPluginReady(t, regURL, pluginAuthName, v1alpha1.ConditionTrue)
+	require.NotNil(t, plugin.Status.ResolvedSource, "plugin never recorded a resolved source: %s", pluginRaw)
+	require.Len(t, plugin.Status.ResolvedSource.Commit, 40)
+	require.NotNil(t, plugin.Status.Manifest)
+	assert.Equal(t, "private-plugin", plugin.Status.Manifest.Name)
+
+	t.Logf("Verifying authenticated Skill %q resolves the private source", skillAuthName)
+	skill, skillRaw := waitForSkillReady(t, regURL, skillAuthName, v1alpha1.ConditionTrue)
+	require.NotNil(t, skill.Status.ResolvedSource, "skill never recorded a resolved source: %s", skillRaw)
+	require.Len(t, skill.Status.ResolvedSource.Commit, 40)
+	assert.Equal(t, plugin.Status.ResolvedSource.Commit, skill.Status.ResolvedSource.Commit)
+
+	t.Logf("Verifying anonymous Plugin %q cannot resolve the private source", pluginAnonName)
+	pluginAnon, _ := waitForPluginReady(t, regURL, pluginAnonName, v1alpha1.ConditionFalse)
+	assert.Equal(t, "SourceUnresolvable", pluginAnon.Status.GetCondition("Ready").Reason)
+	t.Logf("Verifying anonymous Skill %q cannot resolve the private source", skillAnonName)
+	skillAnon, _ := waitForSkillReady(t, regURL, skillAnonName, v1alpha1.ConditionFalse)
+	assert.Equal(t, "SourceUnresolvable", skillAnon.Status.GetCondition("Ready").Reason)
+
+	t.Logf("Verifying failed authentication for Plugin %q redacts credentials", pluginInvalidAuthName)
+	pluginInvalidAuth, pluginInvalidAuthRaw := waitForPluginReady(
+		t,
+		regURL,
+		pluginInvalidAuthName,
+		v1alpha1.ConditionFalse,
+	)
+	invalidAuthCondition := pluginInvalidAuth.Status.GetCondition("Ready")
+	assert.Equal(t, "SourceUnresolvable", invalidAuthCondition.Reason)
+	assert.Contains(t, strings.ToLower(invalidAuthCondition.Message), "authentication failed")
+	assert.NotContains(t, pluginInvalidAuthRaw, privateGitInvalidPassword)
+	assert.Contains(t, pluginInvalidAuthRaw, "xxxxx")
+}
+
+func renderPrivateGitSources(t *testing.T, outputDir string, data map[string]string) string {
+	t.Helper()
+	manifest := privateGitTestdata("private_git_sources.yaml.tmpl")
+	tmpl, err := template.New(filepath.Base(manifest)).Option("missingkey=error").ParseFiles(manifest)
+	require.NoError(t, err)
+
+	var rendered bytes.Buffer
+	require.NoError(t, tmpl.Execute(&rendered, data))
+	return writeDeclarativeYAML(t, outputDir, "private-git-sources.yaml", rendered.String())
+}
+
+func waitForPluginReady(t *testing.T, regURL, name string, want v1alpha1.ConditionStatus) (*v1alpha1.Plugin, string) {
+	t.Helper()
+	var plugin *v1alpha1.Plugin
+	var raw string
+	deadline := time.Now().Add(2 * time.Minute)
+	for time.Now().Before(deadline) {
+		plugin, raw = getPrivateGitResource(t, regURL, "plugins", name, defaultArtifactTag, func() *v1alpha1.Plugin {
+			return &v1alpha1.Plugin{}
+		})
+		if plugin != nil && plugin.Status.GetCondition("Ready") != nil && plugin.Status.GetCondition("Ready").Status == want {
+			return plugin, raw
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	t.Fatalf("plugin %s never reached Ready=%s (last response: %s)", name, want, raw)
+	return nil, ""
+}
+
+func waitForSkillReady(t *testing.T, regURL, name string, want v1alpha1.ConditionStatus) (*v1alpha1.Skill, string) {
+	t.Helper()
+	var skill *v1alpha1.Skill
+	var raw string
+	deadline := time.Now().Add(2 * time.Minute)
+	for time.Now().Before(deadline) {
+		skill, raw = getPrivateGitResource(t, regURL, "skills", name, defaultArtifactTag, func() *v1alpha1.Skill {
+			return &v1alpha1.Skill{}
+		})
+		if skill != nil && skill.Status.GetCondition("Ready") != nil && skill.Status.GetCondition("Ready").Status == want {
+			return skill, raw
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	t.Fatalf("skill %s never reached Ready=%s (last response: %s)", name, want, raw)
+	return nil, ""
+}
+
+func getPrivateGitResource[T any](t *testing.T, regURL, resource, name, tag string, newObject func() *T) (*T, string) {
+	t.Helper()
+	resp := RegistryGet(t, resourceURL(regURL, resource, name, tag))
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	if resp.StatusCode != http.StatusOK {
+		return nil, string(body)
+	}
+	object := newObject()
+	require.NoError(t, json.Unmarshal(body, object))
+	return object, string(body)
+}
+
+func requirePrivateGitFixture(t *testing.T) {
+	t.Helper()
+	manifest := privateGitTestdata("private_git_fixture.yaml")
+	cmd := exec.Command("kubectl", "--context", e2eKubeContext, "apply", "-f", manifest)
+	out, err := cmd.CombinedOutput()
+	require.NoError(t, err, "apply private Git fixture: %s", string(out))
+
+	t.Cleanup(func() {
+		t.Logf("Deleting private Git fixture from %s", manifest)
+		cmd := exec.Command(
+			"kubectl", "--context", e2eKubeContext,
+			"delete", "-f", manifest,
+			"--ignore-not-found", "--wait=false",
+		)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Logf("delete private Git fixture: %v (output: %s)", err, string(out))
+		}
+	})
+
+	cmd = exec.Command(
+		"kubectl", "--context", e2eKubeContext,
+		"-n", privateGitFixtureNamespace,
+		"rollout", "status", "deployment/"+privateGitFixtureName,
+		"--timeout=120s",
+	)
+	out, err = cmd.CombinedOutput()
+	require.NoError(t, err, "private Git fixture never became ready: %s", string(out))
+
+	t.Logf("Waiting for private Git fixture Service endpoints")
+	cmd = exec.Command(
+		"kubectl", "--context", e2eKubeContext,
+		"-n", privateGitFixtureNamespace,
+		"wait", "--for=jsonpath={.subsets[0].addresses[0].ip}",
+		"endpoints/"+privateGitFixtureName,
+		"--timeout=120s",
+	)
+	out, err = cmd.CombinedOutput()
+	require.NoError(t, err, "private Git fixture Service has no ready endpoints: %s", string(out))
+}
+
+func privateGitTestdata(name string) string {
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		panic("resolve private Git testdata")
+	}
+	return filepath.Join(filepath.Dir(file), "testdata", name)
+}

--- a/test/e2e/testdata/private_git_fixture.yaml
+++ b/test/e2e/testdata/private_git_fixture.yaml
@@ -1,0 +1,104 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: git-fixture
+  namespace: agentregistry
+data:
+  htpasswd: |
+    git:$apr1$e2etest$UMVlrgHCOL949vUHSFgxm0
+  nginx.conf: |
+    events {}
+    http {
+      server {
+        listen 80;
+        auth_basic "git";
+        auth_basic_user_file /config/htpasswd;
+        location / {
+          include /etc/nginx/fastcgi_params;
+          fastcgi_param SCRIPT_FILENAME /usr/libexec/git-core/git-http-backend;
+          fastcgi_param GIT_PROJECT_ROOT /srv;
+          fastcgi_param GIT_HTTP_EXPORT_ALL 1;
+          fastcgi_param PATH_INFO $uri;
+          fastcgi_pass 127.0.0.1:9000;
+        }
+      }
+    }
+  seed.sh: |
+    set -eu
+    git init -q --bare /srv/acme/private.git
+    git init -q /tmp/work
+    cd /tmp/work
+    git config user.email e2e@example.com
+    git config user.name e2e
+    mkdir -p plugin/.claude-plugin skill
+    printf '{"name":"private-plugin","version":"1.0.0"}\n' > plugin/.claude-plugin/plugin.json
+    printf '%s\n' '---' 'name: private-skill' 'description: E2E private skill' '---' > skill/SKILL.md
+    git add -A
+    git commit -qm "e2e private catalog sources"
+    git branch -M main
+    git push -q /srv/acme/private.git main
+    git -C /srv/acme/private.git symbolic-ref HEAD refs/heads/main
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: git-fixture
+  namespace: agentregistry
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: git-fixture
+  template:
+    metadata:
+      labels:
+        app: git-fixture
+    spec:
+      volumes:
+        - name: repos
+          emptyDir: {}
+        - name: config
+          configMap:
+            name: git-fixture
+            defaultMode: 0755
+      initContainers:
+        - name: seed
+          image: alpine/git:v2.47.2
+          command: ["/bin/sh", "/config/seed.sh"]
+          volumeMounts:
+            - name: repos
+              mountPath: /srv
+            - name: config
+              mountPath: /config
+      containers:
+        - name: git-http
+          image: nginx:1.27-alpine
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -eu
+              apk add --no-cache fcgiwrap git git-daemon
+              fcgiwrap -s tcp:127.0.0.1:9000 &
+              exec nginx -c /config/nginx.conf -g 'daemon off;'
+          ports:
+            - containerPort: 80
+          readinessProbe:
+            tcpSocket:
+              port: 80
+          volumeMounts:
+            - name: repos
+              mountPath: /srv
+            - name: config
+              mountPath: /config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: git-fixture
+  namespace: agentregistry
+spec:
+  selector:
+    app: git-fixture
+  ports:
+    - port: 80
+      targetPort: 80

--- a/test/e2e/testdata/private_git_sources.yaml.tmpl
+++ b/test/e2e/testdata/private_git_sources.yaml.tmpl
@@ -1,0 +1,91 @@
+apiVersion: ar.dev/v1alpha1
+kind: Secret
+metadata:
+  name: {{ .SecretName }}
+spec:
+  type: Opaque
+  stringData:
+    username: git
+    password: s3cret-e2e-token
+---
+apiVersion: ar.dev/v1alpha1
+kind: Secret
+metadata:
+  name: {{ .InvalidSecretName }}
+spec:
+  type: Opaque
+  stringData:
+    username: git
+    password: invalid-e2e-token
+---
+apiVersion: ar.dev/v1alpha1
+kind: Plugin
+metadata:
+  name: {{ .PluginAuthName }}
+spec:
+  title: E2E Private Plugin
+  source:
+    type: git
+    git:
+      repository:
+        url: http://git-fixture.agentregistry.svc.cluster.local/acme/private.git
+        branch: main
+        subfolder: plugin
+        credentialsRef:
+          name: {{ .SecretName }}
+---
+apiVersion: ar.dev/v1alpha1
+kind: Plugin
+metadata:
+  name: {{ .PluginInvalidAuthName }}
+spec:
+  title: E2E Private Plugin Invalid Credentials
+  source:
+    type: git
+    git:
+      repository:
+        url: http://git-fixture.agentregistry.svc.cluster.local/acme/private.git
+        branch: main
+        subfolder: plugin
+        credentialsRef:
+          name: {{ .InvalidSecretName }}
+---
+apiVersion: ar.dev/v1alpha1
+kind: Plugin
+metadata:
+  name: {{ .PluginAnonName }}
+spec:
+  title: E2E Private Plugin Anonymous Control
+  source:
+    type: git
+    git:
+      repository:
+        url: http://git-fixture.agentregistry.svc.cluster.local/acme/private.git
+        branch: main
+        subfolder: plugin
+---
+apiVersion: ar.dev/v1alpha1
+kind: Skill
+metadata:
+  name: {{ .SkillAuthName }}
+spec:
+  title: E2E Private Skill
+  source:
+    repository:
+      url: http://git-fixture.agentregistry.svc.cluster.local/acme/private.git
+      branch: main
+      subfolder: skill
+      credentialsRef:
+        name: {{ .SecretName }}
+---
+apiVersion: ar.dev/v1alpha1
+kind: Skill
+metadata:
+  name: {{ .SkillAnonName }}
+spec:
+  title: E2E Private Skill Anonymous Control
+  source:
+    repository:
+      url: http://git-fixture.agentregistry.svc.cluster.local/acme/private.git
+      branch: main
+      subfolder: skill


### PR DESCRIPTION
# Description

Git-backed Plugin and Skill resources now resolve `Repository.credentialsRef`
through the configured namespace-local Secret store. Resources without a
credentials reference continue fetching anonymously, and Git failures include
sanitized diagnostics without persisting credential material.

Custom integrations can continue overriding credential resolution through
`AppOptions.GitCredentials`.

Fixes #650

# Change Type

/kind feature

# Changelog

```release-note
Plugin and Skill resources can now resolve private Git sources using namespace-local Secret credentials.
```

# Additional Notes

Functional coverage uses a local basic-auth Git fixture to verify authenticated
Plugin and Skill resolution, anonymous failures, commit pinning, Plugin manifest
ingestion, and credential redaction.

Focused validation:

- `go test -race ./internal/cli/common/gitutil -count=1`
- `go test -count=1 -v -tags=e2e -timeout 10m ./test/e2e -run '^TestPrivateGitCatalogSources$'`
