### PR TITLE
internal: Fix MCP catalog tool schemas

### DIFF
--- a/internal/mcp/registryserver/server.go
+++ b/internal/mcp/registryserver/server.go
@@ -121,6 +121,7 @@ func NewServer(
 	})
 	addKindTools(server, stores[v1alpha1.KindDeployment], kindTools[*v1alpha1.Deployment]{
 		Kind:       v1alpha1.KindDeployment,
+		Mutable:    true,
 		ListName:   "list_deployments",
 		GetName:    "get_deployment",
 		ListDesc:   "List deployments as v1alpha1 envelopes with optional namespace and substring-name filters.",
@@ -131,6 +132,7 @@ func NewServer(
 	})
 	addKindTools(server, stores[v1alpha1.KindRuntime], kindTools[*v1alpha1.Runtime]{
 		Kind:       v1alpha1.KindRuntime,
+		Mutable:    true,
 		ListName:   "list_runtimes",
 		GetName:    "get_runtime",
 		ListDesc:   "List runtimes as v1alpha1 envelopes with optional namespace and substring-name filters.",
@@ -148,9 +150,10 @@ func NewServer(
 // kindTools bundles the per-kind inputs the generic addKindTools helper
 // needs to register `list_X` + `get_X` for a v1alpha1 kind. Tool names
 // are explicit (not derived from Kind) because they are user-facing in
-// Claude — `list_servers` is kept, not renamed to `list_mcpservers`.
+// Claude - `list_servers` is kept, not renamed to `list_mcpservers`.
 type kindTools[T v1alpha1.Object] struct {
 	Kind     string
+	Mutable  bool
 	ListName string
 	GetName  string
 	ListDesc string
@@ -161,13 +164,8 @@ type kindTools[T v1alpha1.Object] struct {
 	ListFilter ListFilter
 }
 
-// Schemas are built here instead of letting the MCP SDK infer them because
-// the default inference maps json.RawMessage to a byte-array schema,
-// while at marshal time a RawMessage emits the raw JSON it holds (for
-// example status.details is a JSON object). Any envelope carrying a
-// populated RawMessage fails the SDK's output validation.
-// The override only applies to json.RawMessage. A named RawMessage wrapper
-// or a plain []byte field would need its own TypeSchemas entry.
+// Explicit schemas match custom JSON marshalers rather than their Go storage
+// shapes, which would reject valid structured tool output.
 func outputSchemaFor[T any]() *jsonschema.Schema {
 	rt := reflect.TypeFor[T]()
 	if rt.Kind() == reflect.Pointer {
@@ -177,6 +175,9 @@ func outputSchemaFor[T any]() *jsonschema.Schema {
 		TypeSchemas: map[reflect.Type]*jsonschema.Schema{
 			reflect.TypeFor[json.RawMessage](): {Types: []string{
 				"null", "boolean", "object", "array", "number", "string",
+			}},
+			reflect.TypeFor[v1alpha1.CommandsField](): {Types: []string{
+				"null", "object", "array", "string",
 			}},
 		},
 	})
@@ -193,11 +194,12 @@ func addKindTools[T v1alpha1.Object](server *mcp.Server, store *v1alpha1store.St
 	if store == nil {
 		return
 	}
-	mcp.AddTool(server, &mcp.Tool{
+	listTool := &mcp.Tool{
 		Name:         cfg.ListName,
 		Description:  cfg.ListDesc,
 		OutputSchema: outputSchemaFor[listOutput[T]](),
-	}, func(ctx context.Context, _ *mcp.CallToolRequest, args listInput) (*mcp.CallToolResult, listOutput[T], error) {
+	}
+	list := func(ctx context.Context, args listInput) (*mcp.CallToolResult, listOutput[T], error) {
 		raws, next, err := runList(ctx, store, cfg.Kind, cfg.Authorize, cfg.ListFilter, args)
 		if err != nil {
 			return nil, listOutput[T]{}, err
@@ -207,14 +209,39 @@ func addKindTools[T v1alpha1.Object](server *mcp.Server, store *v1alpha1store.St
 			return nil, listOutput[T]{}, err
 		}
 		return nil, listOutput[T]{Items: items, NextCursor: next, Count: len(items)}, nil
-	})
-	mcp.AddTool(server, &mcp.Tool{
+	}
+	if !cfg.Mutable {
+		mcp.AddTool(server, listTool, func(ctx context.Context, _ *mcp.CallToolRequest, args listInput) (*mcp.CallToolResult, listOutput[T], error) {
+			return list(ctx, args)
+		})
+	} else {
+		mcp.AddTool(server, listTool, func(ctx context.Context, _ *mcp.CallToolRequest, args mutableListInput) (*mcp.CallToolResult, listOutput[T], error) {
+			return list(ctx, listInput{
+				Namespace: args.Namespace,
+				Cursor:    args.Cursor,
+				Limit:     args.Limit,
+				Search:    args.Search,
+			})
+		})
+	}
+
+	getTool := &mcp.Tool{
 		Name:         cfg.GetName,
 		Description:  cfg.GetDesc,
 		OutputSchema: outputSchemaFor[T](),
-	}, func(ctx context.Context, _ *mcp.CallToolRequest, args getByRefInput) (*mcp.CallToolResult, T, error) {
-		return getEnvelope(ctx, store, cfg.Kind, cfg.Authorize, args, cfg.NewObj)
-	})
+	}
+	if !cfg.Mutable {
+		mcp.AddTool(server, getTool, func(ctx context.Context, _ *mcp.CallToolRequest, args getByRefInput) (*mcp.CallToolResult, T, error) {
+			return getEnvelope(ctx, store, cfg.Kind, cfg.Authorize, args, cfg.NewObj)
+		})
+	} else {
+		mcp.AddTool(server, getTool, func(ctx context.Context, _ *mcp.CallToolRequest, args getByNameInput) (*mcp.CallToolResult, T, error) {
+			return getEnvelope(ctx, store, cfg.Kind, cfg.Authorize, getByRefInput{
+				Namespace: args.Namespace,
+				Name:      args.Name,
+			}, cfg.NewObj)
+		})
+	}
 }
 
 // listInput is the shared shape for list_* tools. Search is a
@@ -225,13 +252,25 @@ type listInput struct {
 	Cursor    string `json:"cursor,omitempty"    doc:"Pagination cursor returned by a previous call"`
 	Limit     int    `json:"limit,omitempty"     doc:"Max items (1-100, default 30)"`
 	Search    string `json:"search,omitempty"    doc:"Case-insensitive substring filter on metadata.name"`
-	Tag       string `json:"tag,omitempty"       doc:"'latest' to return only the literal latest tag per (namespace, name); empty returns every tag"`
+	Tag       string `json:"tag,omitempty"       doc:"Exact tag; empty returns every tag"`
+}
+
+type mutableListInput struct {
+	Namespace string `json:"namespace,omitempty" doc:"Filter by namespace (empty = all namespaces)"`
+	Cursor    string `json:"cursor,omitempty"    doc:"Pagination cursor returned by a previous call"`
+	Limit     int    `json:"limit,omitempty"     doc:"Max items (1-100, default 30)"`
+	Search    string `json:"search,omitempty"    doc:"Case-insensitive substring filter on metadata.name"`
 }
 
 type getByRefInput struct {
 	Namespace string `json:"namespace,omitempty" doc:"Namespace (empty defaults to 'default')"`
 	Name      string `json:"name"                doc:"Resource name"    required:"true"`
 	Tag       string `json:"tag,omitempty"       doc:"Exact tag; empty or 'latest' returns the literal latest tag"`
+}
+
+type getByNameInput struct {
+	Namespace string `json:"namespace,omitempty" doc:"Namespace (empty defaults to 'default')"`
+	Name      string `json:"name"                doc:"Resource name"    required:"true"`
 }
 
 // listOutput is the generic envelope every list_* tool returns. Items
@@ -293,6 +332,8 @@ func runList(
 	tag := strings.TrimSpace(args.Tag)
 	if strings.EqualFold(tag, "latest") {
 		opts.LatestOnly = true
+	} else if tag != "" {
+		opts.Tag = tag
 	}
 	if listFilter != nil {
 		extraWhere, extraArgs, err := listFilter(ctx, resource.AuthorizeInput{Verb: "list", Kind: kind, Namespace: namespace})

--- a/internal/mcp/registryserver/server.go
+++ b/internal/mcp/registryserver/server.go
@@ -5,6 +5,11 @@
 // outputs are v1alpha1 envelopes (apiVersion/kind/metadata/spec/status).
 package registryserver
 
+// TODO(tim): Rename this package to internal/mcp/catalog to distinguish it
+// from the MCP Registry compatibility API.
+// TODO(tim): Replace NewServer's parallel maps with one per-kind configuration
+// so tool metadata and hooks are wired together.
+
 import (
 	"context"
 	"encoding/json"

--- a/internal/mcp/registryserver/server_integration_test.go
+++ b/internal/mcp/registryserver/server_integration_test.go
@@ -107,31 +107,6 @@ func TestMCPListServers_HappyPath(t *testing.T) {
 	assert.Equal(t, "Echo test server", gotOne.Spec.Description)
 }
 
-// seedMCPServer publishes one MCPServer so the authz-seam tests have a row to
-// include/exclude, and returns its namespace/name.
-func seedMCPServer(ctx context.Context, t *testing.T, stores map[string]*v1alpha1store.Store) (namespace, name string) {
-	t.Helper()
-	namespace, name = "default", "echo"
-	_, err := stores[v1alpha1.KindMCPServer].Upsert(ctx, &v1alpha1.MCPServer{
-		Metadata: v1alpha1.ObjectMeta{Namespace: namespace, Name: name},
-		Spec: v1alpha1.MCPServerSpec{
-			Description: "Echo test server",
-			Source: &v1alpha1.MCPServerSource{
-				Package: &v1alpha1.MCPPackage{
-					Origin: v1alpha1.MCPPackageOrigin{
-						Type:       v1alpha1.MCPPackageOriginTypeOCI,
-						Identifier: "ghcr.io/example/echo:1.0.0",
-						OCI:        &v1alpha1.MCPPackageOriginOCI{ServerName: "echo"},
-					},
-					Transport: v1alpha1.MCPTransport{Type: "stdio"},
-				},
-			},
-		},
-	})
-	require.NoError(t, err, "seed server")
-	return namespace, name
-}
-
 // TestRunList_Authz exercises the list read path's RBAC seam directly with fake
 // per-kind hooks: denial short-circuits, and Extra{Where+Args} reach the SQL query.
 func TestRunList_Authz(t *testing.T) {
@@ -187,6 +162,35 @@ func TestRunList_Authz(t *testing.T) {
 	})
 }
 
+func TestRunList_TagFilter(t *testing.T) {
+	ctx := context.Background()
+	pool := v1alpha1store.NewTestPool(t)
+	stores := v1alpha1store.NewStores(pool, v1alpha1store.TestSchemaRegistry())
+	store := stores[v1alpha1.KindAgent]
+
+	for _, tag := range []string{"latest", "v1", "v2"} {
+		_, err := store.Upsert(ctx, &v1alpha1.Agent{
+			Metadata: v1alpha1.ObjectMeta{Namespace: "default", Name: "test-agent", Tag: tag},
+			Spec:     v1alpha1.AgentSpec{Description: tag},
+		})
+		require.NoError(t, err)
+	}
+
+	rows, _, err := runList(ctx, store, v1alpha1.KindAgent, nil, nil, listInput{Tag: "v1"})
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	assert.Equal(t, "v1", rows[0].Metadata.Tag)
+
+	rows, _, err = runList(ctx, store, v1alpha1.KindAgent, nil, nil, listInput{Tag: "does-not-exist"})
+	require.NoError(t, err)
+	assert.Empty(t, rows)
+
+	rows, _, err = runList(ctx, store, v1alpha1.KindAgent, nil, nil, listInput{Tag: "LATEST"})
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	assert.Equal(t, "latest", rows[0].Metadata.Tag)
+}
+
 // TestGetEnvelope_Authz exercises the get read path's RBAC seam: denial
 // short-circuits before the fetch, a nil authorizer returns the object, and the
 // authorizer receives the get AuthorizeInput.
@@ -218,6 +222,31 @@ func TestGetEnvelope_Authz(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, resource.AuthorizeInput{Verb: "get", Kind: v1alpha1.KindMCPServer, Namespace: ns, Name: name}, got)
 	})
+}
+
+// seedMCPServer publishes one MCPServer so the authz-seam tests have a row to
+// include/exclude, and returns its namespace/name.
+func seedMCPServer(ctx context.Context, t *testing.T, stores map[string]*v1alpha1store.Store) (namespace, name string) {
+	t.Helper()
+	namespace, name = "default", "echo"
+	_, err := stores[v1alpha1.KindMCPServer].Upsert(ctx, &v1alpha1.MCPServer{
+		Metadata: v1alpha1.ObjectMeta{Namespace: namespace, Name: name},
+		Spec: v1alpha1.MCPServerSpec{
+			Description: "Echo test server",
+			Source: &v1alpha1.MCPServerSource{
+				Package: &v1alpha1.MCPPackage{
+					Origin: v1alpha1.MCPPackageOrigin{
+						Type:       v1alpha1.MCPPackageOriginTypeOCI,
+						Identifier: "ghcr.io/example/echo:1.0.0",
+						OCI:        &v1alpha1.MCPPackageOriginOCI{ServerName: "echo"},
+					},
+					Transport: v1alpha1.MCPTransport{Type: "stdio"},
+				},
+			},
+		},
+	})
+	require.NoError(t, err, "seed server")
+	return namespace, name
 }
 
 // envelopeMeta decodes just the identity of a v1alpha1 envelope, so one helper
@@ -339,6 +368,19 @@ func TestMCPCatalogTools(t *testing.T) {
 					Spec:     v1alpha1.PluginSpec{Description: "Test plugin"},
 				})
 				require.NoError(t, err, "seed plugin")
+				status := v1alpha1.PluginStatus{
+					Manifest: &v1alpha1.PluginManifest{
+						Commands: &v1alpha1.CommandsField{Map: map[string]v1alpha1.CommandEntry{
+							"docs": {Description: "Search documentation"},
+							"page": {Description: "Open a page"},
+						}},
+					},
+				}
+				statusJSON, err := json.Marshal(status)
+				require.NoError(t, err, "marshal plugin status")
+				require.NoError(t, stores[v1alpha1.KindPlugin].PatchStatus(ctx, namespace, name, taggedTag,
+					func(json.RawMessage) (json.RawMessage, error) { return statusJSON, nil },
+				), "seed plugin status")
 			},
 		},
 		{

--- a/internal/mcp/registryserver/server_test.go
+++ b/internal/mcp/registryserver/server_test.go
@@ -1,13 +1,18 @@
 package registryserver
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
+	"io"
 	"testing"
 
 	"github.com/google/jsonschema-go/jsonschema"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/require"
 
 	"github.com/agentregistry-dev/agentregistry/pkg/api/v1alpha1"
+	"github.com/agentregistry-dev/agentregistry/pkg/registry/v1alpha1store"
 )
 
 // A populated status.details is the trigger for the RawMessage schema
@@ -47,5 +52,95 @@ func TestOutputSchemaFor_AcceptsPopulatedRawMessage(t *testing.T) {
 			require.NoError(t, json.Unmarshal(raw, &decoded))
 			require.NoError(t, resolved.Validate(decoded))
 		})
+	}
+}
+
+func TestOutputSchemaFor_AcceptsPluginCommands(t *testing.T) {
+	p := &v1alpha1.Plugin{
+		Metadata: v1alpha1.ObjectMeta{Namespace: "default", Name: "test-plugin"},
+		Status: v1alpha1.PluginStatus{
+			Manifest: &v1alpha1.PluginManifest{
+				Commands: &v1alpha1.CommandsField{Map: map[string]v1alpha1.CommandEntry{
+					"docs": {Description: "Search documentation"},
+					"page": {Description: "Open a page"},
+				}},
+			},
+		},
+	}
+
+	cases := map[string]struct {
+		schema *jsonschema.Schema
+		value  any
+	}{
+		"list": {
+			schema: outputSchemaFor[listOutput[*v1alpha1.Plugin]](),
+			value:  listOutput[*v1alpha1.Plugin]{Items: []*v1alpha1.Plugin{p}, Count: 1},
+		},
+		"get": {
+			schema: outputSchemaFor[*v1alpha1.Plugin](),
+			value:  p,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			resolved, err := tc.schema.Resolve(nil)
+			require.NoError(t, err)
+			raw, err := json.Marshal(tc.value)
+			require.NoError(t, err)
+			var decoded any
+			require.NoError(t, json.Unmarshal(raw, &decoded))
+			require.NoError(t, resolved.Validate(decoded))
+		})
+	}
+}
+
+func TestMutableToolSchemasOmitTag(t *testing.T) {
+	ctx := context.Background()
+	stores := map[string]*v1alpha1store.Store{
+		v1alpha1.KindAgent:      {},
+		v1alpha1.KindDeployment: {},
+		v1alpha1.KindRuntime:    {},
+	}
+	server := NewServer(stores, nil, nil)
+	clientTransport, serverTransport := mcp.NewInMemoryTransports()
+
+	serverSession, err := server.Connect(ctx, serverTransport, nil)
+	require.NoError(t, err)
+	defer func() {
+		err := serverSession.Wait()
+		if err != nil && !errors.Is(err, io.ErrClosedPipe) && !errors.Is(err, io.EOF) {
+			require.NoError(t, err)
+		}
+	}()
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "v0.0.1"}, nil)
+	clientSession, err := client.Connect(ctx, clientTransport, nil)
+	require.NoError(t, err)
+	defer func() { _ = clientSession.Close() }()
+
+	result, err := clientSession.ListTools(ctx, nil)
+	require.NoError(t, err)
+	tools := make(map[string]*mcp.Tool, len(result.Tools))
+	for _, tool := range result.Tools {
+		tools[tool.Name] = tool
+	}
+
+	for _, name := range []string{"list_agents", "get_agent"} {
+		raw, err := json.Marshal(tools[name].InputSchema)
+		require.NoError(t, err)
+		var schema struct {
+			Properties map[string]json.RawMessage `json:"properties"`
+		}
+		require.NoError(t, json.Unmarshal(raw, &schema))
+		require.Contains(t, schema.Properties, "tag", name)
+	}
+	for _, name := range []string{"list_deployments", "get_deployment", "list_runtimes", "get_runtime"} {
+		raw, err := json.Marshal(tools[name].InputSchema)
+		require.NoError(t, err)
+		var schema struct {
+			Properties map[string]json.RawMessage `json:"properties"`
+		}
+		require.NoError(t, json.Unmarshal(raw, &schema))
+		require.NotContains(t, schema.Properties, "tag", name)
 	}
 }


### PR DESCRIPTION
# Description

Fix MCP catalog tool schemas and filtering so structured plugin output, exact
tags, and mutable resource inputs match the public tool contract.

Plugin command maps now validate against their JSON wire shape. Tagged list
tools forward exact tags to storage while preserving `latest`, and Runtime and
Deployment list/get schemas no longer advertise tags.

# Change Type

/kind fix

# Changelog

```release-note
MCP clients can now read plugins that define commands and reliably filter catalog resources by tag, while runtime and deployment tools no longer offer unsupported tag filters.
```

# Additional Notes

Validated with:

- `go test ./internal/mcp/registryserver`
- `go test -tags=integration ./internal/mcp/registryserver`

Follow-up functional coverage is tracked in #656.
