### PR TITLE
chore: reduce unnecessary tooling in the server image

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -57,7 +57,7 @@ services:
       postgres:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "curl", "--fail", "--silent", "--show-error", "http://localhost:8080/v0/ping"]
+      test: ["CMD-SHELL", "exec 3<>/dev/tcp/localhost/8080"]
       interval: 5s
       timeout: 2s
       retries: 12

--- a/docker/server.Dockerfile
+++ b/docker/server.Dockerfile
@@ -14,9 +14,6 @@ RUN make build-ui
 ARG BUILDPLATFORM
 FROM --platform=$BUILDPLATFORM golang:1.26-alpine AS builder
 
-# alpine install make
-RUN apk add --no-cache make
-
 WORKDIR /app
 
 COPY go.mod go.sum ./
@@ -41,7 +38,6 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -ldfl
 FROM ubuntu:22.04 AS runtime
 
 RUN apt-get update && apt-get install -y \
-    curl \
     git \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Summary

Per #659: the server Dockerfile installs `make` in the Go builder even though it invokes `go build` directly, and the runtime installs `curl` only for the local Docker Compose health check.

## Changes

- `docker/server.Dockerfile`:
  - removed `apk add make` from the Go builder (kept in the ui-builder, where `make build-ui` uses it)
  - removed `curl` from the runtime image (kept `git`)
- `docker/docker-compose.yml`:
  - replaced the curl HTTP health check with a TCP-based check (`exec 3<>/dev/tcp/localhost/8080`), matching the Helm chart probes — no `curl` needed

## Verification

- Dockerfile: builder no longer installs make; runtime no longer installs curl
- Compose: health check is shell-builtin TCP, no external binary required
- Not built locally (no Docker env here); changes are minimal and follow the issue's remediation exactly