### PR TITLE
docker: reduce unnecessary server image tooling

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -57,7 +57,7 @@ services:
       postgres:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "curl", "--fail", "--silent", "--show-error", "http://localhost:8080/v0/ping"]
+      test: ["CMD", "bash", "-c", "</dev/tcp/127.0.0.1/8080"]
       interval: 5s
       timeout: 2s
       retries: 12

--- a/docker/server.Dockerfile
+++ b/docker/server.Dockerfile
@@ -14,9 +14,6 @@ RUN make build-ui
 ARG BUILDPLATFORM
 FROM --platform=$BUILDPLATFORM golang:1.26-alpine AS builder
 
-# alpine install make
-RUN apk add --no-cache make
-
 WORKDIR /app
 
 COPY go.mod go.sum ./
@@ -41,7 +38,6 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -ldfl
 FROM ubuntu:22.04 AS runtime
 
 RUN apt-get update && apt-get install -y \
-    curl \
     git \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
# Description

Remove unnecessary tooling from the server image:

- stop installing `make` in the Go builder, which invokes `go build` directly;
- stop installing `curl` in the runtime image;
- replace the Docker Compose HTTP health check with a TCP check using Bash's `/dev/tcp`, matching the Helm chart probes.

Alternative implementation to #660. This version preserves the existing line endings, invokes Bash explicitly for `/dev/tcp`, and has been validated end to end with Docker Compose.

Fixes #659

# Change Type

/kind cleanup

# Changelog

```release-note
NONE
```

# Additional Notes

Validated by:

- building the complete server image;
- confirming `git` and `bash` remain available while `curl` and `make` are absent from the runtime;
- starting the Docker Compose stack and waiting for both PostgreSQL and AgentRegistry to become healthy;
- verifying `/v0/ping` returns `{"pong":true}`;
- confirming the TCP check fails when no process is listening.