### PR TITLE
chore(docker): slim server image

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -57,7 +57,7 @@ services:
       postgres:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "curl", "--fail", "--silent", "--show-error", "http://localhost:8080/v0/ping"]
+      test: ["CMD-SHELL", "bash -c 'true < /dev/tcp/localhost/8080'"]
       interval: 5s
       timeout: 2s
       retries: 12

--- a/docker/server.Dockerfile
+++ b/docker/server.Dockerfile
@@ -14,9 +14,6 @@ RUN make build-ui
 ARG BUILDPLATFORM
 FROM --platform=$BUILDPLATFORM golang:1.26-alpine AS builder
 
-# alpine install make
-RUN apk add --no-cache make
-
 WORKDIR /app
 
 COPY go.mod go.sum ./
@@ -39,11 +36,6 @@ ARG LDFLAGS
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -ldflags "$LDFLAGS" -o bin/arctl-server cmd/server/main.go
 
 FROM ubuntu:22.04 AS runtime
-
-RUN apt-get update && apt-get install -y \
-    curl \
-    git \
-    && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /app/bin/arctl-server /app/bin/arctl-server
 


### PR DESCRIPTION
# Description

Fixes #659.

The Go builder invokes `go build` directly, so it no longer installs `make`. The runtime image no longer installs `curl` or `git`. The UI builder remains unchanged because it runs `make build-ui`.

Docker Compose now uses a TCP health check for port 8080, matching the Helm chart probes without requiring an HTTP client in the runtime image.

# Change Type

/kind cleanup

# Changelog

```release-note
NONE
```

# Additional Notes

Validation:

- `make test-unit`
- focused ping and router package tests
- static assertions that the runtime and Compose configuration no longer reference curl or git, while the UI builder retains make

Docker is not installed in this environment, so an image build was not run locally.