### PR TITLE
runtime: support managed reconciliation lifecycle

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v1.43.0
 	golang.org/x/mod v0.36.0
 	golang.org/x/term v0.44.0
+	golang.org/x/time v0.15.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.35.3
 	k8s.io/apimachinery v0.35.3
@@ -125,7 +126,6 @@ require (
 	golang.org/x/sync v0.21.0 // indirect
 	golang.org/x/sys v0.46.0 // indirect
 	golang.org/x/text v0.38.0 // indirect
-	golang.org/x/time v0.15.0 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect

--- a/internal/cli/commands/declarative.go
+++ b/internal/cli/commands/declarative.go
@@ -101,7 +101,7 @@ func init() {
 	scheme.Register(
 		mutableTypedKind(
 			"runtime", "runtimes", []string{"Runtime"},
-			[]scheme.Column{{Header: "NAME"}, {Header: "TYPE"}},
+			[]scheme.Column{{Header: "NAME"}, {Header: "TYPE"}, {Header: "STATUS"}},
 			v1alpha1.KindRuntime,
 			func() *v1alpha1.Runtime { return &v1alpha1.Runtime{} },
 			runtimeRow,

--- a/internal/cli/commands/resources.go
+++ b/internal/cli/commands/resources.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	cliCommon "github.com/agentregistry-dev/agentregistry/internal/cli/common"
 	"github.com/agentregistry-dev/agentregistry/internal/cli/scheme"
 	"github.com/agentregistry-dev/agentregistry/internal/client"
 	"github.com/agentregistry-dev/agentregistry/pkg/api/v1alpha1"
 	"github.com/agentregistry-dev/agentregistry/pkg/printer"
+	statusapi "github.com/agentregistry-dev/agentregistry/pkg/status"
 )
 
 // listAny lists rows of the given kind. The zero scheme.ListOpts returns
@@ -209,7 +211,37 @@ func runtimeRow(runtime *v1alpha1.Runtime) []string {
 	if runtime == nil {
 		return []string{"<invalid>"}
 	}
-	return []string{runtime.Metadata.Name, runtime.Spec.Type}
+	return []string{runtime.Metadata.Name, runtime.Spec.Type, runtimeStatus(runtime)}
+}
+
+// Runtime status labels are CLI presentation values rather than API condition
+// values. Keeping them here prevents callers from treating display text as a
+// lifecycle contract.
+const (
+	runtimeStatusTerminating = "terminating"
+	runtimeStatusPending     = "pending"
+	runtimeStatusReady       = "ready"
+	runtimeStatusNotReady    = "not ready"
+)
+
+// runtimeStatus reduces Runtime lifecycle conditions to a table-friendly value.
+// A missing Ready condition is pending; an explicit False without a reason is
+// not ready, while a deletion timestamp always takes precedence as terminating.
+func runtimeStatus(runtime *v1alpha1.Runtime) string {
+	if runtime.Metadata.DeletionTimestamp != nil {
+		return runtimeStatusTerminating
+	}
+	ready := runtime.Status.GetCondition(statusapi.ConditionTypeReady)
+	if ready == nil {
+		return runtimeStatusPending
+	}
+	if ready.Status == v1alpha1.ConditionTrue {
+		return runtimeStatusReady
+	}
+	if ready.Reason != "" {
+		return strings.ToLower(ready.Reason)
+	}
+	return runtimeStatusNotReady
 }
 
 func modelRow(model *v1alpha1.Model) []string {

--- a/internal/cli/commands/runtime_get_test.go
+++ b/internal/cli/commands/runtime_get_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/agentregistry-dev/agentregistry/internal/cli/commands"
 	"github.com/agentregistry-dev/agentregistry/pkg/api/v1alpha1"
+	statusapi "github.com/agentregistry-dev/agentregistry/pkg/status"
 )
 
 // runtimeTestServer builds an httptest.Server that serves:
@@ -102,6 +103,7 @@ func TestRuntimeGet_TableOutput(t *testing.T) {
 	runtimes := []v1alpha1.Runtime{
 		runtimeFixture("my-kagent", "Kagent", nil),
 	}
+	runtimes[0].Status.SetCondition(v1alpha1.Condition{Type: statusapi.ConditionTypeReady, Status: v1alpha1.ConditionTrue})
 	srv := runtimeTestServer(t, runtimes)
 	setupClientForServer(t, srv)
 
@@ -114,6 +116,8 @@ func TestRuntimeGet_TableOutput(t *testing.T) {
 	got := out.String()
 	assert.Contains(t, got, "my-kagent")
 	assert.Contains(t, got, "Kagent")
+	assert.Contains(t, got, "STATUS")
+	assert.Contains(t, got, "ready")
 }
 
 func TestRuntimeGet_ReturnsMatchByNamespaceName(t *testing.T) {

--- a/internal/registry/api/handlers/v0/crud/crud.go
+++ b/internal/registry/api/handlers/v0/crud/crud.go
@@ -84,20 +84,21 @@ func Register(
 			return resource.Config{}, false
 		}
 		return resource.Config{
-			Kind:               kind,
-			BasePrefix:         basePrefix,
-			Store:              store,
-			Resolver:           resolver,
-			RegistryValidator:  registryValidator,
-			Authorize:          perKind.Authorizers[kind],
-			ListFilter:         perKind.ListFilters[kind],
-			EnableOriginFilter: kind == v1alpha1.KindDeployment,
-			PostUpsert:         perKind.PostUpserts[kind],
-			PostDelete:         perKind.PostDeletes[kind],
-			Prepare:            perKind.Prepares[kind],
-			OnUpsertError:      perKind.OnUpsertErrors[kind],
-			DeleteAdmission:    deleteAdmission,
-			InitialFinalizers:  perKind.InitialFinalizers[kind],
+			Kind:                        kind,
+			BasePrefix:                  basePrefix,
+			Store:                       store,
+			Resolver:                    resolver,
+			RegistryValidator:           registryValidator,
+			Authorize:                   perKind.Authorizers[kind],
+			ListFilter:                  perKind.ListFilters[kind],
+			EnableOriginFilter:          kind == v1alpha1.KindDeployment,
+			IncludeTerminatingByDefault: kind == v1alpha1.KindRuntime,
+			PostUpsert:                  perKind.PostUpserts[kind],
+			PostDelete:                  perKind.PostDeletes[kind],
+			Prepare:                     perKind.Prepares[kind],
+			OnUpsertError:               perKind.OnUpsertErrors[kind],
+			DeleteAdmission:             deleteAdmission,
+			InitialFinalizers:           perKind.InitialFinalizers[kind],
 		}, true
 	}
 

--- a/internal/registry/api/handlers/v0/crud/model_crud_test.go
+++ b/internal/registry/api/handlers/v0/crud/model_crud_test.go
@@ -3,6 +3,7 @@
 package crud_test
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"strings"
@@ -108,4 +109,40 @@ func TestModelCRUD(t *testing.T) {
 	require.Equal(t, http.StatusNotFound, resp.Code, resp.Body.String())
 	resp = api.Get("/v0/models/claude-opus")
 	require.Equal(t, http.StatusOK, resp.Code, resp.Body.String())
+}
+
+func TestRuntimeCRUDShowsTerminatingRuntime(t *testing.T) {
+	pool := v1alpha1store.NewTestPool(t)
+	stores := v1alpha1store.NewStores(pool, v1alpha1store.TestSchemaRegistry())
+	_, api := humatest.New(t)
+	crud.Register(api, "/v0", stores, nil, nil, crud.PerKindHooks{
+		InitialFinalizers: map[string]func(v1alpha1.Object) []string{
+			v1alpha1.KindRuntime: func(v1alpha1.Object) []string { return []string{"test/finalizer"} },
+		},
+	}, nil)
+	runtime := v1alpha1.Runtime{
+		TypeMeta: v1alpha1.TypeMeta{APIVersion: v1alpha1.GroupVersion, Kind: v1alpha1.KindRuntime},
+		Metadata: v1alpha1.ObjectMeta{Namespace: "default", Name: "terminating-runtime"},
+		Spec:     v1alpha1.RuntimeSpec{Type: "Test"},
+	}
+	_, err := stores[v1alpha1.KindRuntime].Upsert(context.Background(), &runtime, v1alpha1store.UpsertOpts{
+		InitialFinalizers: []string{"test/finalizer"},
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusNoContent, api.Delete("/v0/runtimes/terminating-runtime").Code)
+
+	resp := api.Get("/v0/runtimes/terminating-runtime")
+	require.Equal(t, http.StatusOK, resp.Code, resp.Body.String())
+	var got v1alpha1.Runtime
+	require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &got))
+	require.NotNil(t, got.Metadata.DeletionTimestamp)
+
+	resp = api.Get("/v0/runtimes")
+	require.Equal(t, http.StatusOK, resp.Code, resp.Body.String())
+	var list struct {
+		Items []v1alpha1.Runtime `json:"items"`
+	}
+	require.NoError(t, json.Unmarshal(resp.Body.Bytes(), &list))
+	require.Len(t, list.Items, 1)
+	require.NotNil(t, list.Items[0].Metadata.DeletionTimestamp)
 }

--- a/internal/registry/controller/controller.go
+++ b/internal/registry/controller/controller.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"time"
 
+	"golang.org/x/time/rate"
 	"k8s.io/client-go/util/workqueue"
 
 	"github.com/agentregistry-dev/agentregistry/pkg/api/v1alpha1"
@@ -18,6 +19,8 @@ import (
 const (
 	defaultControllerEventBatchLimit = 500
 	defaultControllerListPageSize    = 500
+	defaultControllerRetryBase       = 2 * time.Second
+	defaultControllerRetryMax        = time.Minute
 )
 
 // ErrControllerNotReady is returned until Refresh completes successfully.
@@ -47,6 +50,9 @@ type DeploymentController struct {
 	// DependencyKinds extends the built-in resource kinds whose durable events
 	// requeue Deployments. Fingerprint gating prevents unchanged adapter work.
 	DependencyKinds map[string]bool
+	// DeploymentFinalized runs after required provider cleanup, finalizer removal,
+	// and row purge. It wakes owners whose cleanup is gated on child removal.
+	DeploymentFinalized func(context.Context, *v1alpha1.Deployment)
 
 	mu         sync.RWMutex
 	checkpoint int64
@@ -402,11 +408,25 @@ func (c *DeploymentController) workQueue() workqueue.TypedRateLimitingInterface[
 	defer c.queueMu.Unlock()
 	if c.Queue == nil {
 		c.Queue = workqueue.NewTypedRateLimitingQueueWithConfig(
-			workqueue.DefaultTypedControllerRateLimiter[deploymentQueueKey](),
+			deploymentRateLimiter(),
 			workqueue.TypedRateLimitingQueueConfig[deploymentQueueKey]{Name: "deployment-controller"},
 		)
 	}
 	return c.Queue
+}
+
+// deploymentRateLimiter avoids the millisecond retries used by the client-go
+// default, which can repeatedly call slow or eventually consistent providers.
+// Each Deployment backs off from two seconds to one minute, the token bucket
+// limits aggregate bursts, and the outer limiter caps every computed delay.
+func deploymentRateLimiter() workqueue.TypedRateLimiter[deploymentQueueKey] {
+	limiter := workqueue.NewTypedMaxOfRateLimiter(
+		workqueue.NewTypedItemExponentialFailureRateLimiter[deploymentQueueKey](
+			defaultControllerRetryBase, defaultControllerRetryMax,
+		),
+		&workqueue.TypedBucketRateLimiter[deploymentQueueKey]{Limiter: rate.NewLimiter(rate.Limit(10), 100)},
+	)
+	return workqueue.NewTypedWithMaxWaitRateLimiter(limiter, defaultControllerRetryMax)
 }
 
 func (c *DeploymentController) markReady(checkpoint int64) {

--- a/internal/registry/controller/controller_test.go
+++ b/internal/registry/controller/controller_test.go
@@ -3,12 +3,24 @@ package controller
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/agentregistry-dev/agentregistry/pkg/api/v1alpha1"
 	"github.com/agentregistry-dev/agentregistry/pkg/registry/v1alpha1store"
 )
+
+func TestDeploymentRateLimiterCapsRetriesAtOneMinute(t *testing.T) {
+	limiter := deploymentRateLimiter()
+	key := deploymentQueueKey{Namespace: "default", Name: "deployment"}
+
+	require.Equal(t, 2*time.Second, limiter.When(key))
+	for range 20 {
+		require.LessOrEqual(t, limiter.When(key), time.Minute)
+	}
+	require.Equal(t, time.Minute, limiter.When(key))
+}
 
 func TestDeploymentControllerSyncReplaysIgnoredEvents(t *testing.T) {
 	reader := fakeEventReader{

--- a/internal/registry/controller/reconciler.go
+++ b/internal/registry/controller/reconciler.go
@@ -130,7 +130,7 @@ func (c *DeploymentController) apply(ctx context.Context, deployment *v1alpha1.D
 }
 
 func (c *DeploymentController) remove(ctx context.Context, deployment *v1alpha1.Deployment) (string, string, error) {
-	runtime, err := c.resolveRuntime(ctx, deployment)
+	runtime, err := c.resolveRuntimeIncludingTerminating(ctx, deployment)
 	if err != nil {
 		return c.handleRemoveRuntimeError(ctx, deployment, err)
 	}
@@ -154,6 +154,37 @@ func (c *DeploymentController) remove(ctx context.Context, deployment *v1alpha1.
 		}
 	}
 	return "success", "deployment removed", nil
+}
+
+// resolveRuntimeIncludingTerminating keeps the parent Runtime available after
+// its deletion is accepted. Deployment removal still needs that Runtime to
+// select and configure the provider responsible for child cleanup; filtering
+// terminating rows would orphan the provider resources. A truly absent parent
+// falls through to the existing dangling-reference finalization path.
+func (c *DeploymentController) resolveRuntimeIncludingTerminating(
+	ctx context.Context,
+	deployment *v1alpha1.Deployment,
+) (*v1alpha1.Runtime, error) {
+	store := c.Stores[v1alpha1.KindRuntime]
+	if store == nil {
+		return nil, errors.New("deployment controller: no Runtime store registered")
+	}
+	ref := deployment.Spec.RuntimeRef
+	ref.Namespace = refNamespace(ref.Namespace, deployment.Metadata.NamespaceOrDefault())
+	raw, err := store.GetLatestIncludingTerminating(ctx, ref.Namespace, ref.Name)
+	if err != nil {
+		if errors.Is(err, pkgdb.ErrNotFound) {
+			return nil, v1alpha1.ErrDanglingRef
+		}
+		return nil, fmt.Errorf("resolve runtimeRef %s/%s: %w", ref.Namespace, ref.Name, err)
+	}
+	runtime, err := v1alpha1.EnvelopeFromRaw(func() *v1alpha1.Runtime {
+		return &v1alpha1.Runtime{}
+	}, raw, v1alpha1.KindRuntime)
+	if err != nil {
+		return nil, fmt.Errorf("resolve runtimeRef %s/%s: %w", ref.Namespace, ref.Name, err)
+	}
+	return runtime, nil
 }
 
 func (c *DeploymentController) handleRemoveRuntimeError(
@@ -353,6 +384,9 @@ func (c *DeploymentController) finalizeDeletedDeployment(ctx context.Context, de
 	}
 	if _, err := c.deploymentStore().PurgeFinalized(ctx); err != nil {
 		return fmt.Errorf("purge finalized deployment: %w", err)
+	}
+	if c.DeploymentFinalized != nil {
+		c.DeploymentFinalized(ctx, deployment)
 	}
 	return nil
 }

--- a/internal/registry/controller/reconciler_integration_test.go
+++ b/internal/registry/controller/reconciler_integration_test.go
@@ -322,7 +322,7 @@ func TestDeploymentController_RemoveFailureKeepsFinalizerAndRetries(t *testing.T
 	require.Eventually(t, func() bool {
 		processed, err = controller.RunOnce(ctx)
 		return err == nil && adapter.removeCalls.Load() == 2
-	}, time.Second, 10*time.Millisecond)
+	}, 3*time.Second, 10*time.Millisecond)
 
 	requireDeploymentMissing(t, stores, deployment.Metadata.Name)
 }
@@ -388,6 +388,29 @@ func TestDeploymentController_DeleteFinalizesWhenRuntimeRefMissing(t *testing.T)
 	require.NoError(t, err)
 	require.Equal(t, 1, processed)
 	require.Zero(t, adapter.removeCalls.Load(), "missing runtime cannot dispatch adapter remove")
+	requireDeploymentMissing(t, stores, deployment.Metadata.Name)
+}
+
+func TestDeploymentController_DeleteUsesTerminatingRuntime(t *testing.T) {
+	ctx := context.Background()
+	stores := newControllerTestStores(t)
+	seedMCPServer(t, stores, "weather")
+	deployment := seedDeployment(t, stores, "delete-with-runtime", v1alpha1.DesiredStateDeployed)
+	require.NoError(t, stores[v1alpha1.KindRuntime].PatchFinalizers(ctx, "default", "test-runtime", "", func([]string) []string {
+		return []string{"test-runtime-finalizer"}
+	}))
+	require.NoError(t, stores[v1alpha1.KindRuntime].Delete(ctx, "default", "test-runtime", ""))
+	require.NoError(t, stores[v1alpha1.KindDeployment].Delete(ctx, "default", deployment.Metadata.Name, ""))
+
+	adapter := &recordingDeploymentAdapter{}
+	controller := newDeploymentTestController(stores, adapter)
+	_, err := controller.FullReconcile(ctx)
+	require.NoError(t, err)
+
+	processed, err := controller.RunOnce(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 1, processed)
+	require.Equal(t, int32(1), adapter.removeCalls.Load())
 	requireDeploymentMissing(t, stores, deployment.Metadata.Name)
 }
 

--- a/internal/registry/controller/runner.go
+++ b/internal/registry/controller/runner.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	internaldb "github.com/agentregistry-dev/agentregistry/internal/registry/database"
+	"github.com/agentregistry-dev/agentregistry/pkg/api/v1alpha1"
 	"github.com/agentregistry-dev/agentregistry/pkg/logging"
 	pkgdb "github.com/agentregistry-dev/agentregistry/pkg/registry/database"
 	"github.com/agentregistry-dev/agentregistry/pkg/registry/v1alpha1store"
@@ -32,6 +34,8 @@ type ControllerHandle struct {
 	Controller *DeploymentController
 	Discovery  *DeploymentDiscoveryController
 	Retention  *RetentionPruner
+	// done closes after term-scoped controller and discovery workers both exit.
+	done <-chan struct{}
 }
 
 // ControllerConfig controls optional controller maintenance loops.
@@ -41,6 +45,13 @@ type ControllerConfig struct {
 	DiscoveryStaleAfterMisses  int
 	DiscoveryDeleteAfterMisses int
 	DependencyKinds            map[string]bool
+	// Leadership supplies a context for every interval in which this process owns
+	// Deployment and discovery reconciliation. Cancellation stops all provider
+	// mutations before a subsequent owner starts.
+	Leadership <-chan context.Context
+	// DeploymentFinalized runs after required cleanup and finalizer release so a
+	// parent Runtime can promptly re-evaluate whether all children are gone.
+	DeploymentFinalized func(context.Context, *v1alpha1.Deployment)
 }
 
 // StartDeploymentController constructs the Deployment controller, runs the
@@ -61,43 +72,15 @@ func StartDeploymentController(
 		return nil, errors.New("deployment controller: stores are required")
 	}
 
+	// Retention runs once for the process instead of restarting on every leadership
+	// term. It only prunes expired control-plane events, so it can keep history
+	// bounded even while no leader is available without performing provider
+	// mutations or competing with the elected reconciler.
 	controlPlaneEventStore := v1alpha1store.NewControlPlaneEventStore(pool, pkgdb.MustNewSchema(pkgdb.OSSSchema))
-	controller := &DeploymentController{
-		Stores:          stores,
-		Adapters:        adapters,
-		Getter:          internaldb.NewGetter(stores),
-		Events:          controlPlaneEventStore,
-		DependencyKinds: config.DependencyKinds,
-	}
-	if _, err := controller.Refresh(ctx); err != nil {
-		return nil, fmt.Errorf("deployment controller initial refresh: %w", err)
-	}
-	controller.Wakeups = controlPlaneWakeups(ctx, pool)
-	discovery := &DeploymentDiscoveryController{
-		Stores:            stores,
-		Sources:           discoverySources,
-		StaleAfterMisses:  config.DiscoveryStaleAfterMisses,
-		DeleteAfterMisses: config.DiscoveryDeleteAfterMisses,
-	}
-
 	retention := &RetentionPruner{
-		Stores: PruneStores{
-			ControlPlaneEvents: controlPlaneEventStore,
-		},
+		Stores: PruneStores{ControlPlaneEvents: controlPlaneEventStore},
 		Policy: config.Retention,
 	}
-	handle := &ControllerHandle{Controller: controller, Discovery: discovery, Retention: retention}
-
-	go func() {
-		if err := controller.Run(ctx, defaultControllerResyncInterval); err != nil && !errors.Is(err, context.Canceled) {
-			logger.Error("deployment controller stopped", "error", err)
-		}
-	}()
-	go func() {
-		if err := discovery.Run(ctx, config.DiscoveryInterval); err != nil && !errors.Is(err, context.Canceled) {
-			logger.Error("deployment discovery controller stopped", "error", err)
-		}
-	}()
 	if retention.Enabled() {
 		go func() {
 			if err := retention.Run(ctx, defaultRetentionPruneInterval); err != nil && !errors.Is(err, context.Canceled) {
@@ -105,7 +88,151 @@ func StartDeploymentController(
 			}
 		}()
 	}
+	if config.Leadership != nil {
+		go runDeploymentControllerLeadership(ctx, pool, stores, adapters, discoverySources, config)
+		return &ControllerHandle{Retention: retention}, nil
+	}
+
+	handle, err := startDeploymentControllerTerm(ctx, pool, stores, adapters, discoverySources, config)
+	if err != nil {
+		return nil, err
+	}
+	handle.Retention = retention
 	return handle, nil
+}
+
+// startDeploymentControllerTerm builds and starts the controller and discovery
+// workers owned by ctx. Each leadership term needs fresh queues, checkpoints,
+// and wakeup subscriptions because canceled workers cannot be safely reused.
+// If either worker exits, it cancels the generation so its sibling cannot leave
+// the process in a partially running reconciliation state.
+// The returned done channel lets the leadership loop wait for both workers to
+// exit before it accepts another term, preventing overlapping provider calls
+// and status writes from successive leaders.
+func startDeploymentControllerTerm(
+	ctx context.Context,
+	pool *pgxpool.Pool,
+	stores map[string]*v1alpha1store.Store,
+	adapters map[string]types.DeploymentAdapter,
+	discoverySources map[string]types.DeploymentDiscoverySource,
+	config ControllerConfig,
+) (*ControllerHandle, error) {
+	generationCtx, cancelGeneration := context.WithCancel(ctx)
+	controlPlaneEventStore := v1alpha1store.NewControlPlaneEventStore(pool, pkgdb.MustNewSchema(pkgdb.OSSSchema))
+	controller := &DeploymentController{
+		Stores:              stores,
+		Adapters:            adapters,
+		Getter:              internaldb.NewGetter(stores),
+		Events:              controlPlaneEventStore,
+		DependencyKinds:     config.DependencyKinds,
+		DeploymentFinalized: config.DeploymentFinalized,
+	}
+	if _, err := controller.Refresh(generationCtx); err != nil {
+		cancelGeneration()
+		return nil, fmt.Errorf("deployment controller initial refresh: %w", err)
+	}
+	controller.Wakeups = controlPlaneWakeups(generationCtx, pool)
+	discovery := &DeploymentDiscoveryController{
+		Stores:            stores,
+		Sources:           discoverySources,
+		StaleAfterMisses:  config.DiscoveryStaleAfterMisses,
+		DeleteAfterMisses: config.DiscoveryDeleteAfterMisses,
+	}
+
+	handle := &ControllerHandle{Controller: controller, Discovery: discovery}
+	handle.done = runDeploymentControllerWorkers(
+		generationCtx, cancelGeneration, controller, discovery, config.DiscoveryInterval,
+	)
+	return handle, nil
+}
+
+// runDeploymentControllerWorkers runs reconciliation and discovery as one
+// generation. When either worker returns, it cancels their shared context so
+// the sibling and its wakeup subscription also stop. The returned channel
+// closes only after both workers exit, allowing leadership handoff or restart
+// without leaving a partially running generation behind.
+func runDeploymentControllerWorkers(
+	ctx context.Context,
+	cancel context.CancelFunc,
+	controller *DeploymentController,
+	discovery *DeploymentDiscoveryController,
+	discoveryInterval time.Duration,
+) <-chan struct{} {
+	done := make(chan struct{})
+	var workers sync.WaitGroup
+	workers.Add(2)
+	go func() {
+		defer workers.Done()
+		defer cancel()
+		if err := controller.Run(ctx, defaultControllerResyncInterval); err != nil && !errors.Is(err, context.Canceled) {
+			logger.Error("deployment controller stopped", "error", err)
+		}
+	}()
+	go func() {
+		defer workers.Done()
+		defer cancel()
+		if err := discovery.Run(ctx, discoveryInterval); err != nil && !errors.Is(err, context.Canceled) {
+			logger.Error("deployment discovery controller stopped", "error", err)
+		}
+	}()
+	go func() {
+		workers.Wait()
+		close(done)
+	}()
+	return done
+}
+
+// runDeploymentControllerLeadership turns externally elected leadership terms
+// into controller worker lifetimes. It retries initialization while the term is
+// valid and restarts a generation that stops unexpectedly. Application shutdown
+// cancels the term, and the loop waits for every worker to stop before consuming
+// the next term so only one generation can mutate Deployments or provider
+// resources at a time.
+func runDeploymentControllerLeadership(
+	ctx context.Context,
+	pool *pgxpool.Pool,
+	stores map[string]*v1alpha1store.Store,
+	adapters map[string]types.DeploymentAdapter,
+	discoverySources map[string]types.DeploymentDiscoverySource,
+	config ControllerConfig,
+) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case leadershipCtx, ok := <-config.Leadership:
+			if !ok {
+				return
+			}
+			termCtx, cancel := context.WithCancel(leadershipCtx)
+			stop := context.AfterFunc(ctx, cancel)
+		term:
+			for termCtx.Err() == nil {
+				handle, err := startDeploymentControllerTerm(termCtx, pool, stores, adapters, discoverySources, config)
+				if err != nil {
+					if !errors.Is(err, context.Canceled) {
+						logger.Error("start deployment controller leadership", "error", err, "retry_after", defaultWakeupReconnectDelay)
+					}
+				} else {
+					select {
+					case <-termCtx.Done():
+						<-handle.done
+						break term
+					case <-handle.done:
+						if termCtx.Err() != nil {
+							break term
+						}
+						logger.Error("deployment controller leadership generation stopped; restarting", "retry_after", defaultWakeupReconnectDelay)
+					}
+				}
+				if !waitForReconnect(termCtx, defaultWakeupReconnectDelay) {
+					break
+				}
+			}
+			stop()
+			cancel()
+		}
+	}
 }
 
 func controlPlaneWakeups(ctx context.Context, pool *pgxpool.Pool) <-chan struct{} {

--- a/internal/registry/controller/runner_test.go
+++ b/internal/registry/controller/runner_test.go
@@ -4,9 +4,27 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
+
+func TestDeploymentControllerTermStopsWhenEitherWorkerExits(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	done := runDeploymentControllerWorkers(
+		ctx,
+		cancel,
+		&DeploymentController{},
+		&DeploymentDiscoveryController{},
+		time.Hour,
+	)
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("controller generation did not stop after one worker exited")
+	}
+}
 
 func TestControlPlaneWakeupLoopReconnectsAfterListenerError(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())

--- a/internal/registry/registry_app.go
+++ b/internal/registry/registry_app.go
@@ -121,6 +121,8 @@ func App(ctx context.Context, opts ...types.AppOptions) error {
 	}
 	controllerConfig := deploymentControllerConfig(cfg)
 	controllerConfig.DependencyKinds = maps.Clone(options.DeploymentDependencyKinds)
+	controllerConfig.Leadership = options.DeploymentControllerLeadership
+	controllerConfig.DeploymentFinalized = options.DeploymentFinalized
 	if _, err := controller.StartDeploymentController(ctx, pool, stores, deploymentAdapters, discoverySources, controllerConfig); err != nil {
 		return fmt.Errorf("start deployment controller: %w", err)
 	}

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -1,0 +1,4 @@
+package status
+
+// ConditionTypeReady reports whether reconciliation reached its desired state.
+const ConditionTypeReady = "Ready"

--- a/pkg/types/adapter.go
+++ b/pkg/types/adapter.go
@@ -144,10 +144,8 @@ type RemoveInput struct {
 	Runtime    *v1alpha1.Runtime
 }
 
-// RemoveResult describes the outcome of a Remove call. The reconciler
-// merges Conditions into Deployment.Status; idempotent re-Remove on a
-// completed teardown is the expected pattern (no separate finalizer
-// drain — soft-delete + GC handle the lifetime).
+// RemoveResult contains status updates persisted before finalizer release.
+// Remove must return an error until required provider cleanup completes.
 type RemoveResult struct {
 	// Conditions to merge into Deployment.Status (typically
 	// Progressing with Reason="Terminating", then Ready=False with

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -245,6 +245,16 @@ type AppOptions struct {
 	// its apply fingerprint still suppresses unchanged adapter work.
 	DeploymentDependencyKinds map[string]bool
 
+	// DeploymentControllerLeadership supplies one context for each interval in
+	// which this replica may run Deployment reconciliation. Nil preserves the
+	// default behavior of running under the application context.
+	DeploymentControllerLeadership <-chan context.Context
+
+	// DeploymentFinalized notifies lifecycle owners after required Deployment
+	// cleanup finishes and the row is purged. It allows parent
+	// reconciliation to react immediately instead of waiting for a periodic scan.
+	DeploymentFinalized func(context.Context, *v1alpha1.Deployment)
+
 	// Authorizers gates every read + write operation on the
 	// generic v1alpha1 resource handler, keyed by canonical Kind name
 	// (v1alpha1.KindAgent, v1alpha1.KindMCPServer, etc.). Downstream


### PR DESCRIPTION
# Description

Expose leadership-term controller ownership and post-finalization callbacks for
managed Runtime orchestrators.

Keep terminating Runtimes visible and resolvable while child Deployment cleanup
finishes. Back off failed Deployment work from two seconds up to one minute.

Show Runtime readiness and termination in arctl, and clarify the adapter removal
contract that gates finalizer release on required provider cleanup.

# Change Type

```
/kind feature
```

# Changelog

```release-note
Support observable managed Runtime cleanup and non-aggressive Deployment retries.
```

# Additional Notes

NONE
