### PR TITLE
internal: Restore Secret CLI support

### DIFF
--- a/internal/cli/commands/declarative.go
+++ b/internal/cli/commands/declarative.go
@@ -56,7 +56,6 @@ func init() {
 		func() *v1alpha1.Agent { return &v1alpha1.Agent{} },
 		agentRow,
 	))
-
 	scheme.Register(typedKind(
 		"mcp", "mcps", []string{"MCPServer", "mcpserver", "mcp-server", "mcpservers"},
 		[]scheme.Column{{Header: "NAME"}, {Header: "TAG"}, {Header: "DESCRIPTION"}},
@@ -64,7 +63,6 @@ func init() {
 		func() *v1alpha1.MCPServer { return &v1alpha1.MCPServer{} },
 		mcpRow,
 	))
-
 	scheme.Register(typedKind(
 		"skill", "skills", []string{"Skill"},
 		[]scheme.Column{
@@ -74,7 +72,6 @@ func init() {
 		func() *v1alpha1.Skill { return &v1alpha1.Skill{} },
 		skillRow,
 	))
-
 	scheme.Register(typedKind(
 		"prompt", "prompts", []string{"Prompt"},
 		[]scheme.Column{{Header: "NAME"}, {Header: "TAG"}, {Header: "DESCRIPTION"}},
@@ -82,7 +79,6 @@ func init() {
 		func() *v1alpha1.Prompt { return &v1alpha1.Prompt{} },
 		promptRow,
 	))
-
 	scheme.Register(typedKind(
 		"plugin", "plugins", []string{"Plugin"},
 		[]scheme.Column{{Header: "NAME"}, {Header: "TAG"}, {Header: "DESCRIPTION"}},
@@ -90,24 +86,6 @@ func init() {
 		func() *v1alpha1.Plugin { return &v1alpha1.Plugin{} },
 		pluginRow,
 	))
-
-	// Runtime is registered manually because it is a mutable namespace/name
-	// object: the server's runtime store does not expose /tags or
-	// DeleteAllTags endpoints. Routing it through
-	// typedKind would advertise --all-tags on its CLI surface and call
-	// endpoints that don't exist. The Get / Delete / List closures match
-	// what typedKind would otherwise produce; ListTags / DeleteAllTags are
-	// intentionally omitted so the dispatch layer rejects --all-tags cleanly.
-	scheme.Register(
-		mutableTypedKind(
-			"runtime", "runtimes", []string{"Runtime"},
-			[]scheme.Column{{Header: "NAME"}, {Header: "TYPE"}, {Header: "STATUS"}},
-			v1alpha1.KindRuntime,
-			func() *v1alpha1.Runtime { return &v1alpha1.Runtime{} },
-			runtimeRow,
-		),
-	)
-
 	scheme.Register(typedKind(
 		"model", "models", []string{"Model"},
 		[]scheme.Column{
@@ -119,11 +97,15 @@ func init() {
 		modelRow,
 	))
 
-	// Deployment is registered manually because it is a mutable namespace/name
-	// object: the server's deployment store does not expose /tags or
-	// DeleteAllTags endpoints. Explicit get/delete accept either NAME or
-	// NAMESPACE/NAME; ListTags / DeleteAllTags are intentionally omitted so
-	// the dispatch layer rejects --all-tags cleanly.
+	scheme.Register(
+		mutableTypedKind(
+			"runtime", "runtimes", []string{"Runtime"},
+			[]scheme.Column{{Header: "NAME"}, {Header: "TYPE"}, {Header: "STATUS"}},
+			v1alpha1.KindRuntime,
+			func() *v1alpha1.Runtime { return &v1alpha1.Runtime{} },
+			runtimeRow,
+		),
+	)
 	scheme.Register(
 		mutableTypedKind(
 			"deployment", "deployments", []string{"Deployment"},

--- a/internal/cli/commands/declarative.go
+++ b/internal/cli/commands/declarative.go
@@ -108,6 +108,17 @@ func init() {
 	)
 	scheme.Register(
 		mutableTypedKind(
+			"secret", "secrets", []string{"Secret"},
+			[]scheme.Column{
+				{Header: "NAME"}, {Header: "TYPE"}, {Header: "KEYS"}, {Header: "IMMUTABLE"},
+			},
+			v1alpha1.KindSecret,
+			func() *v1alpha1.Secret { return &v1alpha1.Secret{} },
+			secretRow,
+		),
+	)
+	scheme.Register(
+		mutableTypedKind(
 			"deployment", "deployments", []string{"Deployment"},
 			[]scheme.Column{
 				{Header: "NAME"}, {Header: "TARGET"}, {Header: "VERSION"},

--- a/internal/cli/commands/declarative.go
+++ b/internal/cli/commands/declarative.go
@@ -47,109 +47,115 @@ func lookupPersistentFlag(cmd *cobra.Command, name string) string {
 }
 
 func init() {
-	scheme.Register(typedKind(
-		"agent", "agents", []string{"Agent"},
+	registerKind[*v1alpha1.Agent](
+		"agent", "", nil,
 		[]scheme.Column{
 			{Header: "NAME"}, {Header: "TAG"}, {Header: "MODE"}, {Header: "DESCRIPTION"},
 		},
 		v1alpha1.KindAgent,
-		func() *v1alpha1.Agent { return &v1alpha1.Agent{} },
 		agentRow,
-	))
-	scheme.Register(typedKind(
+	)
+	registerKind[*v1alpha1.MCPServer](
 		"mcp", "mcps", []string{"MCPServer", "mcpserver", "mcp-server", "mcpservers"},
 		[]scheme.Column{{Header: "NAME"}, {Header: "TAG"}, {Header: "DESCRIPTION"}},
 		v1alpha1.KindMCPServer,
-		func() *v1alpha1.MCPServer { return &v1alpha1.MCPServer{} },
 		mcpRow,
-	))
-	scheme.Register(typedKind(
-		"skill", "skills", []string{"Skill"},
+	)
+	registerKind[*v1alpha1.Skill](
+		"skill", "", nil,
 		[]scheme.Column{
 			{Header: "NAME"}, {Header: "TAG"}, {Header: "DESCRIPTION"},
 		},
 		v1alpha1.KindSkill,
-		func() *v1alpha1.Skill { return &v1alpha1.Skill{} },
 		skillRow,
-	))
-	scheme.Register(typedKind(
-		"prompt", "prompts", []string{"Prompt"},
+	)
+	registerKind[*v1alpha1.Prompt](
+		"prompt", "", nil,
 		[]scheme.Column{{Header: "NAME"}, {Header: "TAG"}, {Header: "DESCRIPTION"}},
 		v1alpha1.KindPrompt,
-		func() *v1alpha1.Prompt { return &v1alpha1.Prompt{} },
 		promptRow,
-	))
-	scheme.Register(typedKind(
-		"plugin", "plugins", []string{"Plugin"},
+	)
+	registerKind[*v1alpha1.Plugin](
+		"plugin", "", nil,
 		[]scheme.Column{{Header: "NAME"}, {Header: "TAG"}, {Header: "DESCRIPTION"}},
 		v1alpha1.KindPlugin,
-		func() *v1alpha1.Plugin { return &v1alpha1.Plugin{} },
 		pluginRow,
-	))
-	scheme.Register(typedKind(
-		"model", "models", []string{"Model"},
+	)
+	registerKind[*v1alpha1.Model](
+		"model", "", nil,
 		[]scheme.Column{
 			{Header: "NAME"}, {Header: "TAG"}, {Header: "PROVIDER"},
 			{Header: "MODEL"}, {Header: "AUTH"},
 		},
 		v1alpha1.KindModel,
-		func() *v1alpha1.Model { return &v1alpha1.Model{} },
 		modelRow,
-	))
+	)
 
-	scheme.Register(
-		mutableTypedKind(
-			"runtime", "runtimes", []string{"Runtime"},
-			[]scheme.Column{{Header: "NAME"}, {Header: "TYPE"}, {Header: "STATUS"}},
-			v1alpha1.KindRuntime,
-			func() *v1alpha1.Runtime { return &v1alpha1.Runtime{} },
-			runtimeRow,
-		),
+	registerKind[*v1alpha1.Runtime](
+		"runtime", "", nil,
+		[]scheme.Column{{Header: "NAME"}, {Header: "TYPE"}, {Header: "STATUS"}},
+		v1alpha1.KindRuntime,
+		runtimeRow,
 	)
-	scheme.Register(
-		mutableTypedKind(
-			"secret", "secrets", []string{"Secret"},
-			[]scheme.Column{
-				{Header: "NAME"}, {Header: "TYPE"}, {Header: "KEYS"}, {Header: "IMMUTABLE"},
-			},
-			v1alpha1.KindSecret,
-			func() *v1alpha1.Secret { return &v1alpha1.Secret{} },
-			secretRow,
-		),
+	registerKind[*v1alpha1.Secret](
+		"secret", "", nil,
+		[]scheme.Column{
+			{Header: "NAME"}, {Header: "TYPE"}, {Header: "KEYS"}, {Header: "IMMUTABLE"},
+		},
+		v1alpha1.KindSecret,
+		secretRow,
 	)
-	scheme.Register(
-		mutableTypedKind(
-			"deployment", "deployments", []string{"Deployment"},
-			[]scheme.Column{
-				{Header: "NAME"}, {Header: "TARGET"}, {Header: "VERSION"},
-				{Header: "TYPE"}, {Header: "RUNTIME"}, {Header: "STATUS"},
-			},
-			v1alpha1.KindDeployment,
-			func() *v1alpha1.Deployment { return &v1alpha1.Deployment{} },
-			func(deployment *v1alpha1.Deployment) []string {
-				return deploymentRow(cliCommon.DeploymentRecordFromObject(deployment))
-			},
-			withMutableListFunc(listDeploymentResources),
-		),
+	registerKind[*v1alpha1.Deployment](
+		"deployment", "", nil,
+		[]scheme.Column{
+			{Header: "NAME"}, {Header: "TARGET"}, {Header: "VERSION"},
+			{Header: "TYPE"}, {Header: "RUNTIME"}, {Header: "STATUS"},
+		},
+		v1alpha1.KindDeployment,
+		func(deployment *v1alpha1.Deployment) []string {
+			return deploymentRow(cliCommon.DeploymentRecordFromObject(deployment))
+		},
+		withListFunc(listDeploymentResources),
 	)
 }
 
-// typedKind builds a scheme.Kind whose Get / List / Delete dispatch
-// closures all wire through the typed v1alpha1 client helpers
-// (client.GetTyped[T] / client.ListAllTyped[T] / client.Delete) for
-// the canonical kind. Per-kind callers supply the user-facing name +
-// aliases, the table layout, and a row formatter that takes the typed
-// envelope T directly. RowFunc shape-checks the input via T-assertion
-// so the registry's `any` API stays internal.
-func typedKind[T v1alpha1.Object](
+type kindOption func(*scheme.Kind)
+
+func withListFunc(fn scheme.ListFunc) kindOption {
+	return func(k *scheme.Kind) {
+		k.ListFunc = fn
+	}
+}
+
+func registerKind[T v1alpha1.Object](
 	cliName, plural string,
 	aliases []string,
 	columns []scheme.Column,
 	canonicalKind string,
-	newObj func() T,
 	row func(T) []string,
-) *scheme.Kind {
-	return &scheme.Kind{
+	opts ...kindOption,
+) {
+	descriptor, ok := v1alpha1.KindDescriptorFor(canonicalKind)
+	if !ok {
+		panic("commands.registerKind: v1alpha1 kind is not registered: " + canonicalKind)
+	}
+	if plural == "" {
+		plural = descriptor.Plural
+	}
+	if obj := descriptor.NewObject(); obj == nil {
+		panic("commands.registerKind: constructor for " + canonicalKind + " returned nil")
+	} else if _, ok := obj.(T); !ok {
+		panic(fmt.Sprintf("commands.registerKind: constructor for %s returned %T", canonicalKind, obj))
+	}
+	newObj := func() T {
+		obj, ok := descriptor.NewObject().(T)
+		if !ok {
+			panic(fmt.Sprintf("commands.registerKind: constructor for %s returned %T", canonicalKind, obj))
+		}
+		return obj
+	}
+	tagged := descriptor.Storage == v1alpha1.KindStorageTaggedArtifact
+	k := &scheme.Kind{
 		Kind:         cliName,
 		Plural:       plural,
 		Aliases:      aliases,
@@ -167,6 +173,9 @@ func typedKind[T v1alpha1.Object](
 			if err != nil {
 				return nil, err
 			}
+			if !tagged {
+				tag = ""
+			}
 			return client.GetTyped(ctx, c, canonicalKind, ref.Namespace, ref.Name, tag, newObj)
 		},
 		ListFunc: func(ctx context.Context, c *client.Client, opts scheme.ListOpts) ([]any, error) {
@@ -175,70 +184,19 @@ func typedKind[T v1alpha1.Object](
 		Delete: func(ctx context.Context, c *client.Client, name, tag string) error {
 			return deleteAny(ctx, c, canonicalKind, name, tag, newObj)
 		},
-		ListTags: func(ctx context.Context, c *client.Client, name string) ([]any, error) {
+	}
+	if tagged {
+		k.ListTags = func(ctx context.Context, c *client.Client, name string) ([]any, error) {
 			return listTagsAny(ctx, c, canonicalKind, name, newObj)
-		},
-		DeleteAllTags: func(ctx context.Context, c *client.Client, name string) error {
+		}
+		k.DeleteAllTags = func(ctx context.Context, c *client.Client, name string) error {
 			return deleteAllTagsAny(ctx, c, canonicalKind, name, newObj)
-		},
-	}
-}
-
-// mutableTypedKind is typedKind for namespace/name resources such as Runtime
-// and Deployment. These kinds use the generic v1alpha1 CRUD surface but do not
-// expose /tags, so the tag-specific callbacks are intentionally nil.
-type mutableTypedKindOption func(*scheme.Kind)
-
-// withMutableListFunc is an option to override the default ListFunc for a
-// mutableTypedKind.
-func withMutableListFunc(fn scheme.ListFunc) mutableTypedKindOption {
-	return func(k *scheme.Kind) {
-		k.ListFunc = fn
-	}
-}
-
-// mutableTypedKind builds a scheme.Kind for mutable namespace/name resources which
-// do not support tagging.
-func mutableTypedKind[T v1alpha1.Object](
-	cliName, plural string,
-	aliases []string,
-	columns []scheme.Column,
-	canonicalKind string,
-	newObj func() T,
-	row func(T) []string,
-	opts ...mutableTypedKindOption,
-) *scheme.Kind {
-	k := &scheme.Kind{
-		Kind:         cliName,
-		Plural:       plural,
-		Aliases:      aliases,
-		TableColumns: columns,
-		ToYAMLFunc:   func(item any) any { return item },
-		RowFunc: func(item any) []string {
-			t, ok := item.(T)
-			if !ok {
-				return []string{"<invalid>"}
-			}
-			return row(t)
-		},
-		Get: func(ctx context.Context, c *client.Client, name, _ string) (any, error) {
-			ref, err := parseResourceLookupRef(name)
-			if err != nil {
-				return nil, err
-			}
-			return client.GetTyped(ctx, c, canonicalKind, ref.Namespace, ref.Name, "", newObj)
-		},
-		ListFunc: func(ctx context.Context, c *client.Client, opts scheme.ListOpts) ([]any, error) {
-			return listAny(ctx, c, canonicalKind, opts, newObj)
-		},
-		Delete: func(ctx context.Context, c *client.Client, name, tag string) error {
-			return deleteAny(ctx, c, canonicalKind, name, tag, newObj)
-		},
+		}
 	}
 	for _, opt := range opts {
 		if opt != nil {
 			opt(k)
 		}
 	}
-	return k
+	scheme.Register(k)
 }

--- a/internal/cli/commands/delete.go
+++ b/internal/cli/commands/delete.go
@@ -21,15 +21,15 @@ func NewDeleteCmd(deps cliruntime.Deps) *cobra.Command {
 		Short: "Delete a registry resource",
 		Long: `Delete a registry resource.
 
-File mode (declarative): reads resources from the YAML file and sends DELETE /v0/apply.
+File mode: read resources from FILE and delete them declaratively.
   arctl delete -f agent.yaml
 
-Explicit mode: specify type and name. For taggable artifacts, --tag selects an
+Explicit mode: specify type and name. For tagged kinds, --tag selects an
 exact tag and defaults to latest.
-  arctl delete TYPE NAME [--tag TAG]
+  arctl delete TYPE NAME [--tag TAG | --all-tags]
 
-TYPE must be one of: ` + supportedTypes + `
-(plural and uppercase forms also accepted)`,
+TYPE must be one of: ` + supportedTypes + `.
+Type names are case-insensitive; singular, plural, and registered aliases are accepted.`,
 		Example: `  arctl delete -f my-agent/agent.yaml
   arctl delete -f my-server/mcp.yaml
   arctl delete agent acme-summarizer --tag stable
@@ -42,8 +42,8 @@ TYPE must be one of: ` + supportedTypes + `
 		},
 	}
 	cmd.Flags().StringP("filename", "f", "", "YAML file to read resources from")
-	cmd.Flags().String("tag", "", "Specific tag to delete (taggable artifact kinds only; defaults to latest)")
-	cmd.Flags().Bool("all-tags", false, "Delete every tag of NAME (taggable artifact kinds only)")
+	cmd.Flags().String("tag", "", "Tagged kinds only: delete a specific tag (defaults to latest)")
+	cmd.Flags().Bool("all-tags", false, "Tagged kinds only: delete every tag of NAME")
 	return cmd
 }
 

--- a/internal/cli/commands/delete.go
+++ b/internal/cli/commands/delete.go
@@ -15,6 +15,7 @@ import (
 )
 
 func NewDeleteCmd(deps cliruntime.Deps) *cobra.Command {
+	supportedTypes := supportedKindNames(kindRegistry(deps))
 	cmd := &cobra.Command{
 		Use:   cliruntime.CommandDelete + " (TYPE NAME | -f FILE)",
 		Short: "Delete a registry resource",
@@ -27,7 +28,7 @@ Explicit mode: specify type and name. For taggable artifacts, --tag selects an
 exact tag and defaults to latest.
   arctl delete TYPE NAME [--tag TAG]
 
-TYPE must be one of: agent, mcp, skill, prompt, deployment
+TYPE must be one of: ` + supportedTypes + `
 (plural and uppercase forms also accepted)`,
 		Example: `  arctl delete -f my-agent/agent.yaml
   arctl delete -f my-server/mcp.yaml
@@ -143,10 +144,10 @@ func deleteResource(cmd *cobra.Command, kinds *scheme.Registry, c *client.Client
 		return err
 	}
 
-	// Deployments and runtimes have no tag of their own; rejecting --tag here
-	// keeps users from confusing a deployment's target tag (or a runtime's
-	// non-existent tag) with the metadata identity used for delete.
-	if tag != "" && (k.Kind == "deployment" || k.Kind == "runtime") {
+	// Mutable namespace/name resources have no tag of their own. ListTags is
+	// registered only for tagged artifacts, so use that capability instead of
+	// maintaining a second hard-coded list of mutable kinds.
+	if tag != "" && k.ListTags == nil {
 		return fmt.Errorf("--tag is not supported for %s", k.Kind)
 	}
 

--- a/internal/cli/commands/deployment_delete_test.go
+++ b/internal/cli/commands/deployment_delete_test.go
@@ -151,11 +151,9 @@ func TestDeploymentDelete_ServerFailure(t *testing.T) {
 	assert.ElementsMatch(t, []string{"gcp-v1"}, *deleted)
 }
 
-// (4) --tag is rejected for deployments and runtimes: neither kind has a tag
-// of its own, so accepting one would let users confuse the target's tag (or
-// nothing at all, for runtime) with the resource's identity.
-func TestDelete_RejectsTagForDeploymentAndRuntime(t *testing.T) {
-	for _, kind := range []string{"deployment", "runtime"} {
+// (4) --tag is rejected for every mutable namespace/name kind.
+func TestDelete_RejectsTagForMutableKinds(t *testing.T) {
+	for _, kind := range []string{"deployment", "runtime", "secret"} {
 		t.Run(kind, func(t *testing.T) {
 			cmd := commands.NewDeleteCmd(declarativeTestDeps(nil))
 			cmd.SetArgs([]string{kind, "anything", "--tag", "1.0.0"})

--- a/internal/cli/commands/get.go
+++ b/internal/cli/commands/get.go
@@ -26,8 +26,8 @@ func NewGetCmd(deps cliruntime.Deps) *cobra.Command {
 		Short: "List or retrieve registry resources",
 		Long: `List or retrieve registry resources by type.
 
-Supported types: ` + supportedTypes + `
-(singular and uppercase forms also accepted, e.g. Agent, agent, agents)
+Supported types: ` + supportedTypes + `.
+Type names are case-insensitive; singular, plural, and registered aliases are accepted.
 
 Examples:
   arctl get all
@@ -35,7 +35,7 @@ Examples:
   arctl get agents -l team=platform,tier=production
   arctl get agents --show-labels         # list rows with a LABELS column
   arctl get agents --tag stable          # list rows with a specific tag
-  arctl get agents --latest              # list rows pinned to the "latest" tag
+  arctl get agents --latest              # list rows with the literal "latest" tag
   arctl get mcps
   arctl get agent acme-summarizer
   arctl get agent acme-summarizer -o yaml
@@ -52,12 +52,12 @@ Examples:
 		},
 	}
 	cmd.Flags().StringP("output", "o", "table", "Output format: table, yaml, json")
-	cmd.Flags().StringVarP(&labels, "labels", "l", "", "Content kinds only: filter list rows by comma-separated key=value labels.")
+	cmd.Flags().StringVarP(&labels, "labels", "l", "", "Tagged kinds only: filter list rows by comma-separated key=value labels.")
 	cmd.Flags().Bool("show-labels", false, "Print an additional LABELS column with each resource's labels; ignored for -o yaml/json, which already include labels.")
 	cmd.Flags().String("tag", "", "Tagged kinds only. With NAME: fetch one tag (defaults to latest). Without NAME: filter the list to this tag.")
-	cmd.Flags().Bool("latest", false, "List mode only: restrict to rows pinned to the literal 'latest' tag (equivalent to --tag latest).")
-	cmd.Flags().Bool("all-tags", false, "List every tag of NAME (tagged content kinds only)")
-	cmd.Flags().String("origin", "", "Deployments only: filter by provenance — managed, discovered, or all (defaults to managed when unset).")
+	cmd.Flags().Bool("latest", false, "Tagged kinds only: list rows with the literal 'latest' tag (equivalent to --tag latest).")
+	cmd.Flags().Bool("all-tags", false, "Tagged kinds only: list every tag of NAME")
+	cmd.Flags().String("origin", "", "Deployments only: filter provenance by managed, discovered, or all (defaults to managed when unset).")
 	return cmd
 }
 

--- a/internal/cli/commands/get.go
+++ b/internal/cli/commands/get.go
@@ -20,12 +20,13 @@ import (
 // NewGetCmd returns a new "get" cobra command.
 func NewGetCmd(deps cliruntime.Deps) *cobra.Command {
 	var labels string
+	supportedTypes := supportedKindNames(kindRegistry(deps))
 	cmd := &cobra.Command{
 		Use:   "get TYPE [NAME]",
 		Short: "List or retrieve registry resources",
 		Long: `List or retrieve registry resources by type.
 
-Supported types: agents, mcps, skills, prompts, runtimes, deployments
+Supported types: ` + supportedTypes + `
 (singular and uppercase forms also accepted, e.g. Agent, agent, agents)
 
 Examples:

--- a/internal/cli/commands/get_test.go
+++ b/internal/cli/commands/get_test.go
@@ -202,6 +202,18 @@ func TestDeployment_NoAllTagsSupport(t *testing.T) {
 	require.Nil(t, k.DeleteAllTags, "Deployment should not expose DeleteAllTags (mutable object kind)")
 }
 
+func TestSecret_CLIRegistration(t *testing.T) {
+	for _, alias := range []string{"secret", "secrets", "Secret"} {
+		k, err := scheme.Lookup(alias)
+		require.NoError(t, err, "%q should resolve via declarative's init() registration", alias)
+		require.Equal(t, "secret", k.Kind)
+		require.Equal(t, "secrets", k.Plural)
+		require.Equal(t, []scheme.Column{
+			{Header: "NAME"}, {Header: "TYPE"}, {Header: "KEYS"}, {Header: "IMMUTABLE"},
+		}, k.TableColumns)
+	}
+}
+
 // tagGetServer serves GET /v0/agents/{name}/{tag} (specific tag)
 // and /v0/agents/{name} (latest), returning the configured
 // envelope. capturedPaths records every served path so tests can assert

--- a/internal/cli/commands/get_test.go
+++ b/internal/cli/commands/get_test.go
@@ -214,6 +214,18 @@ func TestSecret_CLIRegistration(t *testing.T) {
 	}
 }
 
+func TestCommandHelpListsRegisteredKinds(t *testing.T) {
+	getCmd := commands.NewGetCmd(declarativeTestDeps(nil))
+	deleteCmd := commands.NewDeleteCmd(declarativeTestDeps(nil))
+	for _, kind := range scheme.All() {
+		t.Run(kind.Kind, func(t *testing.T) {
+			require.NotEmpty(t, kind.Plural)
+			assert.Contains(t, getCmd.Long, kind.Plural)
+			assert.Contains(t, deleteCmd.Long, kind.Plural)
+		})
+	}
+}
+
 // tagGetServer serves GET /v0/agents/{name}/{tag} (specific tag)
 // and /v0/agents/{name} (latest), returning the configured
 // envelope. capturedPaths records every served path so tests can assert

--- a/internal/cli/commands/get_test.go
+++ b/internal/cli/commands/get_test.go
@@ -154,54 +154,6 @@ func TestGetCmd_RegistryDrivenColumnLookup(t *testing.T) {
 		"should fail at API client check, not kind lookup")
 }
 
-// TestProvider_NoAllTagsSupport pins that Runtime — a mutable
-// namespace/name object — is registered without ListTags /
-// DeleteAllTags closures. The dispatch layer rejects --all-tags
-// when those fields are nil, which is exactly the behavior we want for
-// Runtime on this branch (its server store has no /tags endpoint).
-func TestProvider_NoAllTagsSupport(t *testing.T) {
-	k, err := scheme.Lookup("runtime")
-	require.NoError(t, err)
-	require.Nil(t, k.ListTags, "Runtime should not expose ListTags (mutable object kind)")
-	require.Nil(t, k.DeleteAllTags, "Runtime should not expose DeleteAllTags (mutable object kind)")
-}
-
-func TestModel_AllTagsSupport(t *testing.T) {
-	k, err := scheme.Lookup("model")
-	require.NoError(t, err)
-	require.NotNil(t, k.ListTags, "tagged Model should expose ListTags")
-	require.NotNil(t, k.DeleteAllTags, "tagged Model should expose DeleteAllTags")
-	require.Equal(t, "model", k.Kind)
-	require.Equal(t, "models", k.Plural)
-}
-
-// TestPlugin_AllTagsSupport pins that Plugin — a tag-versioned artifact kind —
-// resolves via every alias and keeps its tagged-kind wiring (ListTags /
-// DeleteAllTags), so it never silently loses registration or --all-tags support.
-func TestPlugin_AllTagsSupport(t *testing.T) {
-	for _, alias := range []string{"plugin", "plugins", "Plugin"} {
-		k, err := scheme.Lookup(alias)
-		require.NoError(t, err, "%q should resolve via declarative's init() registration", alias)
-		require.NotNil(t, k.ListTags, "tagged Plugin should expose ListTags")
-		require.NotNil(t, k.DeleteAllTags, "tagged Plugin should expose DeleteAllTags")
-		require.Equal(t, "plugin", k.Kind)
-		require.Equal(t, "plugins", k.Plural)
-		require.NotEmpty(t, k.TableColumns, "expected TableColumns on the plugin kind")
-	}
-}
-
-// TestDeployment_NoAllTagsSupport is the symmetric assertion for
-// Deployment — also a mutable namespace/name object. Already
-// covered by TestGet_AllTags_DeploymentRejected at the CLI surface
-// but pinning it at the registry shape level guards against an
-// accidental ListTags wiring regression.
-func TestDeployment_NoAllTagsSupport(t *testing.T) {
-	k, err := scheme.Lookup("deployment")
-	require.NoError(t, err)
-	require.Nil(t, k.ListTags, "Deployment should not expose ListTags (mutable object kind)")
-	require.Nil(t, k.DeleteAllTags, "Deployment should not expose DeleteAllTags (mutable object kind)")
-}
-
 func TestSecret_CLIRegistration(t *testing.T) {
 	for _, alias := range []string{"secret", "secrets", "Secret"} {
 		k, err := scheme.Lookup(alias)
@@ -222,6 +174,36 @@ func TestCommandHelpListsRegisteredKinds(t *testing.T) {
 			require.NotEmpty(t, kind.Plural)
 			assert.Contains(t, getCmd.Long, kind.Plural)
 			assert.Contains(t, deleteCmd.Long, kind.Plural)
+		})
+	}
+}
+
+func TestEveryAPIKindHasCLIRegistration(t *testing.T) {
+	for _, descriptor := range v1alpha1.KindDescriptors() {
+		t.Run(descriptor.Kind, func(t *testing.T) {
+			kind, err := scheme.Lookup(descriptor.Kind)
+			require.NoError(t, err, "API kind %q is missing CLI registration", descriptor.Kind)
+			require.NotEmpty(t, kind.Plural)
+			require.NotEmpty(t, kind.TableColumns)
+			require.NotNil(t, kind.RowFunc)
+			require.NotNil(t, kind.ToYAMLFunc)
+			require.NotNil(t, kind.Get)
+			require.NotNil(t, kind.ListFunc)
+			require.NotNil(t, kind.Delete)
+
+			row := kind.RowFunc(descriptor.NewObject())
+			require.Len(t, row, len(kind.TableColumns))
+
+			switch descriptor.Storage {
+			case v1alpha1.KindStorageTaggedArtifact:
+				require.NotNil(t, kind.ListTags)
+				require.NotNil(t, kind.DeleteAllTags)
+			case v1alpha1.KindStorageMutableObject:
+				require.Nil(t, kind.ListTags)
+				require.Nil(t, kind.DeleteAllTags)
+			default:
+				t.Fatalf("unsupported storage type %q", descriptor.Storage)
+			}
 		})
 	}
 }

--- a/internal/cli/commands/kinds_dispatch.go
+++ b/internal/cli/commands/kinds_dispatch.go
@@ -124,3 +124,11 @@ func kindPlural(k *scheme.Kind) string {
 	}
 	return k.Kind + "s"
 }
+
+func supportedKindNames(kinds *scheme.Registry) string {
+	names := make([]string, 0, len(kinds.All()))
+	for _, kind := range kinds.All() {
+		names = append(names, kindPlural(kind))
+	}
+	return strings.Join(names, ", ")
+}

--- a/internal/cli/commands/resources.go
+++ b/internal/cli/commands/resources.go
@@ -214,6 +214,23 @@ func runtimeRow(runtime *v1alpha1.Runtime) []string {
 	return []string{runtime.Metadata.Name, runtime.Spec.Type, runtimeStatus(runtime)}
 }
 
+func secretRow(secret *v1alpha1.Secret) []string {
+	if secret == nil {
+		return []string{"<invalid>"}
+	}
+	secretType := string(secret.Spec.Type)
+	if secretType == "" {
+		secretType = string(v1alpha1.SecretTypeOpaque)
+	}
+	keys := strings.Join(secret.Status.DataKeys, ",")
+	return []string{
+		printer.TruncateString(secret.Metadata.Name, 40),
+		secretType,
+		printer.EmptyValueOrDefault(keys, "<none>"),
+		fmt.Sprintf("%t", secret.Spec.Immutable),
+	}
+}
+
 // Runtime status labels are CLI presentation values rather than API condition
 // values. Keeping them here prevents callers from treating display text as a
 // lifecycle contract.

--- a/internal/cli/commands/resources_test.go
+++ b/internal/cli/commands/resources_test.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/agentregistry-dev/agentregistry/pkg/api/v1alpha1"
@@ -77,5 +78,29 @@ func TestAgentRowIncludesModeAndDescription(t *testing.T) {
 	want := []string{"reviewer", "stable", "source+harness", "Reviews pull requests"}
 	if got := agentRow(agent); !reflect.DeepEqual(got, want) {
 		t.Fatalf("agentRow() = %#v, want %#v", got, want)
+	}
+}
+
+func TestSecretRowShowsMetadataWithoutPayloadValues(t *testing.T) {
+	secret := &v1alpha1.Secret{
+		Metadata: v1alpha1.ObjectMeta{Name: "provider-credentials"},
+		Spec: v1alpha1.SecretSpec{
+			Immutable:  true,
+			Data:       map[string]string{"token": "c2Vuc2l0aXZl"},
+			StringData: map[string]string{"password": "sensitive"},
+		},
+		Status: v1alpha1.SecretStatus{DataKeys: []string{"password", "token"}},
+	}
+
+	want := []string{"provider-credentials", "Opaque", "password,token", "true"}
+	got := secretRow(secret)
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("secretRow() = %#v, want %#v", got, want)
+	}
+	row := strings.Join(got, " ")
+	for _, payload := range []string{"c2Vuc2l0aXZl", "sensitive"} {
+		if strings.Contains(row, payload) {
+			t.Fatalf("secretRow() exposed payload value %q", payload)
+		}
 	}
 }


### PR DESCRIPTION
# Description

Restore Secret as a supported kind for `arctl get` and `arctl delete`. Built-in
CLI registration now derives generic CRUD behavior and storage capabilities
from v1alpha1 descriptors, so supported type help and tagged-versus-mutable
behavior stay aligned as kinds are added.

Secret table output reports type, key names, and immutability without exposing
payload values. The command help also uses registry-driven supported types and
consistent tag terminology.

# Change Type

/kind fix

# Changelog

```release-note
The CLI now supports listing, retrieving, and deleting Secret resources.
```

# Additional Notes

Focused validation: `go test ./internal/cli/commands ./internal/cli/scheme ./pkg/api/v1alpha1`

Broad integration and lint targets were not run.
