### PR TITLE
runtime: persist deployment metadata in status

### DIFF
--- a/internal/cli/common/deployments.go
+++ b/internal/cli/common/deployments.go
@@ -13,6 +13,7 @@ import (
 )
 
 const runtimeMetadataPrefix = "runtimes.agentregistry.solo.io/"
+const runtimeMetadataDetailsKey = "runtimeMetadata"
 const deploymentOriginManaged = "managed"
 
 // DeploymentRecord is the CLI-friendly projection of a v1alpha1 Deployment.
@@ -109,7 +110,7 @@ func DeploymentRecordFromObject(dep *v1alpha1.Deployment) *DeploymentRecord {
 		Origin:            "managed",
 		Env:               cloneStringMap(dep.Spec.Env),
 		RuntimeConfig:     cloneAnyMap(dep.Spec.RuntimeConfig),
-		RuntimeMetadata:   deploymentRuntimeMetadata(dep.Metadata.Annotations),
+		RuntimeMetadata:   deploymentRuntimeMetadata(dep),
 		Error:             deploymentError(dep.Status),
 		CreatedAt:         dep.Metadata.CreatedAt,
 		UpdatedAt:         dep.Metadata.UpdatedAt,
@@ -187,7 +188,17 @@ func deploymentError(status v1alpha1.Status) string {
 	return ""
 }
 
-func deploymentRuntimeMetadata(annotations map[string]string) map[string]any {
+func deploymentRuntimeMetadata(deployment *v1alpha1.Deployment) map[string]any {
+	if deployment == nil {
+		return nil
+	}
+	var metadata map[string]any
+	found, err := deployment.Status.GetDetailsKey(runtimeMetadataDetailsKey, &metadata)
+	if err == nil && found && len(metadata) > 0 {
+		return metadata
+	}
+
+	annotations := deployment.Metadata.Annotations
 	if len(annotations) == 0 {
 		return nil
 	}

--- a/internal/cli/common/deployments_test.go
+++ b/internal/cli/common/deployments_test.go
@@ -3,13 +3,57 @@ package common
 import (
 	"context"
 	"encoding/json"
+	"maps"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"testing"
 
 	"github.com/agentregistry-dev/agentregistry/internal/client"
+	"github.com/agentregistry-dev/agentregistry/pkg/api/v1alpha1"
 )
+
+func TestDeploymentRecordFromObject_RuntimeMetadata(t *testing.T) {
+	tests := []struct {
+		name        string
+		status      map[string]string
+		annotations map[string]string
+		want        map[string]any
+	}{
+		{
+			name:   "status details",
+			status: map[string]string{"remoteId": "status-id"},
+			annotations: map[string]string{
+				"runtimes.agentregistry.solo.io/test/remoteId": "annotation-id",
+			},
+			want: map[string]any{"remoteId": "status-id"},
+		},
+		{
+			name: "legacy annotation fallback",
+			annotations: map[string]string{
+				"runtimes.agentregistry.solo.io/test/remoteId": "annotation-id",
+			},
+			want: map[string]any{"remoteId": "annotation-id"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			deployment := &v1alpha1.Deployment{}
+			deployment.Metadata.Annotations = tt.annotations
+			if tt.status != nil {
+				if err := deployment.Status.SetDetailsKey(runtimeMetadataDetailsKey, tt.status); err != nil {
+					t.Fatalf("SetDetailsKey() error = %v", err)
+				}
+			}
+
+			got := DeploymentRecordFromObject(deployment).RuntimeMetadata
+			if !maps.Equal(got, tt.want) {
+				t.Fatalf("RuntimeMetadata = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
 
 func TestListDeploymentsDefaultsOriginManaged(t *testing.T) {
 	var rawQuery string

--- a/internal/registry/controller/discovery.go
+++ b/internal/registry/controller/discovery.go
@@ -360,30 +360,27 @@ func discoveredDeploymentFromResult(
 	}, true
 }
 
-// deploymentDiscoveryRemoteID reads the provider identity from the storage
-// location owned by the deployment's controller. Discovery persists runtime
-// metadata in status details, while managed adapters persist it in namespaced
-// annotations.
+// deploymentDiscoveryRemoteID reads provider identity from status, with a
+// legacy annotation fallback for Deployments that have not migrated yet.
 func deploymentDiscoveryRemoteID(deployment *v1alpha1.Deployment) string {
 	if deployment == nil {
 		return ""
 	}
-	if !v1alpha1.IsDiscoveredDeployment(deployment) {
-		for key, value := range deployment.Metadata.Annotations {
-			if strings.HasSuffix(strings.TrimSpace(key), "/"+types.RuntimeMetadataRemoteIDKey) {
-				if remoteID := strings.TrimSpace(value); remoteID != "" {
-					return remoteID
-				}
-			}
-		}
-		return ""
-	}
 	var metadata map[string]string
 	found, err := deployment.Status.GetDetailsKey(deploymentRuntimeDetailsKey, &metadata)
-	if err != nil || !found {
-		return ""
+	if err == nil && found {
+		if remoteID := strings.TrimSpace(metadata[types.RuntimeMetadataRemoteIDKey]); remoteID != "" {
+			return remoteID
+		}
 	}
-	return strings.TrimSpace(metadata[types.RuntimeMetadataRemoteIDKey])
+	for key, value := range deployment.Metadata.Annotations {
+		if strings.HasSuffix(strings.TrimSpace(key), "/"+types.RuntimeMetadataRemoteIDKey) {
+			if remoteID := strings.TrimSpace(value); remoteID != "" {
+				return remoteID
+			}
+		}
+	}
+	return ""
 }
 
 // deploymentRemoteIDKey scopes a provider identity to its deployment runtime.

--- a/internal/registry/controller/discovery_integration_test.go
+++ b/internal/registry/controller/discovery_integration_test.go
@@ -300,6 +300,27 @@ func TestDeploymentDiscoveryController_DedupesManagedDeploymentRemoteID(t *testi
 	stores := newControllerTestStores(t)
 	seedAgentDeployment(t, stores, "managed-agent", "managed-agent", v1alpha1.DesiredStateDeployed)
 	managed := loadDeployment(t, stores, "managed-agent")
+	require.NoError(t, stores[v1alpha1.KindDeployment].PatchStatus(ctx, "default", managed.Metadata.Name, "", v1alpha1.StatusPatcher(func(status *v1alpha1.Status) {
+		_ = status.SetDetailsKey(deploymentRuntimeDetailsKey, map[string]string{types.RuntimeMetadataRemoteIDKey: "agent-123"})
+	})))
+	source := &discoveryTestAdapter{results: []types.DiscoveryResult{{
+		TargetKind:      v1alpha1.KindAgent,
+		Name:            "provider-name",
+		RuntimeMetadata: map[string]string{types.RuntimeMetadataRemoteIDKey: "agent-123"},
+	}}}
+	discovery := newDeploymentDiscoveryTestController(stores, source)
+
+	result, err := discovery.Sync(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 1, result.Runtimes)
+	require.Zero(t, result.Discovered)
+}
+
+func TestDeploymentDiscoveryController_DedupesLegacyManagedDeploymentRemoteID(t *testing.T) {
+	ctx := context.Background()
+	stores := newControllerTestStores(t)
+	seedAgentDeployment(t, stores, "managed-agent", "managed-agent", v1alpha1.DesiredStateDeployed)
+	managed := loadDeployment(t, stores, "managed-agent")
 	require.NoError(t, stores[v1alpha1.KindDeployment].PatchAnnotations(ctx, "default", managed.Metadata.Name, "", func(annotations map[string]string) map[string]string {
 		if annotations == nil {
 			annotations = map[string]string{}

--- a/internal/registry/controller/reconciler.go
+++ b/internal/registry/controller/reconciler.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"maps"
 	"slices"
 
 	"k8s.io/client-go/util/workqueue"
@@ -307,17 +306,8 @@ func (c *DeploymentController) persistApplyResult(
 		}
 		return nil
 	}
-	if len(result.Conditions) > 0 || len(result.Details) > 0 || fingerprint != "" {
+	if len(result.Conditions) > 0 || len(result.Details) > 0 || len(result.RuntimeMetadata) > 0 || fingerprint != "" {
 		patch.Status = deploymentControllerStatusPatch(deployment, result, fingerprint, forceToken, dependencies)
-	}
-	if len(result.RuntimeMetadata) > 0 {
-		patch.Annotations = func(annotations map[string]string) map[string]string {
-			if annotations == nil {
-				annotations = map[string]string{}
-			}
-			maps.Copy(annotations, result.RuntimeMetadata)
-			return annotations
-		}
 	}
 	if err := c.deploymentStore().ApplyPatch(ctx, deployment.Metadata.NamespaceOrDefault(), deployment.Metadata.Name, "", patch); err != nil {
 		return fmt.Errorf("persist apply result: %w", err)
@@ -342,6 +332,9 @@ func deploymentControllerStatusPatch(
 			}
 			for key, encoded := range result.Details {
 				_ = s.SetDetailsKeyJSON(key, encoded)
+			}
+			if len(result.RuntimeMetadata) > 0 {
+				_ = s.SetDetailsKey(deploymentRuntimeDetailsKey, result.RuntimeMetadata)
 			}
 		}
 		if fingerprint != "" {

--- a/internal/registry/controller/reconciler_integration_test.go
+++ b/internal/registry/controller/reconciler_integration_test.go
@@ -24,7 +24,7 @@ func TestDeploymentController_EnqueuesAndExecutesApply(t *testing.T) {
 	seedMCPServer(t, stores, "weather")
 	deployment := seedDeployment(t, stores, "weather-deploy", v1alpha1.DesiredStateDeployed)
 
-	adapter := &recordingDeploymentAdapter{}
+	adapter := &recordingDeploymentAdapter{runtimeMetadata: map[string]string{types.RuntimeMetadataRemoteIDKey: "agent-123"}}
 	controller := newDeploymentTestController(stores, adapter)
 	_, err := controller.FullReconcile(ctx)
 	require.NoError(t, err)
@@ -42,6 +42,11 @@ func TestDeploymentController_EnqueuesAndExecutesApply(t *testing.T) {
 	require.NotNil(t, ready)
 	require.Equal(t, v1alpha1.ConditionTrue, ready.Status)
 	require.Equal(t, deployment.Metadata.Generation, ready.ObservedGeneration)
+	var runtimeMetadata map[string]string
+	ok, err := got.Status.GetDetailsKey(deploymentRuntimeDetailsKey, &runtimeMetadata)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, "agent-123", runtimeMetadata[types.RuntimeMetadataRemoteIDKey])
 }
 
 func TestDeploymentController_SkipsUnchangedApplyAfterRepairReconcile(t *testing.T) {
@@ -571,6 +576,7 @@ type recordingDeploymentAdapter struct {
 	lastApplyGeneration atomic.Int64
 	applyErr            error
 	removeErr           error
+	runtimeMetadata     map[string]string
 }
 
 func (a *recordingDeploymentAdapter) Type() string { return "Test" }
@@ -588,6 +594,7 @@ func (a *recordingDeploymentAdapter) Apply(_ context.Context, input types.ApplyI
 		return nil, a.applyErr
 	}
 	return &types.ApplyResult{
+		RuntimeMetadata: a.runtimeMetadata,
 		Conditions: []v1alpha1.Condition{{
 			Type:               "Ready",
 			Status:             v1alpha1.ConditionTrue,

--- a/pkg/types/adapter.go
+++ b/pkg/types/adapter.go
@@ -106,8 +106,8 @@ type ApplyInput struct {
 	Getter v1alpha1.GetterFunc
 }
 
-// ApplyResult captures the status + annotation deltas the reconciler
-// should persist after Apply.
+// ApplyResult captures the status updates the reconciler should persist after
+// Apply.
 type ApplyResult struct {
 	// Conditions to merge into Deployment.Status via
 	// Store.PatchStatus. Canonical types:
@@ -117,16 +117,15 @@ type ApplyResult struct {
 	//   - "Degraded"    — transient failure, will retry
 	Conditions []v1alpha1.Condition
 
-	// RuntimeMetadata carries adapter-internal state to persist
-	// into Deployment.Metadata.Annotations (keyed under
-	// runtimes.agentregistry.solo.io/<type>/*). Callers marshal
-	// to string values since Annotations is map[string]string.
+	// RuntimeMetadata carries provider state persisted in
+	// Deployment.Status.Details.runtimeMetadata.
 	RuntimeMetadata map[string]string
 
 	// Details is a map of top-level keys to JSON-encoded values to merge into
 	// Deployment.Status.Details via Status.SetDetailsKeyJSON. Each adapter owns its
-	// own top-level key; other keys in Status.Details are preserved across
-	// the patch. A nil value at a key removes that key.
+	// own top-level key; other keys in Status.Details are preserved across the
+	// patch. The "runtimeMetadata" key is reserved for RuntimeMetadata and must not
+	// be set here. A nil value at a key removes that key.
 	//
 	// Use Details for structured state that Conditions cannot express cleanly;
 	// stable, typed status should still be modeled as Conditions.


### PR DESCRIPTION
# Description

Store provider runtime metadata in Deployment status so user object applies
cannot remove discovery correlation state. Retain annotation reads only as an
upgrade fallback for existing managed Deployments.

# Change Type

/kind fix

# Changelog

```release-note
Runtime provider metadata is now persisted in Deployment status.
```
