### PR TITLE
api: allow OpenAI Responses agent protocol

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -28,6 +28,7 @@ components:
           enum:
           - A2A
           - HTTP
+          - OpenAIResponses
           type: string
         repository:
           $ref: '#/components/schemas/Repository'

--- a/pkg/api/v1alpha1/agent.go
+++ b/pkg/api/v1alpha1/agent.go
@@ -81,15 +81,16 @@ type AgentSource struct {
 	// Protocol is the application protocol spoken by every runnable form of the
 	// agent, whether built from Repository or supplied as Image. When omitted,
 	// A2A is inferred as the default.
-	Protocol *AgentProtocol `json:"protocol,omitempty" yaml:"protocol,omitempty" enum:"A2A,HTTP"`
+	Protocol *AgentProtocol `json:"protocol,omitempty" yaml:"protocol,omitempty" enum:"A2A,HTTP,OpenAIResponses"`
 }
 
 // AgentProtocol is the application protocol exposed by an Agent source.
 type AgentProtocol string
 
 const (
-	AgentProtocolA2A  AgentProtocol = "A2A"
-	AgentProtocolHTTP AgentProtocol = "HTTP"
+	AgentProtocolA2A             AgentProtocol = "A2A"
+	AgentProtocolHTTP            AgentProtocol = "HTTP"
+	AgentProtocolOpenAIResponses AgentProtocol = "OpenAIResponses"
 )
 
 // HarnessCompatibility declares one harness family this Agent can run under.

--- a/pkg/api/v1alpha1/agent_validate.go
+++ b/pkg/api/v1alpha1/agent_validate.go
@@ -72,9 +72,10 @@ func validateAgentSpec(s *AgentSpec) FieldErrors {
 		if s.Source.Protocol != nil {
 			protocol := ptr.Deref(s.Source.Protocol, AgentProtocol(""))
 			switch protocol {
-			case AgentProtocolA2A, AgentProtocolHTTP:
+			case AgentProtocolA2A, AgentProtocolHTTP, AgentProtocolOpenAIResponses:
 			default:
-				errs.Append("spec.source.protocol", fmt.Errorf("%w: must be %q or %q, got %q", ErrInvalidFormat, AgentProtocolA2A, AgentProtocolHTTP, protocol))
+				errs.Append("spec.source.protocol", fmt.Errorf("%w: must be %q, %q, or %q, got %q", ErrInvalidFormat,
+					AgentProtocolA2A, AgentProtocolHTTP, AgentProtocolOpenAIResponses, protocol))
 			}
 		}
 	}

--- a/pkg/api/v1alpha1/validation_test.go
+++ b/pkg/api/v1alpha1/validation_test.go
@@ -127,6 +127,7 @@ func TestAgentValidate_Protocol(t *testing.T) {
 		{name: "omitted defaults at consumption"},
 		{name: "A2A", protocol: new(AgentProtocolA2A)},
 		{name: "HTTP", protocol: new(AgentProtocolHTTP)},
+		{name: "OpenAI Responses", protocol: new(AgentProtocolOpenAIResponses)},
 		{name: "reject empty", protocol: new(AgentProtocol("")), wantErr: true},
 		{name: "reject lowercase", protocol: new(AgentProtocol("http")), wantErr: true},
 		{name: "reject unknown", protocol: new(AgentProtocol("GRPC")), wantErr: true},

--- a/ui/lib/api/types.gen.ts
+++ b/ui/lib/api/types.gen.ts
@@ -14,7 +14,7 @@ export type Agent = {
 
 export type AgentSource = {
     image?: string;
-    protocol?: 'A2A' | 'HTTP';
+    protocol?: 'A2A' | 'HTTP' | 'OpenAIResponses';
     repository?: Repository;
 };
 


### PR DESCRIPTION
# Description

Allow agents to declare the OpenAI Responses application protocol so runtime
providers and invocation clients can select its request contract.

# Change Type

/kind feature

# Changelog

```release-note
Agents can declare OpenAIResponses as their source protocol.
```
