### PR TITLE
internal: Fix descriptor-driven CLI kinds

### DIFF
--- a/internal/cli/commands/all_tags_test.go
+++ b/internal/cli/commands/all_tags_test.go
@@ -18,12 +18,7 @@ import (
 	cliruntime "github.com/agentregistry-dev/agentregistry/pkg/cli/runtime"
 )
 
-var activeDeclarativeTestClient *client.Client
-
 func declarativeTestDeps(c *client.Client) cliruntime.Deps {
-	if c == nil {
-		c = activeDeclarativeTestClient
-	}
 	if c == nil {
 		c = client.NewClient("http://127.0.0.1:1", "")
 	}
@@ -44,18 +39,9 @@ func (e declarativeTestEnv) Getenv(key string) string {
 	return e[key]
 }
 
-func setDeclarativeTestClient(t *testing.T, c *client.Client) {
+func setupClientForServer(t *testing.T, srv *httptest.Server) cliruntime.Deps {
 	t.Helper()
-	prev := activeDeclarativeTestClient
-	activeDeclarativeTestClient = c
-	t.Cleanup(func() {
-		activeDeclarativeTestClient = prev
-	})
-}
-
-func setupClientForServer(t *testing.T, srv *httptest.Server) {
-	t.Helper()
-	setDeclarativeTestClient(t, client.NewClient(srv.URL, ""))
+	return declarativeTestDeps(client.NewClient(srv.URL, ""))
 }
 
 // agentTagFixture builds a minimal Agent envelope at the given tag for use
@@ -113,10 +99,10 @@ func TestGet_AllTags_Agent_PrintsAllRows(t *testing.T) {
 		agentTagFixture("acme-bot", "1"),
 	}
 	srv, _ := tagsListServer(t, rows)
-	setupClientForServer(t, srv)
+	deps := setupClientForServer(t, srv)
 
 	out := &bytes.Buffer{}
-	cmd := commands.NewGetCmd(declarativeTestDeps(nil))
+	cmd := commands.NewGetCmd(deps)
 	cmd.SetOut(out)
 	cmd.SetErr(out)
 	cmd.SetArgs([]string{"agent", "acme-bot", "--all-tags"})
@@ -139,9 +125,9 @@ func TestGet_AllTags_Agent_PrintsAllRowsByNamespaceName(t *testing.T) {
 		agentTagFixture("acme-bot", "1"),
 	}
 	srv, paths := tagsListServer(t, rows)
-	setupClientForServer(t, srv)
+	deps := setupClientForServer(t, srv)
 
-	cmd := commands.NewGetCmd(declarativeTestDeps(nil))
+	cmd := commands.NewGetCmd(deps)
 	cmd.SetOut(&bytes.Buffer{})
 	cmd.SetErr(&bytes.Buffer{})
 	cmd.SetArgs([]string{"agent", "team-a/acme-bot", "--all-tags"})
@@ -158,10 +144,10 @@ func TestGet_AllTags_Agent_JSONOutput(t *testing.T) {
 		agentTagFixture("acme-bot", "1"),
 	}
 	srv, _ := tagsListServer(t, rows)
-	setupClientForServer(t, srv)
+	deps := setupClientForServer(t, srv)
 
 	out := &bytes.Buffer{}
-	cmd := commands.NewGetCmd(declarativeTestDeps(nil))
+	cmd := commands.NewGetCmd(deps)
 	cmd.SetOut(out)
 	cmd.SetErr(out)
 	cmd.SetArgs([]string{"agent", "acme-bot", "--all-tags", "-o", "json"})
@@ -177,8 +163,6 @@ func TestGet_AllTags_Agent_JSONOutput(t *testing.T) {
 // (3) `arctl get deployment NAME --all-tags` errors cleanly because
 // deployments are mutable namespace/name objects, not taggable artifacts.
 func TestGet_AllTags_DeploymentRejected(t *testing.T) {
-	setDeclarativeTestClient(t, client.NewClient("http://127.0.0.1:1", ""))
-
 	cmd := commands.NewGetCmd(declarativeTestDeps(nil))
 	cmd.SetArgs([]string{"deployment", "summarizer", "--all-tags"})
 	err := cmd.Execute()
@@ -188,8 +172,6 @@ func TestGet_AllTags_DeploymentRejected(t *testing.T) {
 }
 
 func TestGet_AllTags_RuntimeRejected(t *testing.T) {
-	setDeclarativeTestClient(t, client.NewClient("http://127.0.0.1:1", ""))
-
 	cmd := commands.NewGetCmd(declarativeTestDeps(nil))
 	cmd.SetArgs([]string{"runtime", "my-kagent", "--all-tags"})
 	err := cmd.Execute()
@@ -201,8 +183,6 @@ func TestGet_AllTags_RuntimeRejected(t *testing.T) {
 // (4) `arctl get agents --all-tags` (no NAME) errors — the flag
 // requires a NAME argument.
 func TestGet_AllTags_RequiresName(t *testing.T) {
-	setDeclarativeTestClient(t, client.NewClient("http://127.0.0.1:1", ""))
-
 	cmd := commands.NewGetCmd(declarativeTestDeps(nil))
 	cmd.SetArgs([]string{"agents", "--all-tags"})
 	err := cmd.Execute()
@@ -262,10 +242,10 @@ func TestDelete_AllTags_Agent_DeletesEveryListedTag(t *testing.T) {
 		agentTagFixture("acme-bot", "latest"),
 	}
 	srv, paths := deleteAllTagsServer(t, rows, "")
-	setupClientForServer(t, srv)
+	deps := setupClientForServer(t, srv)
 
 	out := &bytes.Buffer{}
-	cmd := commands.NewDeleteCmd(declarativeTestDeps(nil))
+	cmd := commands.NewDeleteCmd(deps)
 	cmd.SetOut(out)
 	cmd.SetErr(out)
 	cmd.SetArgs([]string{"agent", "acme-bot", "--all-tags"})
@@ -283,9 +263,9 @@ func TestDelete_AllTags_Agent_DeletesEveryListedTagByNamespaceName(t *testing.T)
 		agentTagFixture("acme-bot", "latest"),
 	}
 	srv, paths := deleteAllTagsServer(t, rows, "")
-	setupClientForServer(t, srv)
+	deps := setupClientForServer(t, srv)
 
-	cmd := commands.NewDeleteCmd(declarativeTestDeps(nil))
+	cmd := commands.NewDeleteCmd(deps)
 	cmd.SetOut(&bytes.Buffer{})
 	cmd.SetErr(&bytes.Buffer{})
 	cmd.SetArgs([]string{"agent", "team-a/acme-bot", "--all-tags"})
@@ -298,8 +278,6 @@ func TestDelete_AllTags_Agent_DeletesEveryListedTagByNamespaceName(t *testing.T)
 
 // (7) `arctl delete deployment NAME --all-tags` errors cleanly.
 func TestDelete_AllTags_DeploymentRejected(t *testing.T) {
-	setDeclarativeTestClient(t, client.NewClient("http://127.0.0.1:1", ""))
-
 	cmd := commands.NewDeleteCmd(declarativeTestDeps(nil))
 	cmd.SetArgs([]string{"deployment", "summarizer", "--all-tags"})
 	err := cmd.Execute()
@@ -310,8 +288,6 @@ func TestDelete_AllTags_DeploymentRejected(t *testing.T) {
 // (7b) `arctl delete runtime NAME --all-tags` errors cleanly —
 // Runtime has no DeleteAllTags endpoint server-side.
 func TestDelete_AllTags_ProviderRejected(t *testing.T) {
-	setDeclarativeTestClient(t, client.NewClient("http://127.0.0.1:1", ""))
-
 	cmd := commands.NewDeleteCmd(declarativeTestDeps(nil))
 	cmd.SetArgs([]string{"runtime", "my-kagent", "--all-tags"})
 	err := cmd.Execute()
@@ -333,9 +309,9 @@ func TestDelete_AllTags_AndTagMutuallyExclusive(t *testing.T) {
 func TestDelete_AllTags_PropagatesServerFailure(t *testing.T) {
 	rows := []v1alpha1.Agent{agentTagFixture("acme-bot", "stable")}
 	srv, _ := deleteAllTagsServer(t, rows, "stable")
-	setupClientForServer(t, srv)
+	deps := setupClientForServer(t, srv)
 
-	cmd := commands.NewDeleteCmd(declarativeTestDeps(nil))
+	cmd := commands.NewDeleteCmd(deps)
 	cmd.SetArgs([]string{"agent", "acme-bot", "--all-tags"})
 	err := cmd.Execute()
 	require.Error(t, err)

--- a/internal/cli/commands/all_tags_test.go
+++ b/internal/cli/commands/all_tags_test.go
@@ -187,11 +187,7 @@ func TestGet_AllTags_DeploymentRejected(t *testing.T) {
 	assert.Contains(t, err.Error(), "deployment")
 }
 
-// (3b) `arctl get runtime NAME --all-tags` errors cleanly — Runtime
-// is a mutable namespace/name object whose store has no /tags endpoint.
-// Pin the CLI surface so a future typedKind change can't
-// silently re-expose --all-tags for Runtime.
-func TestGet_AllTags_ProviderRejected(t *testing.T) {
+func TestGet_AllTags_RuntimeRejected(t *testing.T) {
 	setDeclarativeTestClient(t, client.NewClient("http://127.0.0.1:1", ""))
 
 	cmd := commands.NewGetCmd(declarativeTestDeps(nil))

--- a/internal/cli/commands/declarative.go
+++ b/internal/cli/commands/declarative.go
@@ -227,7 +227,7 @@ func newKindFromDescriptor(
 			return listAny(ctx, c, descriptor.Kind, opts, newObj)
 		},
 		Delete: func(ctx context.Context, c *client.Client, name, tag string) error {
-			return deleteAny(ctx, c, descriptor.Kind, name, tag, newObj)
+			return deleteAny(ctx, c, descriptor.Kind, name, tag, tagged, newObj)
 		},
 	}
 	if tagged {

--- a/internal/cli/commands/declarative.go
+++ b/internal/cli/commands/declarative.go
@@ -139,20 +139,65 @@ func registerKind[T v1alpha1.Object](
 	if !ok {
 		panic("commands.registerKind: v1alpha1 kind is not registered: " + canonicalKind)
 	}
-	if plural == "" {
-		plural = descriptor.Plural
-	}
 	if obj := descriptor.NewObject(); obj == nil {
 		panic("commands.registerKind: constructor for " + canonicalKind + " returned nil")
 	} else if _, ok := obj.(T); !ok {
 		panic(fmt.Sprintf("commands.registerKind: constructor for %s returned %T", canonicalKind, obj))
 	}
-	newObj := func() T {
+	newObj := func() v1alpha1.Object {
 		obj, ok := descriptor.NewObject().(T)
 		if !ok {
 			panic(fmt.Sprintf("commands.registerKind: constructor for %s returned %T", canonicalKind, obj))
 		}
 		return obj
+	}
+	rowObject := func(obj v1alpha1.Object) []string {
+		t, ok := obj.(T)
+		if !ok {
+			return []string{"<invalid>"}
+		}
+		return row(t)
+	}
+	scheme.Register(newKindFromDescriptor(
+		descriptor,
+		cliName,
+		plural,
+		aliases,
+		columns,
+		newObj,
+		rowObject,
+		opts...,
+	))
+}
+
+func newKindFromDescriptor(
+	descriptor v1alpha1.KindDescriptor,
+	cliName, plural string,
+	aliases []string,
+	columns []scheme.Column,
+	newObj func() v1alpha1.Object,
+	row func(v1alpha1.Object) []string,
+	opts ...kindOption,
+) *scheme.Kind {
+	if plural == "" {
+		plural = descriptor.Plural
+	}
+	if newObj == nil {
+		newObj = func() v1alpha1.Object {
+			obj, ok := descriptor.NewObject().(v1alpha1.Object)
+			if !ok {
+				panic(fmt.Sprintf("commands: constructor for %s returned %T", descriptor.Kind, obj))
+			}
+			return obj
+		}
+	}
+	if obj := newObj(); obj == nil {
+		panic("commands: constructor for " + descriptor.Kind + " returned nil")
+	}
+	if row == nil {
+		row = func(obj v1alpha1.Object) []string {
+			return []string{obj.GetMetadata().Name}
+		}
 	}
 	tagged := descriptor.Storage == v1alpha1.KindStorageTaggedArtifact
 	k := &scheme.Kind{
@@ -162,11 +207,11 @@ func registerKind[T v1alpha1.Object](
 		TableColumns: columns,
 		ToYAMLFunc:   func(item any) any { return item },
 		RowFunc: func(item any) []string {
-			t, ok := item.(T)
+			obj, ok := item.(v1alpha1.Object)
 			if !ok {
 				return []string{"<invalid>"}
 			}
-			return row(t)
+			return row(obj)
 		},
 		Get: func(ctx context.Context, c *client.Client, name, tag string) (any, error) {
 			ref, err := parseResourceLookupRef(name)
@@ -176,21 +221,21 @@ func registerKind[T v1alpha1.Object](
 			if !tagged {
 				tag = ""
 			}
-			return client.GetTyped(ctx, c, canonicalKind, ref.Namespace, ref.Name, tag, newObj)
+			return client.GetTyped(ctx, c, descriptor.Kind, ref.Namespace, ref.Name, tag, newObj)
 		},
 		ListFunc: func(ctx context.Context, c *client.Client, opts scheme.ListOpts) ([]any, error) {
-			return listAny(ctx, c, canonicalKind, opts, newObj)
+			return listAny(ctx, c, descriptor.Kind, opts, newObj)
 		},
 		Delete: func(ctx context.Context, c *client.Client, name, tag string) error {
-			return deleteAny(ctx, c, canonicalKind, name, tag, newObj)
+			return deleteAny(ctx, c, descriptor.Kind, name, tag, newObj)
 		},
 	}
 	if tagged {
 		k.ListTags = func(ctx context.Context, c *client.Client, name string) ([]any, error) {
-			return listTagsAny(ctx, c, canonicalKind, name, newObj)
+			return listTagsAny(ctx, c, descriptor.Kind, name, newObj)
 		}
 		k.DeleteAllTags = func(ctx context.Context, c *client.Client, name string) error {
-			return deleteAllTagsAny(ctx, c, canonicalKind, name, newObj)
+			return deleteAllTagsAny(ctx, c, descriptor.Kind, name, newObj)
 		}
 	}
 	for _, opt := range opts {
@@ -198,5 +243,5 @@ func registerKind[T v1alpha1.Object](
 			opt(k)
 		}
 	}
-	scheme.Register(k)
+	return k
 }

--- a/internal/cli/commands/delete_test.go
+++ b/internal/cli/commands/delete_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/agentregistry-dev/agentregistry/internal/cli/commands"
-	"github.com/agentregistry-dev/agentregistry/internal/client"
 	arv0 "github.com/agentregistry-dev/agentregistry/pkg/api/v0"
 	cliruntime "github.com/agentregistry-dev/agentregistry/pkg/cli/runtime"
 )
@@ -37,22 +36,16 @@ func newDeleteTestServer(t *testing.T, results []arv0.ApplyResult) (*httptest.Se
 	return srv, captured
 }
 
-// setupDeleteClient wires a client pointing at srv into the declarative package.
-func setupDeleteClient(t *testing.T, srv *httptest.Server) {
-	t.Helper()
-	setDeclarativeTestClient(t, client.NewClient(srv.URL, ""))
-}
-
 // TestDeleteFileModeUsesDeleteApplyEndpoint verifies that -f sends DELETE to /v0/apply.
 func TestDeleteFileModeUsesDeleteApplyEndpoint(t *testing.T) {
 	results := []arv0.ApplyResult{
 		{Kind: "agent", Name: "acme-bot", Tag: "1.0.0", Status: arv0.ApplyStatusDeleted},
 	}
 	srv, captured := newDeleteTestServer(t, results)
-	setupDeleteClient(t, srv)
+	deps := setupClientForServer(t, srv)
 
 	var buf bytes.Buffer
-	cmd := commands.NewDeleteCmd(declarativeTestDeps(nil))
+	cmd := commands.NewDeleteCmd(deps)
 	cmd.SetOut(&buf)
 	cmd.SetErr(&buf)
 	cmd.SetArgs([]string{"-f", writeTempYAML(t, agentYAML)})
@@ -68,10 +61,10 @@ func TestDeleteFileModeReportsResults(t *testing.T) {
 		{Kind: "agent", Name: "acme-bot", Tag: "1.0.0", Status: arv0.ApplyStatusDeleted},
 	}
 	srv, _ := newDeleteTestServer(t, results)
-	setupDeleteClient(t, srv)
+	deps := setupClientForServer(t, srv)
 
 	var out bytes.Buffer
-	cmd := commands.NewDeleteCmd(declarativeTestDeps(nil))
+	cmd := commands.NewDeleteCmd(deps)
 	cmd.SetOut(&out)
 	cmd.SetErr(&out)
 	cmd.SetArgs([]string{"-f", writeTempYAML(t, agentYAML)})
@@ -86,9 +79,9 @@ func TestDeleteFileModeFailedResultsReturnError(t *testing.T) {
 		{Kind: "agent", Name: "acme-bot", Status: arv0.ApplyStatusFailed, Error: "not found"},
 	}
 	srv, _ := newDeleteTestServer(t, results)
-	setupDeleteClient(t, srv)
+	deps := setupClientForServer(t, srv)
 
-	cmd := commands.NewDeleteCmd(declarativeTestDeps(nil))
+	cmd := commands.NewDeleteCmd(deps)
 	cmd.SetArgs([]string{"-f", writeTempYAML(t, agentYAML)})
 	err := cmd.Execute()
 	require.Error(t, err)

--- a/internal/cli/commands/delete_test.go
+++ b/internal/cli/commands/delete_test.go
@@ -124,6 +124,25 @@ func TestDeleteExplicitModeWithoutTag(t *testing.T) {
 	assert.NotContains(t, err.Error(), "tag")
 }
 
+func TestDeleteExplicitUntaggedSkipsGet(t *testing.T) {
+	var requests []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests = append(requests, r.Method+" "+r.URL.RequestURI())
+		if r.Method == http.MethodGet {
+			http.Error(w, "forbidden", http.StatusForbidden)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(srv.Close)
+
+	cmd := commands.NewDeleteCmd(setupClientForServer(t, srv))
+	cmd.SetArgs([]string{"runtime", "team-a/my-aws"})
+	require.NoError(t, cmd.Execute())
+
+	assert.Equal(t, []string{"DELETE /v0/runtimes/my-aws?namespace=team-a"}, requests)
+}
+
 // TestDeleteExplicitModeRequiresTwoArgs verifies that explicit mode without two args errors.
 func TestDeleteExplicitModeRequiresTwoArgs(t *testing.T) {
 	cmd := commands.NewDeleteCmd(declarativeTestDeps(nil))

--- a/internal/cli/commands/deployment_delete_test.go
+++ b/internal/cli/commands/deployment_delete_test.go
@@ -18,13 +18,13 @@ import (
 
 // deploymentTestServer builds an httptest.Server routing:
 //   - GET    /v0/deployments                → returns `list`
-//   - DELETE /v0/deployments/{name}         → status 204 unless id is in `failIDs`, then 500
+//   - DELETE /v0/deployments/{name}         → returns 404, 500, or 204 from fixture state
 //
-// Captures every received DELETE id in order for assertions.
+// Captures DELETE targets and queries after they match an existing fixture.
 func deploymentTestServer(t *testing.T, list []v1alpha1.Deployment, failIDs map[string]bool) (*httptest.Server, *[]string, *[]string) {
 	t.Helper()
 	var mu sync.Mutex
-	deleted := make([]string, 0)
+	deleteTargets := make([]string, 0)
 	capturedQuery := make([]string, 0)
 	mux := http.NewServeMux()
 	mux.HandleFunc("/v0/deployments", func(w http.ResponseWriter, r *http.Request) {
@@ -59,9 +59,24 @@ func deploymentTestServer(t *testing.T, list []v1alpha1.Deployment, failIDs map[
 			}
 			w.WriteHeader(http.StatusNotFound)
 		case http.MethodDelete:
+			namespace := r.URL.Query().Get("namespace")
+			if namespace == "" {
+				namespace = v1alpha1.DefaultNamespace
+			}
+			found := false
+			for _, d := range list {
+				if d.Metadata.Name == parts[0] && d.Metadata.NamespaceOrDefault() == namespace {
+					found = true
+					break
+				}
+			}
+			if !found {
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
 			mu.Lock()
 			capturedQuery = append(capturedQuery, r.URL.RawQuery)
-			deleted = append(deleted, parts[0])
+			deleteTargets = append(deleteTargets, parts[0])
 			mu.Unlock()
 			if failIDs[parts[0]] {
 				http.Error(w, fmt.Sprintf(`{"error":"simulated delete failure for %s"}`, parts[0]), http.StatusInternalServerError)
@@ -75,7 +90,7 @@ func deploymentTestServer(t *testing.T, list []v1alpha1.Deployment, failIDs map[
 	})
 	srv := httptest.NewServer(mux)
 	t.Cleanup(srv.Close)
-	return srv, &deleted, &capturedQuery
+	return srv, &deleteTargets, &capturedQuery
 }
 
 // (1) Deployment delete addresses the Deployment metadata.name. Deployments do
@@ -88,14 +103,14 @@ func TestDeploymentDelete_RemovesNamedDeployment(t *testing.T) {
 		deploymentFixture("aws-v2", "summarizer", "2.0.0", "my-aws", "agent", "pending"),
 		deploymentFixture("other", "unrelated", "1.0.0", "my-aws", "agent", "pending"),
 	}
-	srv, deleted, _ := deploymentTestServer(t, deployments, nil)
+	srv, deleteTargets, _ := deploymentTestServer(t, deployments, nil)
 	deps := setupClientForServer(t, srv)
 
 	cmd := commands.NewDeleteCmd(deps)
 	cmd.SetArgs([]string{"deployment", "aws-v1"})
 	require.NoError(t, cmd.Execute())
 
-	assert.ElementsMatch(t, []string{"aws-v1"}, *deleted,
+	assert.ElementsMatch(t, []string{"aws-v1"}, *deleteTargets,
 		"only the named Deployment should be deleted; same-target variants stay untouched")
 }
 
@@ -103,14 +118,14 @@ func TestDeploymentDelete_RemovesMatchByNamespaceName(t *testing.T) {
 	defaultDeployment := deploymentFixture("aws-v1", "default-summarizer", "1.0.0", "my-aws", "agent", "pending")
 	teamDeployment := deploymentFixture("aws-v1", "team-summarizer", "1.0.0", "my-aws", "agent", "pending")
 	teamDeployment.Metadata.Namespace = "team-a"
-	srv, deleted, capturedQuery := deploymentTestServer(t, []v1alpha1.Deployment{defaultDeployment, teamDeployment}, nil)
+	srv, deleteTargets, capturedQuery := deploymentTestServer(t, []v1alpha1.Deployment{defaultDeployment, teamDeployment}, nil)
 	deps := setupClientForServer(t, srv)
 
 	cmd := commands.NewDeleteCmd(deps)
 	cmd.SetArgs([]string{"deployment", "team-a/aws-v1"})
 	require.NoError(t, cmd.Execute())
 
-	assert.ElementsMatch(t, []string{"aws-v1"}, *deleted)
+	assert.ElementsMatch(t, []string{"aws-v1"}, *deleteTargets)
 	require.Len(t, *capturedQuery, 1)
 	assert.Equal(t, "namespace=team-a", (*capturedQuery)[0])
 }
@@ -120,7 +135,7 @@ func TestDeploymentDelete_NotFound(t *testing.T) {
 	deployments := []v1alpha1.Deployment{
 		deploymentFixture("aws-v2", "other-target", "2.0.0", "my-aws", "agent", "pending"),
 	}
-	srv, deleted, _ := deploymentTestServer(t, deployments, nil)
+	srv, deleteTargets, _ := deploymentTestServer(t, deployments, nil)
 	deps := setupClientForServer(t, srv)
 
 	cmd := commands.NewDeleteCmd(deps)
@@ -129,7 +144,7 @@ func TestDeploymentDelete_NotFound(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not found",
 		"no match should surface the registry not-found sentinel")
-	assert.Empty(t, *deleted, "no DELETE requests should be issued when nothing matches")
+	assert.Empty(t, *deleteTargets, "no existing deployment should be matched for deletion")
 }
 
 func TestDeploymentDelete_ServerFailure(t *testing.T) {
@@ -138,7 +153,7 @@ func TestDeploymentDelete_ServerFailure(t *testing.T) {
 		deploymentFixture("gcp-v1", "summarizer", "1.0.0", "my-gcp", "agent", "pending"),
 	}
 	// Fail the GCP delete only.
-	srv, deleted, _ := deploymentTestServer(t, deployments, map[string]bool{"gcp-v1": true})
+	srv, deleteTargets, _ := deploymentTestServer(t, deployments, map[string]bool{"gcp-v1": true})
 	deps := setupClientForServer(t, srv)
 
 	cmd := commands.NewDeleteCmd(deps)
@@ -147,8 +162,7 @@ func TestDeploymentDelete_ServerFailure(t *testing.T) {
 	require.Error(t, err, "failure must propagate")
 	assert.Contains(t, err.Error(), "gcp-v1", "error should identify which deployment failed")
 
-	// Both DELETEs should have been attempted — we don't stop on first failure.
-	assert.ElementsMatch(t, []string{"gcp-v1"}, *deleted)
+	assert.ElementsMatch(t, []string{"gcp-v1"}, *deleteTargets)
 }
 
 // (4) --tag is rejected for every mutable namespace/name kind.

--- a/internal/cli/commands/deployment_delete_test.go
+++ b/internal/cli/commands/deployment_delete_test.go
@@ -89,9 +89,9 @@ func TestDeploymentDelete_RemovesNamedDeployment(t *testing.T) {
 		deploymentFixture("other", "unrelated", "1.0.0", "my-aws", "agent", "pending"),
 	}
 	srv, deleted, _ := deploymentTestServer(t, deployments, nil)
-	setupClientForServer(t, srv)
+	deps := setupClientForServer(t, srv)
 
-	cmd := commands.NewDeleteCmd(declarativeTestDeps(nil))
+	cmd := commands.NewDeleteCmd(deps)
 	cmd.SetArgs([]string{"deployment", "aws-v1"})
 	require.NoError(t, cmd.Execute())
 
@@ -104,9 +104,9 @@ func TestDeploymentDelete_RemovesMatchByNamespaceName(t *testing.T) {
 	teamDeployment := deploymentFixture("aws-v1", "team-summarizer", "1.0.0", "my-aws", "agent", "pending")
 	teamDeployment.Metadata.Namespace = "team-a"
 	srv, deleted, capturedQuery := deploymentTestServer(t, []v1alpha1.Deployment{defaultDeployment, teamDeployment}, nil)
-	setupClientForServer(t, srv)
+	deps := setupClientForServer(t, srv)
 
-	cmd := commands.NewDeleteCmd(declarativeTestDeps(nil))
+	cmd := commands.NewDeleteCmd(deps)
 	cmd.SetArgs([]string{"deployment", "team-a/aws-v1"})
 	require.NoError(t, cmd.Execute())
 
@@ -121,9 +121,9 @@ func TestDeploymentDelete_NotFound(t *testing.T) {
 		deploymentFixture("aws-v2", "other-target", "2.0.0", "my-aws", "agent", "pending"),
 	}
 	srv, deleted, _ := deploymentTestServer(t, deployments, nil)
-	setupClientForServer(t, srv)
+	deps := setupClientForServer(t, srv)
 
-	cmd := commands.NewDeleteCmd(declarativeTestDeps(nil))
+	cmd := commands.NewDeleteCmd(deps)
 	cmd.SetArgs([]string{"deployment", "summarizer"})
 	err := cmd.Execute()
 	require.Error(t, err)
@@ -139,9 +139,9 @@ func TestDeploymentDelete_ServerFailure(t *testing.T) {
 	}
 	// Fail the GCP delete only.
 	srv, deleted, _ := deploymentTestServer(t, deployments, map[string]bool{"gcp-v1": true})
-	setupClientForServer(t, srv)
+	deps := setupClientForServer(t, srv)
 
-	cmd := commands.NewDeleteCmd(declarativeTestDeps(nil))
+	cmd := commands.NewDeleteCmd(deps)
 	cmd.SetArgs([]string{"deployment", "gcp-v1"})
 	err := cmd.Execute()
 	require.Error(t, err, "failure must propagate")
@@ -172,9 +172,9 @@ func TestDeploymentDelete_OmitsLegacyForceQueryParam(t *testing.T) {
 	}
 
 	srv, _, capturedQuery := deploymentTestServer(t, deployments, map[string]bool{"gcp-v1": true})
-	setupClientForServer(t, srv)
+	deps := setupClientForServer(t, srv)
 
-	cmd := commands.NewDeleteCmd(declarativeTestDeps(nil))
+	cmd := commands.NewDeleteCmd(deps)
 	cmd.SetArgs([]string{"deployment", "aws-v1"})
 	require.NoError(t, cmd.Execute())
 

--- a/internal/cli/commands/deployment_get_test.go
+++ b/internal/cli/commands/deployment_get_test.go
@@ -126,10 +126,10 @@ func TestDeploymentGet_ReturnsMatchByName(t *testing.T) {
 		deploymentFixture("other", "unrelated", "1.0.0", "my-aws", "agent", "deployed"),
 	}
 	srv := deploymentTestServerV1Alpha1(t, deployments)
-	setupClientForServer(t, srv)
+	deps := setupClientForServer(t, srv)
 
 	out := &bytes.Buffer{}
-	cmd := commands.NewGetCmd(declarativeTestDeps(nil))
+	cmd := commands.NewGetCmd(deps)
 	cmd.SetOut(out)
 	cmd.SetArgs([]string{"deployment", "aws-v1"})
 	require.NoError(t, cmd.Execute())
@@ -146,10 +146,10 @@ func TestDeploymentGet_ReturnsMatchByNamespaceName(t *testing.T) {
 	teamDeployment.Metadata.Namespace = "team-a"
 
 	srv := deploymentTestServerV1Alpha1(t, []v1alpha1.Deployment{defaultDeployment, teamDeployment})
-	setupClientForServer(t, srv)
+	deps := setupClientForServer(t, srv)
 
 	out := &bytes.Buffer{}
-	cmd := commands.NewGetCmd(declarativeTestDeps(nil))
+	cmd := commands.NewGetCmd(deps)
 	cmd.SetOut(out)
 	cmd.SetArgs([]string{"deployment", "team-a/aws-v1"})
 	require.NoError(t, cmd.Execute())
@@ -167,10 +167,10 @@ func TestDeploymentGet_NotFoundError(t *testing.T) {
 		deploymentFixture("other", "unrelated", "1.0.0", "my-aws", "agent", "deployed"),
 	}
 	srv := deploymentTestServerV1Alpha1(t, deployments)
-	setupClientForServer(t, srv)
+	deps := setupClientForServer(t, srv)
 
 	out := &bytes.Buffer{}
-	cmd := commands.NewGetCmd(declarativeTestDeps(nil))
+	cmd := commands.NewGetCmd(deps)
 	cmd.SetOut(out)
 	cmd.SetArgs([]string{"deployment", "does-not-exist"})
 	err := cmd.Execute()
@@ -242,10 +242,10 @@ func TestDeploymentGet_OriginFiltering(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			srv := deploymentTestServerV1Alpha1(t, deployments)
-			setupClientForServer(t, srv)
+			deps := setupClientForServer(t, srv)
 
 			out := &bytes.Buffer{}
-			cmd := commands.NewGetCmd(declarativeTestDeps(nil))
+			cmd := commands.NewGetCmd(deps)
 			cmd.SetOut(out)
 			cmd.SetArgs(tt.args)
 			err := cmd.Execute()
@@ -278,10 +278,10 @@ func TestGetAll_DeploymentOriginDefaults(t *testing.T) {
 		v1alpha1.DeploymentOriginAnnotation: v1alpha1.DeploymentOriginDiscovered,
 	}
 	srv := deploymentTestServerV1Alpha1(t, deployments)
-	setupClientForServer(t, srv)
+	deps := setupClientForServer(t, srv)
 
 	out := &bytes.Buffer{}
-	cmd := commands.NewGetCmd(declarativeTestDeps(nil))
+	cmd := commands.NewGetCmd(deps)
 	cmd.SetOut(out)
 	cmd.SetArgs([]string{"all"})
 	require.NoError(t, cmd.Execute())
@@ -302,10 +302,10 @@ func TestDeploymentGet_YAMLOutputIncludesStatus(t *testing.T) {
 		"reconcile.agentregistry.dev/force": "2026-06-16T12:00:00Z",
 	}
 	srv := deploymentTestServerV1Alpha1(t, []v1alpha1.Deployment{deployment})
-	setupClientForServer(t, srv)
+	deps := setupClientForServer(t, srv)
 
 	out := &bytes.Buffer{}
-	cmd := commands.NewGetCmd(declarativeTestDeps(nil))
+	cmd := commands.NewGetCmd(deps)
 	cmd.SetOut(out)
 	cmd.SetArgs([]string{"deployment", "aws-v1", "-o", "yaml"})
 	require.NoError(t, cmd.Execute())

--- a/internal/cli/commands/deployment_wait_test.go
+++ b/internal/cli/commands/deployment_wait_test.go
@@ -67,10 +67,10 @@ func TestDeploymentWait_DeployedReturnsImmediately(t *testing.T) {
 	srv := deploymentWaitTestServer(t, []v1alpha1.Deployment{
 		deploymentFixture("aws-v1", "summarizer", "1.0.0", "my-aws", "agent", "deployed"),
 	})
-	setupClientForServer(t, srv)
+	deps := setupClientForServer(t, srv)
 
 	out := &bytes.Buffer{}
-	cmd := commands.NewWaitCmd(declarativeTestDeps(nil))
+	cmd := commands.NewWaitCmd(deps)
 	cmd.SetOut(out)
 	cmd.SetArgs([]string{"deployment", "aws-v1", "--timeout=1s"})
 
@@ -83,10 +83,10 @@ func TestDeploymentWait_ReturnsMatchByNamespaceName(t *testing.T) {
 	teamDeployment := deploymentFixture("aws-v1", "team-summarizer", "1.0.0", "my-aws", "agent", "deployed")
 	teamDeployment.Metadata.Namespace = "team-a"
 	srv := deploymentWaitTestServer(t, []v1alpha1.Deployment{defaultDeployment, teamDeployment})
-	setupClientForServer(t, srv)
+	deps := setupClientForServer(t, srv)
 
 	out := &bytes.Buffer{}
-	cmd := commands.NewWaitCmd(declarativeTestDeps(nil))
+	cmd := commands.NewWaitCmd(deps)
 	cmd.SetOut(out)
 	cmd.SetArgs([]string{"deployment", "team-a/aws-v1", "--timeout=1s"})
 
@@ -100,9 +100,9 @@ func TestDeploymentWait_FailedSurfacesError(t *testing.T) {
 	srv := deploymentWaitTestServer(t, []v1alpha1.Deployment{
 		deploymentFixture("aws-v1", "summarizer", "1.0.0", "my-aws", "agent", "failed"),
 	})
-	setupClientForServer(t, srv)
+	deps := setupClientForServer(t, srv)
 
-	cmd := commands.NewWaitCmd(declarativeTestDeps(nil))
+	cmd := commands.NewWaitCmd(deps)
 	cmd.SetOut(&bytes.Buffer{})
 	cmd.SetErr(&bytes.Buffer{})
 	cmd.SetArgs([]string{"deployment", "aws-v1", "--timeout=1s"})
@@ -117,10 +117,10 @@ func TestDeploymentWait_ForFailedSucceedsOnFailed(t *testing.T) {
 	srv := deploymentWaitTestServer(t, []v1alpha1.Deployment{
 		deploymentFixture("aws-v1", "summarizer", "1.0.0", "my-aws", "agent", "failed"),
 	})
-	setupClientForServer(t, srv)
+	deps := setupClientForServer(t, srv)
 
 	out := &bytes.Buffer{}
-	cmd := commands.NewWaitCmd(declarativeTestDeps(nil))
+	cmd := commands.NewWaitCmd(deps)
 	cmd.SetOut(out)
 	cmd.SetArgs([]string{"deployment", "aws-v1", "--for=failed", "--timeout=1s"})
 
@@ -133,10 +133,10 @@ func TestDeploymentWait_ForDeleteSucceedsWhenAbsent(t *testing.T) {
 	srv := deploymentWaitTestServer(t, []v1alpha1.Deployment{
 		deploymentFixture("other", "unrelated", "1.0.0", "my-aws", "agent", "deployed"),
 	})
-	setupClientForServer(t, srv)
+	deps := setupClientForServer(t, srv)
 
 	out := &bytes.Buffer{}
-	cmd := commands.NewWaitCmd(declarativeTestDeps(nil))
+	cmd := commands.NewWaitCmd(deps)
 	cmd.SetOut(out)
 	cmd.SetArgs([]string{"deployment", "aws-v1", "--for=delete", "--timeout=1s"})
 
@@ -149,9 +149,9 @@ func TestDeploymentWait_NotFound(t *testing.T) {
 	srv := deploymentWaitTestServer(t, []v1alpha1.Deployment{
 		deploymentFixture("other", "unrelated", "1.0.0", "my-aws", "agent", "deployed"),
 	})
-	setupClientForServer(t, srv)
+	deps := setupClientForServer(t, srv)
 
-	cmd := commands.NewWaitCmd(declarativeTestDeps(nil))
+	cmd := commands.NewWaitCmd(deps)
 	cmd.SetOut(&bytes.Buffer{})
 	cmd.SetErr(&bytes.Buffer{})
 	cmd.SetArgs([]string{"deployment", "aws-v1", "--timeout=1s"})
@@ -166,9 +166,9 @@ func TestDeploymentWait_RejectsUnknownForValue(t *testing.T) {
 	srv := deploymentWaitTestServer(t, []v1alpha1.Deployment{
 		deploymentFixture("aws-v1", "summarizer", "1.0.0", "my-aws", "agent", "deploying"),
 	})
-	setupClientForServer(t, srv)
+	deps := setupClientForServer(t, srv)
 
-	cmd := commands.NewWaitCmd(declarativeTestDeps(nil))
+	cmd := commands.NewWaitCmd(deps)
 	cmd.SetOut(&bytes.Buffer{})
 	cmd.SetErr(&bytes.Buffer{})
 	cmd.SetArgs([]string{"deployment", "aws-v1", "--for=garbage", "--timeout=1s"})
@@ -181,9 +181,9 @@ func TestDeploymentWait_RejectsUnknownForValue(t *testing.T) {
 // Non-deployment kinds are rejected.
 func TestDeploymentWait_RejectsNonDeploymentKinds(t *testing.T) {
 	srv := deploymentWaitTestServer(t, nil)
-	setupClientForServer(t, srv)
+	deps := setupClientForServer(t, srv)
 
-	cmd := commands.NewWaitCmd(declarativeTestDeps(nil))
+	cmd := commands.NewWaitCmd(deps)
 	cmd.SetOut(&bytes.Buffer{})
 	cmd.SetErr(&bytes.Buffer{})
 	cmd.SetArgs([]string{"agent", "summarizer"})

--- a/internal/cli/commands/extension.go
+++ b/internal/cli/commands/extension.go
@@ -1,10 +1,7 @@
 package commands
 
 import (
-	"context"
-
 	"github.com/agentregistry-dev/agentregistry/internal/cli/scheme"
-	"github.com/agentregistry-dev/agentregistry/internal/client"
 	"github.com/agentregistry-dev/agentregistry/pkg/api/v1alpha1"
 )
 
@@ -37,56 +34,20 @@ func NewExtensionKind(k ExtensionKind) *scheme.Kind {
 	if k.CanonicalKind == "" {
 		k.CanonicalKind = k.Name
 	}
-	if k.NewObject == nil {
-		k.NewObject = newSchemeObject(k.CanonicalKind)
+	descriptor, ok := v1alpha1.KindDescriptorFor(k.CanonicalKind)
+	if !ok {
+		panic("commands.RegisterExtensionKind: v1alpha1 kind is not registered: " + k.CanonicalKind)
 	}
 	if len(k.TableColumns) == 0 {
 		k.TableColumns = []scheme.Column{{Header: "NAME"}}
 	}
-
-	return &scheme.Kind{
-		Kind:         k.Name,
-		Plural:       k.Plural,
-		Aliases:      k.Aliases,
-		TableColumns: k.TableColumns,
-		ToYAMLFunc:   func(item any) any { return item },
-		RowFunc: func(item any) []string {
-			obj, ok := item.(v1alpha1.Object)
-			if !ok {
-				return []string{"<invalid>"}
-			}
-			if k.Row != nil {
-				return k.Row(obj)
-			}
-			meta := obj.GetMetadata()
-			return []string{meta.Name}
-		},
-		Get: func(ctx context.Context, c *client.Client, name, _ string) (any, error) {
-			ref, err := parseResourceLookupRef(name)
-			if err != nil {
-				return nil, err
-			}
-			return client.GetTyped(ctx, c, k.CanonicalKind, ref.Namespace, ref.Name, "", k.NewObject)
-		},
-		ListFunc: func(ctx context.Context, c *client.Client, opts scheme.ListOpts) ([]any, error) {
-			return listAny(ctx, c, k.CanonicalKind, opts, k.NewObject)
-		},
-		Delete: func(ctx context.Context, c *client.Client, name, tag string) error {
-			return deleteAny(ctx, c, k.CanonicalKind, name, tag, k.NewObject)
-		},
-	}
-}
-
-func newSchemeObject(kind string) func() v1alpha1.Object {
-	_, newAny, ok := v1alpha1.Default.Lookup(kind)
-	if !ok {
-		panic("commands.RegisterExtensionKind: v1alpha1 kind is not registered: " + kind)
-	}
-	return func() v1alpha1.Object {
-		obj, ok := newAny().(v1alpha1.Object)
-		if !ok {
-			panic("commands.RegisterExtensionKind: object does not implement v1alpha1.Object: " + kind)
-		}
-		return obj
-	}
+	return newKindFromDescriptor(
+		descriptor,
+		k.Name,
+		k.Plural,
+		k.Aliases,
+		k.TableColumns,
+		k.NewObject,
+		k.Row,
+	)
 }

--- a/internal/cli/commands/extension_test.go
+++ b/internal/cli/commands/extension_test.go
@@ -1,0 +1,100 @@
+package commands_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/agentregistry-dev/agentregistry/internal/cli/commands"
+	"github.com/agentregistry-dev/agentregistry/internal/client"
+	"github.com/agentregistry-dev/agentregistry/pkg/api/v1alpha1"
+)
+
+func TestNewExtensionKindUsesDescriptorStorage(t *testing.T) {
+	tests := []struct {
+		name       string
+		kind       string
+		wantPlural string
+		wantTagged bool
+	}{
+		{name: "tagged", kind: v1alpha1.KindAgent, wantPlural: "agents", wantTagged: true},
+		{name: "untagged", kind: v1alpha1.KindRuntime, wantPlural: "runtimes"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			kind := commands.NewExtensionKind(commands.ExtensionKind{
+				Name:          "extension-" + tt.name,
+				CanonicalKind: tt.kind,
+			})
+
+			assert.Equal(t, tt.wantPlural, kind.Plural)
+			require.NotNil(t, kind.Get)
+			require.NotNil(t, kind.ListFunc)
+			require.NotNil(t, kind.Delete)
+			if tt.wantTagged {
+				require.NotNil(t, kind.ListTags)
+				require.NotNil(t, kind.DeleteAllTags)
+			} else {
+				require.Nil(t, kind.ListTags)
+				require.Nil(t, kind.DeleteAllTags)
+			}
+		})
+	}
+}
+
+func TestNewExtensionKindUsesDescriptorRoutes(t *testing.T) {
+	tests := []struct {
+		name     string
+		kind     string
+		tag      string
+		response v1alpha1.Object
+		wantURI  string
+	}{
+		{
+			name: "tagged",
+			kind: v1alpha1.KindAgent,
+			tag:  "stable",
+			response: &v1alpha1.Agent{
+				TypeMeta: v1alpha1.TypeMeta{APIVersion: v1alpha1.GroupVersion, Kind: v1alpha1.KindAgent},
+				Metadata: v1alpha1.ObjectMeta{Namespace: "team-a", Name: "example", Tag: "stable"},
+			},
+			wantURI: "/v0/agents/example/stable?namespace=team-a",
+		},
+		{
+			name: "untagged",
+			kind: v1alpha1.KindRuntime,
+			tag:  "ignored",
+			response: &v1alpha1.Runtime{
+				TypeMeta: v1alpha1.TypeMeta{APIVersion: v1alpha1.GroupVersion, Kind: v1alpha1.KindRuntime},
+				Metadata: v1alpha1.ObjectMeta{Namespace: "team-a", Name: "example"},
+			},
+			wantURI: "/v0/runtimes/example?namespace=team-a",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotURI string
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotURI = r.URL.RequestURI()
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(tt.response)
+			}))
+			t.Cleanup(srv.Close)
+
+			kind := commands.NewExtensionKind(commands.ExtensionKind{
+				Name:          "extension-" + tt.name,
+				CanonicalKind: tt.kind,
+			})
+			_, err := kind.Get(context.Background(), client.NewClient(srv.URL, ""), "team-a/example", tt.tag)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantURI, gotURI)
+		})
+	}
+}

--- a/internal/cli/commands/get.go
+++ b/internal/cli/commands/get.go
@@ -114,9 +114,6 @@ func runGet(cmd *cobra.Command, deps cliruntime.Deps, args []string) error {
 		return runGetAllTags(cmd, deps, k, args, outputFormat)
 	}
 
-	// --tag / --latest are only meaningful for tagged content-registry kinds.
-	// ListTags is set exclusively on those kinds via typedKind, so it's a
-	// stable proxy without coupling get.go to v1alpha1's kind table.
 	if tag != "" && k.ListTags == nil {
 		return fmt.Errorf("%s not supported for kind %q (resource is not tagged)", tagFlag, k.Kind)
 	}
@@ -124,7 +121,7 @@ func runGet(cmd *cobra.Command, deps cliruntime.Deps, args []string) error {
 		return fmt.Errorf("%s not supported for kind %q (resource is not tagged)", latestFlag, k.Kind)
 	}
 	if labels != "" && k.ListTags == nil {
-		return fmt.Errorf("--labels not supported for kind %q (resource is not a content kind)", k.Kind)
+		return fmt.Errorf("--labels not supported for kind %q (resource is not tagged)", k.Kind)
 	}
 	if labels != "" && len(args) == 2 {
 		return fmt.Errorf("--labels is a list filter and cannot be combined with a resource NAME")

--- a/internal/cli/commands/get_test.go
+++ b/internal/cli/commands/get_test.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/agentregistry-dev/agentregistry/internal/cli/commands"
 	"github.com/agentregistry-dev/agentregistry/internal/cli/scheme"
-	"github.com/agentregistry-dev/agentregistry/internal/client"
 	"github.com/agentregistry-dev/agentregistry/pkg/api/v1alpha1"
 	cliruntime "github.com/agentregistry-dev/agentregistry/pkg/cli/runtime"
 )
@@ -52,9 +51,9 @@ func TestGet_Labels_ListModeForwardsSelector(t *testing.T) {
 				_, _ = w.Write([]byte(`{"items":[]}`))
 			}))
 			t.Cleanup(srv.Close)
-			setupClientForServer(t, srv)
+			deps := setupClientForServer(t, srv)
 
-			cmd := commands.NewGetCmd(declarativeTestDeps(nil))
+			cmd := commands.NewGetCmd(deps)
 			cmd.SetArgs([]string{"agents", flag, "team=platform,tier=production"})
 			require.NoError(t, cmd.Execute())
 			assert.Equal(t, "team=platform,tier=production", got)
@@ -63,7 +62,6 @@ func TestGet_Labels_ListModeForwardsSelector(t *testing.T) {
 }
 
 func TestGet_Labels_RejectsNonListUses(t *testing.T) {
-	setDeclarativeTestClient(t, client.NewClient("http://127.0.0.1:1", ""))
 
 	for _, tc := range []struct {
 		name string
@@ -99,10 +97,10 @@ func TestGet_ShowLabels(t *testing.T) {
 		_ = json.NewEncoder(w).Encode(map[string]any{"items": rows})
 	}))
 	t.Cleanup(srv.Close)
-	setupClientForServer(t, srv)
+	deps := setupClientForServer(t, srv)
 
 	out := &bytes.Buffer{}
-	cmd := commands.NewGetCmd(declarativeTestDeps(nil))
+	cmd := commands.NewGetCmd(deps)
 	cmd.SetOut(out)
 	cmd.SetErr(out)
 	cmd.SetArgs([]string{"agents", "--show-labels"})
@@ -121,10 +119,10 @@ func TestGet_ShowLabels_OmittedByDefault(t *testing.T) {
 		_ = json.NewEncoder(w).Encode(map[string]any{"items": rows})
 	}))
 	t.Cleanup(srv.Close)
-	setupClientForServer(t, srv)
+	deps := setupClientForServer(t, srv)
 
 	out := &bytes.Buffer{}
-	cmd := commands.NewGetCmd(declarativeTestDeps(nil))
+	cmd := commands.NewGetCmd(deps)
 	cmd.SetOut(out)
 	cmd.SetErr(out)
 	cmd.SetArgs([]string{"agents"})
@@ -251,10 +249,10 @@ func TestGet_Tag_FetchesSpecificTag(t *testing.T) {
 	v1 := agentTagFixture("acme-bot", "1")
 	v2 := agentTagFixture("acme-bot", "2")
 	srv, captured := tagGetServer(t, v2, v1)
-	setupClientForServer(t, srv)
+	deps := setupClientForServer(t, srv)
 
 	out := &bytes.Buffer{}
-	cmd := commands.NewGetCmd(declarativeTestDeps(nil))
+	cmd := commands.NewGetCmd(deps)
 	cmd.SetOut(out)
 	cmd.SetErr(out)
 	cmd.SetArgs([]string{"agent", "acme-bot", "--tag", "1", "-o", "json"})
@@ -281,10 +279,10 @@ func TestGet_Tag_FetchesSpecificTagByNamespaceName(t *testing.T) {
 	v1 := agentTagFixture("acme-bot", "1")
 	v2 := agentTagFixture("acme-bot", "2")
 	srv, captured := tagGetServer(t, v2, v1)
-	setupClientForServer(t, srv)
+	deps := setupClientForServer(t, srv)
 
 	out := &bytes.Buffer{}
-	cmd := commands.NewGetCmd(declarativeTestDeps(nil))
+	cmd := commands.NewGetCmd(deps)
 	cmd.SetOut(out)
 	cmd.SetErr(out)
 	cmd.SetArgs([]string{"agent", "team-a/acme-bot", "--tag", "1", "-o", "json"})
@@ -299,10 +297,10 @@ func TestGet_Tag_DefaultsToLatest(t *testing.T) {
 	v1 := agentTagFixture("acme-bot", "1")
 	v2 := agentTagFixture("acme-bot", "2")
 	srv, captured := tagGetServer(t, v2, v1)
-	setupClientForServer(t, srv)
+	deps := setupClientForServer(t, srv)
 
 	out := &bytes.Buffer{}
-	cmd := commands.NewGetCmd(declarativeTestDeps(nil))
+	cmd := commands.NewGetCmd(deps)
 	cmd.SetOut(out)
 	cmd.SetErr(out)
 	cmd.SetArgs([]string{"agent", "acme-bot", "-o", "json"})
@@ -322,8 +320,6 @@ func TestGet_Tag_DefaultsToLatest(t *testing.T) {
 // TestGet_Tag_MutuallyExclusiveWithAllTags pins the flag-validation
 // guard on runGet.
 func TestGet_Tag_MutuallyExclusiveWithAllTags(t *testing.T) {
-	setDeclarativeTestClient(t, client.NewClient("http://127.0.0.1:1", ""))
-
 	cmd := commands.NewGetCmd(declarativeTestDeps(nil))
 	cmd.SetArgs([]string{"agent", "acme-bot", "--tag", "1", "--all-tags"})
 	err := cmd.Execute()
@@ -335,8 +331,6 @@ func TestGet_Tag_MutuallyExclusiveWithAllTags(t *testing.T) {
 // for mutable namespace/name kinds (Runtime, Deployment) before any client
 // dispatch happens.
 func TestGet_Tag_NotSupportedForProvider(t *testing.T) {
-	setDeclarativeTestClient(t, client.NewClient("http://127.0.0.1:1", ""))
-
 	cmd := commands.NewGetCmd(declarativeTestDeps(nil))
 	cmd.SetArgs([]string{"runtime", "my-kagent", "--tag", "1"})
 	err := cmd.Execute()
@@ -348,8 +342,6 @@ func TestGet_Tag_NotSupportedForProvider(t *testing.T) {
 // TestGet_Tag_NotSupportedForDeployment is the symmetric assertion
 // for Deployment.
 func TestGet_Tag_NotSupportedForDeployment(t *testing.T) {
-	setDeclarativeTestClient(t, client.NewClient("http://127.0.0.1:1", ""))
-
 	cmd := commands.NewGetCmd(declarativeTestDeps(nil))
 	cmd.SetArgs([]string{"deployment", "summarizer", "--tag", "1"})
 	err := cmd.Execute()
@@ -376,9 +368,9 @@ func TestGet_Tag_ListModeFiltersByTag(t *testing.T) {
 		_, _ = w.Write([]byte(`{"items":[]}`))
 	}))
 	t.Cleanup(srv.Close)
-	setupClientForServer(t, srv)
+	deps := setupClientForServer(t, srv)
 
-	cmd := commands.NewGetCmd(declarativeTestDeps(nil))
+	cmd := commands.NewGetCmd(deps)
 	cmd.SetArgs([]string{"agents", "--tag", "0.1.0"})
 	require.NoError(t, cmd.Execute())
 
@@ -405,9 +397,9 @@ func TestGet_Latest_ListModeFiltersByLatestOnly(t *testing.T) {
 		_, _ = w.Write([]byte(`{"items":[]}`))
 	}))
 	t.Cleanup(srv.Close)
-	setupClientForServer(t, srv)
+	deps := setupClientForServer(t, srv)
 
-	cmd := commands.NewGetCmd(declarativeTestDeps(nil))
+	cmd := commands.NewGetCmd(deps)
 	cmd.SetArgs([]string{"agents", "--latest"})
 	require.NoError(t, cmd.Execute())
 
@@ -435,9 +427,9 @@ func TestGet_ListModeDefault_NoTagFilter(t *testing.T) {
 		_, _ = w.Write([]byte(`{"items":[]}`))
 	}))
 	t.Cleanup(srv.Close)
-	setupClientForServer(t, srv)
+	deps := setupClientForServer(t, srv)
 
-	cmd := commands.NewGetCmd(declarativeTestDeps(nil))
+	cmd := commands.NewGetCmd(deps)
 	cmd.SetArgs([]string{"agents"})
 	require.NoError(t, cmd.Execute())
 
@@ -452,8 +444,6 @@ func TestGet_ListModeDefault_NoTagFilter(t *testing.T) {
 
 // TestGet_TagAndLatest_MutuallyExclusive pins the flag-validation guard.
 func TestGet_TagAndLatest_MutuallyExclusive(t *testing.T) {
-	setDeclarativeTestClient(t, client.NewClient("http://127.0.0.1:1", ""))
-
 	cmd := commands.NewGetCmd(declarativeTestDeps(nil))
 	cmd.SetArgs([]string{"agents", "--tag", "1", "--latest"})
 	err := cmd.Execute()
@@ -465,8 +455,6 @@ func TestGet_TagAndLatest_MutuallyExclusive(t *testing.T) {
 // is also a tag-shaped filter and should be rejected for mutable kinds
 // before any dispatch.
 func TestGet_Latest_NotSupportedForProvider(t *testing.T) {
-	setDeclarativeTestClient(t, client.NewClient("http://127.0.0.1:1", ""))
-
 	cmd := commands.NewGetCmd(declarativeTestDeps(nil))
 	cmd.SetArgs([]string{"runtime", "--latest"})
 	err := cmd.Execute()

--- a/internal/cli/commands/resources.go
+++ b/internal/cli/commands/resources.go
@@ -93,10 +93,13 @@ func deleteAllTagsAny[T v1alpha1.Object](ctx context.Context, c *client.Client, 
 	return errorsJoin(errs)
 }
 
-func deleteAny[T v1alpha1.Object](ctx context.Context, c *client.Client, kind, name, tag string, newObj func() T) error {
+func deleteAny[T v1alpha1.Object](ctx context.Context, c *client.Client, kind, name, tag string, tagged bool, newObj func() T) error {
 	ref, err := parseResourceLookupRef(name)
 	if err != nil {
 		return err
+	}
+	if !tagged {
+		return c.Delete(ctx, kind, ref.Namespace, ref.Name, "")
 	}
 	targetTag := tag
 	if targetTag == "" {

--- a/internal/cli/commands/runtime_get_test.go
+++ b/internal/cli/commands/runtime_get_test.go
@@ -77,10 +77,10 @@ func TestRuntimeGet_YAMLOutputPreservesCanonicalEnvelope(t *testing.T) {
 		"reconcile.agentregistry.dev/force": "2026-06-16T12:00:00Z",
 	}
 	srv := runtimeTestServer(t, runtimes)
-	setupClientForServer(t, srv)
+	deps := setupClientForServer(t, srv)
 
 	out := &bytes.Buffer{}
-	cmd := commands.NewGetCmd(declarativeTestDeps(nil))
+	cmd := commands.NewGetCmd(deps)
 	cmd.SetOut(out)
 	cmd.SetArgs([]string{"runtime", "my-kagent", "-o", "yaml"})
 	require.NoError(t, cmd.Execute())
@@ -105,10 +105,10 @@ func TestRuntimeGet_TableOutput(t *testing.T) {
 	}
 	runtimes[0].Status.SetCondition(v1alpha1.Condition{Type: statusapi.ConditionTypeReady, Status: v1alpha1.ConditionTrue})
 	srv := runtimeTestServer(t, runtimes)
-	setupClientForServer(t, srv)
+	deps := setupClientForServer(t, srv)
 
 	out := &bytes.Buffer{}
-	cmd := commands.NewGetCmd(declarativeTestDeps(nil))
+	cmd := commands.NewGetCmd(deps)
 	cmd.SetOut(out)
 	cmd.SetArgs([]string{"runtime", "my-kagent"})
 	require.NoError(t, cmd.Execute())
@@ -126,10 +126,10 @@ func TestRuntimeGet_ReturnsMatchByNamespaceName(t *testing.T) {
 	teamRuntime.Metadata.Namespace = "team-a"
 	runtimes := []v1alpha1.Runtime{defaultRuntime, teamRuntime}
 	srv := runtimeTestServer(t, runtimes)
-	setupClientForServer(t, srv)
+	deps := setupClientForServer(t, srv)
 
 	out := &bytes.Buffer{}
-	cmd := commands.NewGetCmd(declarativeTestDeps(nil))
+	cmd := commands.NewGetCmd(deps)
 	cmd.SetOut(out)
 	cmd.SetArgs([]string{"runtime", "team-a/my-kagent"})
 	require.NoError(t, cmd.Execute())


### PR DESCRIPTION
# Description

Follow up on #666 by completing descriptor-driven CLI kind dispatch. Extension
kinds now use the same descriptor-backed callbacks as built-in kinds, so plural
routing and tagged operations follow their registered storage behavior.

Untagged explicit deletes now use the name-only DELETE route directly instead
of issuing a preliminary GET. This removes a redundant request and allows a
caller with delete permission, but not read permission, to delete the resource.
Command tests now receive their clients through dependencies instead of shared
package state.

# Change Type

/kind fix

# Changelog

```release-note
CLI extension kinds now honor their registered storage behavior, and deleting untagged resources no longer requires read permission.
```

# Additional Notes

Tagged deletes still resolve the latest concrete tag when `--tag` is omitted.
Broader storage and CLI terminology renames remain isolated in follow-up
branches.
