### PR TITLE
feat(cli): show plugin and skill readiness

### DIFF
--- a/docs/declarative-cli.md
+++ b/docs/declarative-cli.md
@@ -178,6 +178,11 @@ arctl get prompts
 arctl delete prompt summarizer-system-prompt --tag stable
 ```
 
+The default table output for `arctl get skills` and `arctl get plugins` includes
+`READY` and `REASON` columns. These show the status (`True`, `False`, or `Unknown`)
+and reason of the resource's `Ready` condition. If no `Ready` condition has been
+recorded, both columns show `<none>`. An empty reason also appears as `<none>`.
+
 ## Pulling Resources
 
 Fetch a registered resource's source back to a local directory:

--- a/internal/cli/commands/declarative.go
+++ b/internal/cli/commands/declarative.go
@@ -64,7 +64,7 @@ func init() {
 	registerKind[*v1alpha1.Skill](
 		"skill", "", nil,
 		[]scheme.Column{
-			{Header: "NAME"}, {Header: "TAG"}, {Header: "DESCRIPTION"},
+			{Header: "NAME"}, {Header: "TAG"}, {Header: "READY"}, {Header: "REASON"}, {Header: "DESCRIPTION"},
 		},
 		v1alpha1.KindSkill,
 		skillRow,
@@ -77,7 +77,7 @@ func init() {
 	)
 	registerKind[*v1alpha1.Plugin](
 		"plugin", "", nil,
-		[]scheme.Column{{Header: "NAME"}, {Header: "TAG"}, {Header: "DESCRIPTION"}},
+		[]scheme.Column{{Header: "NAME"}, {Header: "TAG"}, {Header: "READY"}, {Header: "REASON"}, {Header: "DESCRIPTION"}},
 		v1alpha1.KindPlugin,
 		pluginRow,
 	)

--- a/internal/cli/commands/get_test.go
+++ b/internal/cli/commands/get_test.go
@@ -17,7 +17,74 @@ import (
 	"github.com/agentregistry-dev/agentregistry/internal/client"
 	"github.com/agentregistry-dev/agentregistry/pkg/api/v1alpha1"
 	cliruntime "github.com/agentregistry-dev/agentregistry/pkg/cli/runtime"
+	statusapi "github.com/agentregistry-dev/agentregistry/pkg/status"
 )
+
+func TestGet_PluginAndSkillReadiness(t *testing.T) {
+	tests := []struct {
+		name       string
+		conditions []v1alpha1.Condition
+		ready      string
+		reason     string
+	}{
+		{name: "unreconciled", ready: "<none>", reason: "<none>"},
+		{name: "unrelated", conditions: []v1alpha1.Condition{{Type: "Validated", Status: v1alpha1.ConditionTrue, Reason: "Valid"}}, ready: "<none>", reason: "<none>"},
+		{name: "resolved", conditions: []v1alpha1.Condition{{Type: statusapi.ConditionTypeReady, Status: v1alpha1.ConditionTrue, Reason: "Resolved"}}, ready: "True", reason: "Resolved"},
+		{name: "progressing", conditions: []v1alpha1.Condition{{Type: statusapi.ConditionTypeReady, Status: v1alpha1.ConditionFalse, Reason: "Progressing"}}, ready: "False", reason: "Progressing"},
+		{name: "failed", conditions: []v1alpha1.Condition{{Type: statusapi.ConditionTypeReady, Status: v1alpha1.ConditionFalse, Reason: "SourceUnresolvable"}}, ready: "False", reason: "SourceUnresolvable"},
+		{name: "unknown", conditions: []v1alpha1.Condition{{Type: statusapi.ConditionTypeReady, Status: v1alpha1.ConditionUnknown, Reason: "Reconciling"}}, ready: "Unknown", reason: "Reconciling"},
+		{name: "no-reason", conditions: []v1alpha1.Condition{{Type: statusapi.ConditionTypeReady, Status: v1alpha1.ConditionFalse}}, ready: "False", reason: "<none>"},
+	}
+	for _, kind := range []string{v1alpha1.KindPlugin, v1alpha1.KindSkill} {
+		plural := strings.ToLower(kind) + "s"
+		t.Run(plural, func(t *testing.T) {
+			var items []any
+			for _, tt := range tests {
+				item := map[string]any{
+					"apiVersion": v1alpha1.GroupVersion,
+					"kind":       kind,
+					"metadata":   v1alpha1.ObjectMeta{Name: tt.name, Tag: "stable"},
+					"spec":       map[string]string{"description": "example"},
+				}
+				if len(tt.conditions) > 0 {
+					item["status"] = v1alpha1.Status{Conditions: tt.conditions}
+				}
+				items = append(items, item)
+			}
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, http.MethodGet, r.Method)
+				assert.Equal(t, "/v0/"+plural, r.URL.Path)
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(map[string]any{"items": items})
+			}))
+			t.Cleanup(srv.Close)
+			setupClientForServer(t, srv)
+
+			out := &bytes.Buffer{}
+			cmd := commands.NewGetCmd(declarativeTestDeps(nil))
+			cmd.SetOut(out)
+			cmd.SetArgs([]string{plural})
+			require.NoError(t, cmd.Execute())
+
+			lines := strings.Split(strings.TrimSpace(out.String()), "\n")
+			require.Len(t, lines, len(tests)+1)
+			assert.Equal(t, []string{"NAME", "TAG", "READY", "REASON", "DESCRIPTION"}, strings.Fields(lines[0]))
+			for i, tt := range tests {
+				assert.Equal(t, []string{tt.name, "stable", tt.ready, tt.reason, "example"}, strings.Fields(lines[i+1]))
+			}
+
+			// Table-only columns must not change the API-shaped JSON output.
+			out.Reset()
+			jsonCmd := commands.NewGetCmd(declarativeTestDeps(nil))
+			jsonCmd.SetOut(out)
+			jsonCmd.SetArgs([]string{plural, "-o", "json"})
+			require.NoError(t, jsonCmd.Execute())
+			wantJSON, err := json.Marshal(items)
+			require.NoError(t, err)
+			assert.JSONEq(t, string(wantJSON), out.String())
+		})
+	}
+}
 
 func TestGetCmd_RejectsUnknownType(t *testing.T) {
 	cmd := commands.NewGetCmd(declarativeTestDeps(nil))

--- a/internal/cli/commands/resources.go
+++ b/internal/cli/commands/resources.go
@@ -178,9 +178,12 @@ func skillRow(skill *v1alpha1.Skill) []string {
 	if skill == nil {
 		return []string{"<invalid>"}
 	}
+	ready, reason := readinessColumns(skill.Status.GetCondition(statusapi.ConditionTypeReady))
 	return []string{
 		printer.TruncateString(skill.Metadata.Name, 40),
 		skill.Metadata.Tag,
+		ready,
+		reason,
 		printer.TruncateString(printer.EmptyValueOrDefault(skill.Spec.Description, "<none>"), 60),
 	}
 }
@@ -200,11 +203,21 @@ func pluginRow(plugin *v1alpha1.Plugin) []string {
 	if plugin == nil {
 		return []string{"<invalid>"}
 	}
+	ready, reason := readinessColumns(plugin.Status.GetCondition(statusapi.ConditionTypeReady))
 	return []string{
 		printer.TruncateString(plugin.Metadata.Name, 40),
 		plugin.Metadata.Tag,
+		ready,
+		reason,
 		printer.TruncateString(printer.EmptyValueOrDefault(plugin.Spec.Description, "<none>"), 60),
 	}
+}
+
+func readinessColumns(ready *v1alpha1.Condition) (string, string) {
+	if ready == nil {
+		return "<none>", "<none>"
+	}
+	return string(ready.Status), printer.EmptyValueOrDefault(ready.Reason, "<none>")
 }
 
 func runtimeRow(runtime *v1alpha1.Runtime) []string {


### PR DESCRIPTION
# Description

Fixes #651.

Show `READY` and `REASON` in the default table output for `arctl get plugins` and `arctl get skills`, using the resource's `Ready` condition. When that condition is absent, show `<none>` in both columns; an empty reason also displays as `<none>`.

Add regression coverage for both resource kinds, including absent and unrelated conditions, True/False/Unknown states, empty reasons, and unchanged JSON output. Document the columns in the declarative CLI guide.

# Change Type

/kind feature

# Changelog

```release-note
Add READY and REASON columns to plugin and skill list output, showing <none> when no Ready condition has been recorded.
```

# Additional Notes

Local validation passed:

- `make lint` (`0 issues`).
- `go test -tags=unit -timeout 5m ./...`.
- CLI build and subprocess smoke checks for plugin/skill table, JSON, YAML, named-resource, label-filter, and empty-list output.
